### PR TITLE
Other patches to make it build on old systems and ARM

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(CheckLibraryExists)
+
 set (SFIZZ_SOURCES
     sfizz/Synth.cpp
     sfizz/FilePool.cpp
@@ -30,7 +32,10 @@ target_link_libraries (sfizz_static PRIVATE sfizz_parser absl::flat_hash_map Thr
 add_library (sfizz::parser ALIAS sfizz_parser)
 add_library (sfizz::sfizz ALIAS sfizz_static)
 if (UNIX AND NOT APPLE)
-    target_link_libraries (sfizz_static PRIVATE atomic)
+    check_library_exists(atomic __atomic_load "" LIBATOMIC_FOUND)
+    if (LIBATOMIC_FOUND)
+        target_link_libraries (sfizz_static PRIVATE atomic)
+    endif()
 endif()
 
 # Shared library and installation target
@@ -55,7 +60,9 @@ if (SFIZZ_SHARED)
     endif()
 
     if (UNIX AND NOT APPLE)
-        target_link_libraries (sfizz_shared PRIVATE atomic)
+        if (LIBATOMIC_FOUND)
+            target_link_libraries (sfizz_shared PRIVATE atomic)
+        endif()
     endif()
 endif()
 

--- a/src/external/atomic_queue/defs.h
+++ b/src/external/atomic_queue/defs.h
@@ -20,7 +20,21 @@ static inline void spin_loop_pause() noexcept {
 namespace atomic_queue {
 constexpr int CACHE_LINE_SIZE = 64;
 static inline void spin_loop_pause() noexcept {
-    __asm__ __volatile__("yield");
+#if (defined(__ARM_ARCH_6K__) || \
+     defined(__ARM_ARCH_6Z__) || \
+     defined(__ARM_ARCH_6ZK__) || \
+     defined(__ARM_ARCH_6T2__) || \
+     defined(__ARM_ARCH_7__) || \
+     defined(__ARM_ARCH_7A__) || \
+     defined(__ARM_ARCH_7R__) || \
+     defined(__ARM_ARCH_7M__) || \
+     defined(__ARM_ARCH_7S__) || \
+     defined(__ARM_ARCH_8A__) || \
+     defined(__aarch64__))
+    asm volatile ("yield" ::: "memory");
+#else
+    asm volatile ("nop" ::: "memory");
+#endif
 }
 } // namespace atomic_queue
 #else

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -767,7 +767,7 @@ float sfz::Region::velocityCurve(uint8_t velocity) const noexcept
     return gain;
 }
 
-constexpr uint8_t offsetAndClamp(uint8_t key, int offset, sfz::Range<uint8_t> range)
+uint8_t offsetAndClamp(uint8_t key, int offset, sfz::Range<uint8_t> range)
 {
     const int offsetKey { key + offset };
     if (offsetKey > std::numeric_limits<uint8_t>::max())

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -165,7 +165,7 @@ void sfz::Synth::handleControlOpcodes(const std::vector<Opcode>& members)
             [[fallthrough]];
         case hash("label_cc"):
             if (member.parameter && Default::ccNumberRange.containsWithEnd(*member.parameter))
-                ccNames.emplace_back(*member.parameter, member.value);
+                ccNames.emplace_back(*member.parameter, std::string(member.value));
             break;
         case hash("Default_path"):
             [[fallthrough]];


### PR DESCRIPTION
It should be clear enough for most.

Regarding ARM, some older targets don't have `yield`, and and some v6 it's present as an equivalent of `nop`.