### PR TITLE
Parse all parameters in opcodes

### DIFF
--- a/src/sfizz/Opcode.cpp
+++ b/src/sfizz/Opcode.cpp
@@ -15,28 +15,56 @@ sfz::Opcode::Opcode(absl::string_view inputOpcode, absl::string_view inputValue)
     trimInPlace(value);
     trimInPlace(opcode);
     size_t nextCharIndex { 0 };
+    int parameterPosition { 0 };
     auto nextNumIndex = opcode.find_first_of("1234567890");
     while (nextNumIndex != opcode.npos) {
-        lettersOnlyHash = hash(opcode.substr(nextCharIndex, nextNumIndex - nextCharIndex), lettersOnlyHash);
+        const auto numLetters = nextNumIndex - nextCharIndex;
+        parameterPosition += numLetters;
+        lettersOnlyHash = hash(opcode.substr(nextCharIndex, numLetters), lettersOnlyHash);
         nextCharIndex = opcode.find_first_not_of("1234567890", nextNumIndex);
 
         uint32_t returnedValue;
-        if (nextCharIndex == absl::string_view::npos) {
-            if (absl::SimpleAtoi(opcode.substr(nextNumIndex), &returnedValue)) {
-                ASSERT(returnedValue < std::numeric_limits<uint8_t>::max());
-                backParameter = static_cast<uint8_t>(returnedValue);
-                break;
-            }
-        } else {
-            if (absl::SimpleAtoi(opcode.substr(nextNumIndex, nextCharIndex - nextNumIndex), &returnedValue)) {
-                ASSERT(returnedValue < std::numeric_limits<uint8_t>::max());
-                parameters.push_back(static_cast<uint8_t>(returnedValue));
-            }
+        hasBackParameter = (nextCharIndex == opcode.npos);
+        const auto numDigits = hasBackParameter ? opcode.npos : nextCharIndex - nextNumIndex;
+        if (absl::SimpleAtoi(opcode.substr(nextNumIndex, numDigits), &returnedValue)) {
+            ASSERT(returnedValue < std::numeric_limits<uint8_t>::max());
+            parameterPositions.push_back(parameterPosition);
+            parameters.push_back(returnedValue);
         }
+
         nextNumIndex = opcode.find_first_of("1234567890", nextCharIndex);
     }
 
     if (nextCharIndex != opcode.npos)
         lettersOnlyHash = hash(opcode.substr(nextCharIndex), lettersOnlyHash);
+}
 
+absl::optional<uint8_t> sfz::Opcode::backParameter() const noexcept
+{
+    if (hasBackParameter && !parameters.empty())
+        return parameters.back();
+
+    return {};
+}
+
+absl::optional<uint8_t> sfz::Opcode::firstParameter() const noexcept
+{
+    if (!hasBackParameter && !parameters.empty())
+        return parameters.front();
+
+    if (hasBackParameter && parameters.size() > 1)
+        return parameters.front();
+
+    return {};
+}
+
+absl::optional<uint8_t> sfz::Opcode::middleParameter() const noexcept
+{
+    if (!hasBackParameter && parameters.size() > 1)
+        return parameters[1];
+
+    if (hasBackParameter && parameters.size() > 2)
+        return parameters[1];
+
+    return {};
 }

--- a/src/sfizz/Opcode.cpp
+++ b/src/sfizz/Opcode.cpp
@@ -14,29 +14,29 @@ sfz::Opcode::Opcode(absl::string_view inputOpcode, absl::string_view inputValue)
 {
     trimInPlace(value);
     trimInPlace(opcode);
-    size_t firstCharIndex { 0 };
-    auto firstNumIndex = opcode.find_first_of("1234567890");
-    while (firstNumIndex != opcode.npos) {
-        lettersOnlyHash = hash(opcode.substr(firstCharIndex, firstNumIndex - firstCharIndex), lettersOnlyHash);
-        firstCharIndex = opcode.find_first_not_of("1234567890", firstNumIndex);
+    size_t nextCharIndex { 0 };
+    auto nextNumIndex = opcode.find_first_of("1234567890");
+    while (nextNumIndex != opcode.npos) {
+        lettersOnlyHash = hash(opcode.substr(nextCharIndex, nextNumIndex - nextCharIndex), lettersOnlyHash);
+        nextCharIndex = opcode.find_first_not_of("1234567890", nextNumIndex);
 
         uint32_t returnedValue;
-        if (firstCharIndex == absl::string_view::npos) {
-            if (absl::SimpleAtoi(opcode.substr(firstNumIndex), &returnedValue)) {
+        if (nextCharIndex == absl::string_view::npos) {
+            if (absl::SimpleAtoi(opcode.substr(nextNumIndex), &returnedValue)) {
                 ASSERT(returnedValue < std::numeric_limits<uint8_t>::max());
                 backParameter = static_cast<uint8_t>(returnedValue);
                 break;
             }
         } else {
-            if (absl::SimpleAtoi(opcode.substr(firstNumIndex, firstCharIndex - firstNumIndex), &returnedValue)) {
+            if (absl::SimpleAtoi(opcode.substr(nextNumIndex, nextCharIndex - nextNumIndex), &returnedValue)) {
                 ASSERT(returnedValue < std::numeric_limits<uint8_t>::max());
                 parameters.push_back(static_cast<uint8_t>(returnedValue));
             }
         }
-        firstNumIndex = opcode.find_first_of("1234567890", firstCharIndex);
+        nextNumIndex = opcode.find_first_of("1234567890", nextCharIndex);
     }
 
-    if (firstCharIndex != opcode.npos)
-        lettersOnlyHash = hash(opcode.substr(firstCharIndex), lettersOnlyHash);
+    if (nextCharIndex != opcode.npos)
+        lettersOnlyHash = hash(opcode.substr(nextCharIndex), lettersOnlyHash);
 
 }

--- a/src/sfizz/Opcode.cpp
+++ b/src/sfizz/Opcode.cpp
@@ -6,8 +6,8 @@
 
 #include "Opcode.h"
 #include "StringViewHelpers.h"
-#include "absl/strings/charconv.h"
 #include <cctype>
+
 sfz::Opcode::Opcode(absl::string_view inputOpcode, absl::string_view inputValue)
     : opcode(inputOpcode)
     , value(inputValue)

--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -12,6 +12,7 @@
 #include "StringViewHelpers.h"
 #include <absl/types/optional.h>
 #include <string_view>
+#include <vector>
 #include <type_traits>
 
 // charconv support is still sketchy with clang/gcc so we use abseil's numbers
@@ -29,8 +30,10 @@ struct Opcode {
     Opcode(absl::string_view inputOpcode, absl::string_view inputValue);
     absl::string_view opcode {};
     absl::string_view value {};
-    // This is to handle the integer parameter of some opcodes
-    absl::optional<uint8_t> parameter;
+    uint64_t lettersOnlyHash { Fnv1aBasis };
+    // This is to handle the integer parameters of some opcodes
+    std::vector<uint8_t> parameters;
+    absl::optional<uint8_t> backParameter {};
     LEAK_DETECTOR(Opcode);
 };
 
@@ -186,8 +189,8 @@ template <class ValueType>
 inline void setCCPairFromOpcode(const Opcode& opcode, absl::optional<CCValuePair>& target, const Range<ValueType>& validRange)
 {
     auto value = readOpcode(opcode.value, validRange);
-    if (value && opcode.parameter && Default::ccNumberRange.containsWithEnd(*opcode.parameter))
-        target = std::make_pair(*opcode.parameter, *value);
+    if (value && opcode.backParameter && Default::ccNumberRange.containsWithEnd(*opcode.backParameter))
+        target = std::make_pair(*opcode.backParameter, *value);
     else
         target = {};
 }

--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -20,20 +20,23 @@
 
 namespace sfz {
 /**
- * @brief Opcode description class; should be very lightweight to use
- * and move around. The class parses the parameters of the opcode
- * on construction.
+ * @brief Opcode description class. The class parses the parameters
+ * of the opcode on construction.
  *
  */
 struct Opcode {
     Opcode() = delete;
+    absl::optional<uint8_t> backParameter() const noexcept;
+    absl::optional<uint8_t> firstParameter() const noexcept;
+    absl::optional<uint8_t> middleParameter() const noexcept;
     Opcode(absl::string_view inputOpcode, absl::string_view inputValue);
     absl::string_view opcode {};
     absl::string_view value {};
     uint64_t lettersOnlyHash { Fnv1aBasis };
     // This is to handle the integer parameters of some opcodes
     std::vector<uint8_t> parameters;
-    absl::optional<uint8_t> backParameter {};
+    std::vector<int> parameterPositions;
+    bool hasBackParameter { false };
     LEAK_DETECTOR(Opcode);
 };
 
@@ -189,8 +192,9 @@ template <class ValueType>
 inline void setCCPairFromOpcode(const Opcode& opcode, absl::optional<CCValuePair>& target, const Range<ValueType>& validRange)
 {
     auto value = readOpcode(opcode.value, validRange);
-    if (value && opcode.backParameter && Default::ccNumberRange.containsWithEnd(*opcode.backParameter))
-        target = std::make_pair(*opcode.backParameter, *value);
+    const auto backParameter = opcode.backParameter();
+    if (value && backParameter && Default::ccNumberRange.containsWithEnd(*backParameter))
+        target = std::make_pair(*backParameter, *value);
     else
         target = {};
 }

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -17,9 +17,10 @@
 
 bool sfz::Region::parseOpcode(const Opcode& opcode)
 {
+    const auto backParameter = opcode.backParameter();
     // Check that the parameter is well formed
-    if (opcode.backParameter && !sfz::Default::ccNumberRange.containsWithEnd(*opcode.backParameter)) {
-        DBG("Wrong parameter value (" << std::to_string(*opcode.backParameter) << ") for opcode " << opcode.opcode);
+    if (backParameter && !sfz::Default::ccNumberRange.containsWithEnd(*backParameter)) {
+        DBG("Wrong parameter value (" << std::to_string(*backParameter) << ") for opcode " << opcode.opcode);
         return false;
     }
 
@@ -135,13 +136,13 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         setRangeEndFromOpcode(opcode, bendRange, Default::bendRange);
         break;
     case hash("locc"):
-        if (opcode.backParameter) {
-            setRangeStartFromOpcode(opcode, ccConditions[*opcode.backParameter], Default::ccValueRange);
+        if (backParameter) {
+            setRangeStartFromOpcode(opcode, ccConditions[*backParameter], Default::ccValueRange);
         }
         break;
     case hash("hicc"):
-        if (opcode.backParameter)
-            setRangeEndFromOpcode(opcode, ccConditions[*opcode.backParameter], Default::ccValueRange);
+        if (backParameter)
+            setRangeEndFromOpcode(opcode, ccConditions[*backParameter], Default::ccValueRange);
         break;
     case hash("sw_lokey"):
         setRangeStartFromOpcode(opcode, keyswitchRange, Default::keyRange);
@@ -233,13 +234,13 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         break;
     case hash("on_locc"):
     case hash("start_locc"):
-        if (opcode.backParameter)
-            setRangeStartFromOpcode(opcode, ccTriggers[*opcode.backParameter], Default::ccTriggerValueRange);
+        if (backParameter)
+            setRangeStartFromOpcode(opcode, ccTriggers[*backParameter], Default::ccTriggerValueRange);
         break;
     case hash("on_hicc"):
     case hash("start_hicc"):
-        if (opcode.backParameter)
-            setRangeEndFromOpcode(opcode, ccTriggers[*opcode.backParameter], Default::ccTriggerValueRange);
+        if (backParameter)
+            setRangeEndFromOpcode(opcode, ccTriggers[*backParameter], Default::ccTriggerValueRange);
         break;
 
     // Performance parameters: amplifier
@@ -293,7 +294,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         {
             auto value = readOpcode(opcode.value, Default::ampVelcurveRange);
             if (value)
-                velocityPoints.emplace_back(*opcode.backParameter, *value);
+                velocityPoints.emplace_back(*backParameter, *value);
         }
         break;
     case hash("xfin_lokey"):
@@ -345,23 +346,23 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         }
         break;
     case hash("xfin_locc"):
-        if (opcode.backParameter) {
-            setRangeStartFromOpcode(opcode, crossfadeCCInRange[*opcode.backParameter], Default::ccValueRange);
+        if (backParameter) {
+            setRangeStartFromOpcode(opcode, crossfadeCCInRange[*backParameter], Default::ccValueRange);
         }
         break;
     case hash("xfin_hicc"):
-        if (opcode.backParameter) {
-            setRangeEndFromOpcode(opcode, crossfadeCCInRange[*opcode.backParameter], Default::ccValueRange);
+        if (backParameter) {
+            setRangeEndFromOpcode(opcode, crossfadeCCInRange[*backParameter], Default::ccValueRange);
         }
         break;
     case hash("xfout_locc"):
-        if (opcode.backParameter) {
-            setRangeStartFromOpcode(opcode, crossfadeCCOutRange[*opcode.backParameter], Default::ccValueRange);
+        if (backParameter) {
+            setRangeStartFromOpcode(opcode, crossfadeCCOutRange[*backParameter], Default::ccValueRange);
         }
         break;
     case hash("xfout_hicc"):
-        if (opcode.backParameter) {
-            setRangeEndFromOpcode(opcode, crossfadeCCOutRange[*opcode.backParameter], Default::ccValueRange);
+        if (backParameter) {
+            setRangeEndFromOpcode(opcode, crossfadeCCOutRange[*backParameter], Default::ccValueRange);
         }
         break;
     case hash("xf_cccurve"):

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -18,12 +18,12 @@
 bool sfz::Region::parseOpcode(const Opcode& opcode)
 {
     // Check that the parameter is well formed
-    if (opcode.parameter && !sfz::Default::ccNumberRange.containsWithEnd(*opcode.parameter)) {
-        DBG("Wrong parameter value (" << std::to_string(*opcode.parameter) << ") for opcode " << opcode.opcode);
+    if (opcode.backParameter && !sfz::Default::ccNumberRange.containsWithEnd(*opcode.backParameter)) {
+        DBG("Wrong parameter value (" << std::to_string(*opcode.backParameter) << ") for opcode " << opcode.opcode);
         return false;
     }
 
-    switch (hash(opcode.opcode)) {
+    switch (opcode.lettersOnlyHash) {
     // Sound source: sample playback
     case hash("sample"):
         {
@@ -135,13 +135,13 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         setRangeEndFromOpcode(opcode, bendRange, Default::bendRange);
         break;
     case hash("locc"):
-        if (opcode.parameter) {
-            setRangeStartFromOpcode(opcode, ccConditions[*opcode.parameter], Default::ccValueRange);
+        if (opcode.backParameter) {
+            setRangeStartFromOpcode(opcode, ccConditions[*opcode.backParameter], Default::ccValueRange);
         }
         break;
     case hash("hicc"):
-        if (opcode.parameter)
-            setRangeEndFromOpcode(opcode, ccConditions[*opcode.parameter], Default::ccValueRange);
+        if (opcode.backParameter)
+            setRangeEndFromOpcode(opcode, ccConditions[*opcode.backParameter], Default::ccValueRange);
         break;
     case hash("sw_lokey"):
         setRangeStartFromOpcode(opcode, keyswitchRange, Default::keyRange);
@@ -233,13 +233,13 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         break;
     case hash("on_locc"):
     case hash("start_locc"):
-        if (opcode.parameter)
-            setRangeStartFromOpcode(opcode, ccTriggers[*opcode.parameter], Default::ccTriggerValueRange);
+        if (opcode.backParameter)
+            setRangeStartFromOpcode(opcode, ccTriggers[*opcode.backParameter], Default::ccTriggerValueRange);
         break;
     case hash("on_hicc"):
     case hash("start_hicc"):
-        if (opcode.parameter)
-            setRangeEndFromOpcode(opcode, ccTriggers[*opcode.parameter], Default::ccTriggerValueRange);
+        if (opcode.backParameter)
+            setRangeEndFromOpcode(opcode, ccTriggers[*opcode.backParameter], Default::ccTriggerValueRange);
         break;
 
     // Performance parameters: amplifier
@@ -293,7 +293,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         {
             auto value = readOpcode(opcode.value, Default::ampVelcurveRange);
             if (value)
-                velocityPoints.emplace_back(*opcode.parameter, *value);
+                velocityPoints.emplace_back(*opcode.backParameter, *value);
         }
         break;
     case hash("xfin_lokey"):
@@ -345,23 +345,23 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         }
         break;
     case hash("xfin_locc"):
-        if (opcode.parameter) {
-            setRangeStartFromOpcode(opcode, crossfadeCCInRange[*opcode.parameter], Default::ccValueRange);
+        if (opcode.backParameter) {
+            setRangeStartFromOpcode(opcode, crossfadeCCInRange[*opcode.backParameter], Default::ccValueRange);
         }
         break;
     case hash("xfin_hicc"):
-        if (opcode.parameter) {
-            setRangeEndFromOpcode(opcode, crossfadeCCInRange[*opcode.parameter], Default::ccValueRange);
+        if (opcode.backParameter) {
+            setRangeEndFromOpcode(opcode, crossfadeCCInRange[*opcode.backParameter], Default::ccValueRange);
         }
         break;
     case hash("xfout_locc"):
-        if (opcode.parameter) {
-            setRangeStartFromOpcode(opcode, crossfadeCCOutRange[*opcode.parameter], Default::ccValueRange);
+        if (opcode.backParameter) {
+            setRangeStartFromOpcode(opcode, crossfadeCCOutRange[*opcode.backParameter], Default::ccValueRange);
         }
         break;
     case hash("xfout_hicc"):
-        if (opcode.parameter) {
-            setRangeEndFromOpcode(opcode, crossfadeCCOutRange[*opcode.parameter], Default::ccValueRange);
+        if (opcode.backParameter) {
+            setRangeEndFromOpcode(opcode, crossfadeCCOutRange[*opcode.backParameter], Default::ccValueRange);
         }
         break;
     case hash("xf_cccurve"):
@@ -433,23 +433,29 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
     case hash("ampeg_sustain"):
         setValueFromOpcode(opcode, amplitudeEG.sustain, Default::egPercentRange);
         break;
-    case hash("ampeg_vel2attack"):
-        setValueFromOpcode(opcode, amplitudeEG.vel2attack, Default::egOnCCTimeRange);
+    case hash("ampeg_velattack"):
+        if (!opcode.parameters.empty() && opcode.parameters.front() == 2)
+            setValueFromOpcode(opcode, amplitudeEG.vel2attack, Default::egOnCCTimeRange);
         break;
-    case hash("ampeg_vel2decay"):
-        setValueFromOpcode(opcode, amplitudeEG.vel2decay, Default::egOnCCTimeRange);
+    case hash("ampeg_veldecay"):
+        if (!opcode.parameters.empty() && opcode.parameters.front() == 2)
+            setValueFromOpcode(opcode, amplitudeEG.vel2decay, Default::egOnCCTimeRange);
         break;
-    case hash("ampeg_vel2delay"):
-        setValueFromOpcode(opcode, amplitudeEG.vel2delay, Default::egOnCCTimeRange);
+    case hash("ampeg_veldelay"):
+        if (!opcode.parameters.empty() && opcode.parameters.front() == 2)
+            setValueFromOpcode(opcode, amplitudeEG.vel2delay, Default::egOnCCTimeRange);
         break;
-    case hash("ampeg_vel2hold"):
-        setValueFromOpcode(opcode, amplitudeEG.vel2hold, Default::egOnCCTimeRange);
+    case hash("ampeg_velhold"):
+        if (!opcode.parameters.empty() && opcode.parameters.front() == 2)
+            setValueFromOpcode(opcode, amplitudeEG.vel2hold, Default::egOnCCTimeRange);
         break;
-    case hash("ampeg_vel2release"):
-        setValueFromOpcode(opcode, amplitudeEG.vel2release, Default::egOnCCTimeRange);
+    case hash("ampeg_velrelease"):
+        if (!opcode.parameters.empty() && opcode.parameters.front() == 2)
+            setValueFromOpcode(opcode, amplitudeEG.vel2release, Default::egOnCCTimeRange);
         break;
-    case hash("ampeg_vel2sustain"):
-        setValueFromOpcode(opcode, amplitudeEG.vel2sustain, Default::egOnCCPercentRange);
+    case hash("ampeg_velsustain"):
+        if (!opcode.parameters.empty() && opcode.parameters.front() == 2)
+            setValueFromOpcode(opcode, amplitudeEG.vel2sustain, Default::egOnCCPercentRange);
         break;
     case hash("ampeg_attackcc"):
     case hash("ampeg_attack_oncc"):

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -152,20 +152,21 @@ void sfz::Synth::handleGlobalOpcodes(const std::vector<Opcode>& members)
 void sfz::Synth::handleControlOpcodes(const std::vector<Opcode>& members)
 {
     for (auto& member : members) {
+        const auto backParameter = member.backParameter();
         switch (member.lettersOnlyHash) {
         case hash("Set_cc"):
             [[fallthrough]];
         case hash("set_cc"):
-            if (member.backParameter && Default::ccNumberRange.containsWithEnd(*member.backParameter)) {
+            if (backParameter && Default::ccNumberRange.containsWithEnd(*backParameter)) {
                 const auto ccValue = readOpcode(member.value, Default::ccValueRange).value_or(0);
-                midiState.ccEvent(*member.backParameter, ccValue);
+                midiState.ccEvent(*backParameter, ccValue);
             }
             break;
         case hash("Label_cc"):
             [[fallthrough]];
         case hash("label_cc"):
-            if (member.backParameter && Default::ccNumberRange.containsWithEnd(*member.backParameter))
-                ccNames.emplace_back(*member.backParameter, std::string(member.value));
+            if (backParameter && Default::ccNumberRange.containsWithEnd(*backParameter))
+                ccNames.emplace_back(*backParameter, std::string(member.value));
             break;
         case hash("Default_path"):
             [[fallthrough]];

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -137,7 +137,7 @@ void sfz::Synth::clear()
 void sfz::Synth::handleGlobalOpcodes(const std::vector<Opcode>& members)
 {
     for (auto& member : members) {
-        switch (hash(member.opcode)) {
+        switch (member.lettersOnlyHash) {
         case hash("sw_default"):
             setValueFromOpcode(member, defaultSwitch, Default::keyRange);
             break;
@@ -152,20 +152,20 @@ void sfz::Synth::handleGlobalOpcodes(const std::vector<Opcode>& members)
 void sfz::Synth::handleControlOpcodes(const std::vector<Opcode>& members)
 {
     for (auto& member : members) {
-        switch (hash(member.opcode)) {
+        switch (member.lettersOnlyHash) {
         case hash("Set_cc"):
             [[fallthrough]];
         case hash("set_cc"):
-            if (member.parameter && Default::ccNumberRange.containsWithEnd(*member.parameter)) {
+            if (member.backParameter && Default::ccNumberRange.containsWithEnd(*member.backParameter)) {
                 const auto ccValue = readOpcode(member.value, Default::ccValueRange).value_or(0);
-                midiState.ccEvent(*member.parameter, ccValue);
+                midiState.ccEvent(*member.backParameter, ccValue);
             }
             break;
         case hash("Label_cc"):
             [[fallthrough]];
         case hash("label_cc"):
-            if (member.parameter && Default::ccNumberRange.containsWithEnd(*member.parameter))
-                ccNames.emplace_back(*member.parameter, std::string(member.value));
+            if (member.backParameter && Default::ccNumberRange.containsWithEnd(*member.backParameter))
+                ccNames.emplace_back(*member.backParameter, std::string(member.value));
             break;
         case hash("Default_path"):
             [[fallthrough]];

--- a/tests/OpcodeT.cpp
+++ b/tests/OpcodeT.cpp
@@ -17,7 +17,9 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.lettersOnlyHash == hash("sample"));
         REQUIRE(opcode.parameters.empty());
         REQUIRE(opcode.value == "dummy");
-        REQUIRE(!opcode.backParameter);
+        REQUIRE(!opcode.backParameter());
+        REQUIRE(!opcode.firstParameter());
+        REQUIRE(!opcode.middleParameter());
     }
 
     SECTION("Normal construction with underscore")
@@ -27,7 +29,9 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore"));
         REQUIRE(opcode.parameters.empty());
         REQUIRE(opcode.value == "dummy");
-        REQUIRE(!opcode.backParameter);
+        REQUIRE(!opcode.backParameter());
+        REQUIRE(!opcode.firstParameter());
+        REQUIRE(!opcode.middleParameter());
     }
 
     SECTION("Parameterized opcode")
@@ -36,9 +40,13 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.opcode == "sample123");
         REQUIRE(opcode.lettersOnlyHash == hash("sample"));
         REQUIRE(opcode.value == "dummy");
-        REQUIRE(opcode.parameters.empty());
-        REQUIRE(opcode.backParameter);
-        REQUIRE(*opcode.backParameter == 123);
+        REQUIRE(opcode.parameters.size() == 1);
+        REQUIRE(opcode.parameters == std::vector<uint8_t>({ 123 }));
+        REQUIRE(opcode.parameterPositions == std::vector<int>({ 6 }));
+        REQUIRE(opcode.backParameter());
+        REQUIRE(*opcode.backParameter() == 123);
+        REQUIRE(!opcode.firstParameter());
+        REQUIRE(!opcode.middleParameter());
     }
 
     SECTION("Parameterized opcode with underscore")
@@ -47,9 +55,10 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.opcode == "sample_underscore123");
         REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore"));
         REQUIRE(opcode.value == "dummy");
-        REQUIRE(opcode.parameters.empty());
-        REQUIRE(opcode.backParameter);
-        REQUIRE(*opcode.backParameter == 123);
+        REQUIRE(opcode.parameters == std::vector<uint8_t>({ 123 }));
+        REQUIRE(opcode.parameterPositions == std::vector<int>({ 17 }));
+        REQUIRE(opcode.backParameter());
+        REQUIRE(*opcode.backParameter() == 123);
     }
 
     SECTION("Parameterized opcode within the opcode")
@@ -58,9 +67,11 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.opcode == "sample1_underscore");
         REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore"));
         REQUIRE(opcode.value == "dummy");
-        REQUIRE(opcode.parameters.size() == 1);
-        REQUIRE(opcode.parameters[0] == 1);
-        REQUIRE(!opcode.backParameter);
+        REQUIRE(opcode.parameters == std::vector<uint8_t>({ 1 }));
+        REQUIRE(!opcode.backParameter());
+        REQUIRE(opcode.firstParameter());
+        REQUIRE(*opcode.firstParameter() == 1);
+        REQUIRE(!opcode.middleParameter());
     }
 
     SECTION("Parameterized opcode within the opcode")
@@ -71,7 +82,6 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters.size() == 1);
         REQUIRE(opcode.parameters[0] == 123);
-        REQUIRE(!opcode.backParameter);
     }
 
     SECTION("Parameterized opcode within the opcode twice")
@@ -83,7 +93,13 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.parameters.size() == 2);
         REQUIRE(opcode.parameters[0] == 123);
         REQUIRE(opcode.parameters[1] == 44);
-        REQUIRE(!opcode.backParameter);
+        REQUIRE(opcode.parameters == std::vector<uint8_t>({ 123, 44 }));
+        REQUIRE(opcode.parameterPositions == std::vector<int>({ 6, 13 }));
+        REQUIRE(!opcode.backParameter());
+        REQUIRE(opcode.firstParameter());
+        REQUIRE(*opcode.firstParameter() == 123);
+        REQUIRE(opcode.middleParameter());
+        REQUIRE(*opcode.middleParameter() == 44);
     }
 
     SECTION("Parameterized opcode within the opcode twice, with a back parameter")
@@ -92,11 +108,15 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.opcode == "sample123_double44_underscore23");
         REQUIRE(opcode.lettersOnlyHash == hash("sample_double_underscore"));
         REQUIRE(opcode.value == "dummy");
-        REQUIRE(opcode.parameters.size() == 2);
-        REQUIRE(opcode.parameters[0] == 123);
-        REQUIRE(opcode.parameters[1] == 44);
-        REQUIRE(opcode.backParameter);
-        REQUIRE(*opcode.backParameter == 23);
+        REQUIRE(opcode.parameters.size() == 3);
+        REQUIRE(opcode.parameters == std::vector<uint8_t>({ 123, 44, 23 }));
+        REQUIRE(opcode.parameterPositions == std::vector<int>({ 6, 13, 24 }));
+        REQUIRE(opcode.backParameter());
+        REQUIRE(*opcode.backParameter() == 23);
+        REQUIRE(opcode.firstParameter());
+        REQUIRE(*opcode.firstParameter() == 123);
+        REQUIRE(opcode.middleParameter());
+        REQUIRE(*opcode.middleParameter() == 44);
     }
 }
 

--- a/tests/OpcodeT.cpp
+++ b/tests/OpcodeT.cpp
@@ -14,34 +14,89 @@ TEST_CASE("[Opcode] Construction")
     {
         sfz::Opcode opcode { "sample", "dummy" };
         REQUIRE(opcode.opcode == "sample");
+        REQUIRE(opcode.lettersOnlyHash == hash("sample"));
+        REQUIRE(opcode.parameters.empty());
         REQUIRE(opcode.value == "dummy");
-        REQUIRE(!opcode.parameter);
+        REQUIRE(!opcode.backParameter);
     }
 
     SECTION("Normal construction with underscore")
     {
         sfz::Opcode opcode { "sample_underscore", "dummy" };
         REQUIRE(opcode.opcode == "sample_underscore");
+        REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore"));
+        REQUIRE(opcode.parameters.empty());
         REQUIRE(opcode.value == "dummy");
-        REQUIRE(!opcode.parameter);
+        REQUIRE(!opcode.backParameter);
     }
 
     SECTION("Parameterized opcode")
     {
         sfz::Opcode opcode { "sample123", "dummy" };
-        REQUIRE(opcode.opcode == "sample");
+        REQUIRE(opcode.opcode == "sample123");
+        REQUIRE(opcode.lettersOnlyHash == hash("sample"));
         REQUIRE(opcode.value == "dummy");
-        REQUIRE(opcode.parameter);
-        REQUIRE(*opcode.parameter == 123);
+        REQUIRE(opcode.parameters.empty());
+        REQUIRE(opcode.backParameter);
+        REQUIRE(*opcode.backParameter == 123);
     }
 
     SECTION("Parameterized opcode with underscore")
     {
         sfz::Opcode opcode { "sample_underscore123", "dummy" };
-        REQUIRE(opcode.opcode == "sample_underscore");
+        REQUIRE(opcode.opcode == "sample_underscore123");
+        REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore"));
         REQUIRE(opcode.value == "dummy");
-        REQUIRE(opcode.parameter);
-        REQUIRE(*opcode.parameter == 123);
+        REQUIRE(opcode.parameters.empty());
+        REQUIRE(opcode.backParameter);
+        REQUIRE(*opcode.backParameter == 123);
+    }
+
+    SECTION("Parameterized opcode within the opcode")
+    {
+        sfz::Opcode opcode { "sample1_underscore", "dummy" };
+        REQUIRE(opcode.opcode == "sample1_underscore");
+        REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore"));
+        REQUIRE(opcode.value == "dummy");
+        REQUIRE(opcode.parameters.size() == 1);
+        REQUIRE(opcode.parameters[0] == 1);
+        REQUIRE(!opcode.backParameter);
+    }
+
+    SECTION("Parameterized opcode within the opcode")
+    {
+        sfz::Opcode opcode { "sample123_underscore", "dummy" };
+        REQUIRE(opcode.opcode == "sample123_underscore");
+        REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore"));
+        REQUIRE(opcode.value == "dummy");
+        REQUIRE(opcode.parameters.size() == 1);
+        REQUIRE(opcode.parameters[0] == 123);
+        REQUIRE(!opcode.backParameter);
+    }
+
+    SECTION("Parameterized opcode within the opcode twice")
+    {
+        sfz::Opcode opcode { "sample123_double44_underscore", "dummy" };
+        REQUIRE(opcode.opcode == "sample123_double44_underscore");
+        REQUIRE(opcode.lettersOnlyHash == hash("sample_double_underscore"));
+        REQUIRE(opcode.value == "dummy");
+        REQUIRE(opcode.parameters.size() == 2);
+        REQUIRE(opcode.parameters[0] == 123);
+        REQUIRE(opcode.parameters[1] == 44);
+        REQUIRE(!opcode.backParameter);
+    }
+
+    SECTION("Parameterized opcode within the opcode twice, with a back parameter")
+    {
+        sfz::Opcode opcode { "sample123_double44_underscore23", "dummy" };
+        REQUIRE(opcode.opcode == "sample123_double44_underscore23");
+        REQUIRE(opcode.lettersOnlyHash == hash("sample_double_underscore"));
+        REQUIRE(opcode.value == "dummy");
+        REQUIRE(opcode.parameters.size() == 2);
+        REQUIRE(opcode.parameters[0] == 123);
+        REQUIRE(opcode.parameters[1] == 44);
+        REQUIRE(opcode.backParameter);
+        REQUIRE(*opcode.backParameter == 23);
     }
 }
 


### PR DESCRIPTION
In preparation for the filters and more complex opcodes, you need not only the store the "back" parameter but also other numbers in the opcode name (e.g. eqN_gainccXX). This PR separates the back parameters from the rest since its position does convey meaning, and assumes that the other parameters are ordered within the opcode.

One side effect of the implementation is that it will properly parse say `eq_NgainccXX`. No a priori check is made that the opcodes is of "known form with respect to parameter parsing". If this is desirable, it would require changes to the way the parsing of opcodes is done (e.g. by checking existence and form upon construction).