### PR TITLE
Add the equalizer band filter

### DIFF
--- a/scripts/generate_filters.sh
+++ b/scripts/generate_filters.sh
@@ -21,6 +21,7 @@ faustgen() {
     local cutoffVar=`echo "$code" | $SED -r 's%.*\("Cutoff", &[ \t]*([a-zA-Z0-9_]+).*%\1%;t;d'`
     local resoVar=`echo "$code" | $SED -r 's%.*\("Resonance", &[ \t]*([a-zA-Z0-9_]+).*%\1%;t;d'`
     local pkshVar=`echo "$code" | $SED -r 's%.*\("Peak/shelf gain", &[ \t]*([a-zA-Z0-9_]+).*%\1%;t;d'`
+    local bwVar=`echo "$code" | $SED -r 's%.*\("Bandwidth", &[ \t]*([a-zA-Z0-9_]+).*%\1%;t;d'`
 
     # suppress some faust-specific stuff we don't care
     echo "$code" \
@@ -47,6 +48,9 @@ faustgen() {
     if test ! -z "$pkshVar"; then
         $SED -r -i 's/\b'"$pkshVar"'\b/fPkShGain/' "$outfile"
     fi
+    if test ! -z "$bwVar"; then
+        $SED -r -i 's/\b'"$bwVar"'\b/fBandwidth/' "$outfile"
+    fi
 }
 
 for f in \
@@ -57,7 +61,8 @@ for f in \
     Brf1p Brf2p \
     Lsh Hsh Peq \
     Pink \
-    Lpf2pSv Hpf2pSv Bpf2pSv Brf2pSv
+    Lpf2pSv Hpf2pSv Bpf2pSv Brf2pSv \
+    Eq
 do
     faustgen "$f"
     faustgen "2ch$f"

--- a/src/sfizz/SfzFilter.h
+++ b/src/sfizz/SfzFilter.h
@@ -97,4 +97,53 @@ enum FilterType : int {
     kFilterPeq,
 };
 
+/**
+   Equalizer filter for SFZ v1
+   Available for mono and stereo. (NCh=1, NCh=2)
+
+   Parameters:
+     `cutoff`: it's the opcode `egN_freq` (Hz)
+     `bw`: it's the opcode `eqN_bw` (octave)
+     `pksh`: it's the opcode `eqN_gain` (dB)
+ */
+template <unsigned NCh>
+class FilterEq {
+public:
+    FilterEq();
+    ~FilterEq();
+
+    /**
+       Set up the filter constants.
+       Run it exactly once after instantiating.
+     */
+    void init(double sampleRate);
+
+    /**
+       Reinitialize the filter memory to zeros.
+     */
+    void clear();
+
+    /**
+       Process one cycle of the filter without modulating cutoff or bandwidth.
+       `cutoff` is a frequency expressed in Hz.
+       `bw` is a bandwidth expressed in octaves.
+       `pksh` is a peak/shelf gain expressed in dB.
+       `in[i]` and `out[i]` may refer to identical buffers, for in-place processing
+     */
+    void process(const float *const in[NCh], float *const out[NCh], float cutoff, float bw, float pksh, unsigned nframes);
+
+    /**
+       Process one cycle of the filter with cutoff and bandwidth values varying over time.
+       `cutoff` is a frequency expressed in Hz.
+       `bw` is a bandwidth expressed in octaves.
+       `pksh` is a peak/shelf gain expressed in dB.
+       `in[i]` and `out[i]` may refer to identical buffers, for in-place processing
+     */
+    void processModulated(const float *const in[NCh], float *const out[NCh], const float *cutoff, const float *bw, const float *pksh, unsigned nframes);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> P;
+};
+
 } // namespace sfz

--- a/src/sfizz/SfzFilterImpls.cxx
+++ b/src/sfizz/SfzFilterImpls.cxx
@@ -36,6 +36,7 @@ struct UI {};
 #include "gen/filters/sfzLsh.cxx"
 #include "gen/filters/sfzHsh.cxx"
 #include "gen/filters/sfzPeq.cxx"
+#include "gen/filters/sfzEq.cxx"
 
 #include "gen/filters/sfz2chApf1p.cxx"
 #include "gen/filters/sfz2chBpf1p.cxx"
@@ -60,6 +61,7 @@ struct UI {};
 #include "gen/filters/sfz2chLsh.cxx"
 #include "gen/filters/sfz2chHsh.cxx"
 #include "gen/filters/sfz2chPeq.cxx"
+#include "gen/filters/sfz2chEq.cxx"
 
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
@@ -105,6 +107,16 @@ template <class F> struct sfzFilterPkSh : public F {
     void setPkShGain(float v) { F::fPkShGain = v; }
 };
 
+/**
+   Wrapper of equalizer filters with a bandwidth control
+   Parameterized by cutoff, bandwidth, peak/shelf gain
+ */
+template <class F> struct sfzFilterEq : public F {
+    void setCutoff(float v) { F::fCutoff = v; }
+    void setBandwidth(float v) { F::fBandwidth = v; }
+    void setPkShGain(float v) { F::fPkShGain = v; }
+};
+
 template <unsigned NCh> struct sfzLpf1p;
 template <unsigned NCh> struct sfzLpf2p;
 template <unsigned NCh> struct sfzLpf4p;
@@ -128,6 +140,7 @@ template <unsigned NCh> struct sfzBrf2pSv;
 template <unsigned NCh> struct sfzLsh;
 template <unsigned NCh> struct sfzHsh;
 template <unsigned NCh> struct sfzPeq;
+template <unsigned NCh> struct sfzEq;
 
 template<> struct sfzLpf1p<1> : public sfzFilterNoQ<faustLpf1p> {};
 template<> struct sfzLpf2p<1> : public sfzFilter<faustLpf2p> {};
@@ -152,6 +165,7 @@ template<> struct sfzBrf2pSv<1> : public sfzFilter<faustBrf2pSv> {};
 template<> struct sfzLsh<1> : public sfzFilterPkSh<faustLsh> {};
 template<> struct sfzHsh<1> : public sfzFilterPkSh<faustHsh> {};
 template<> struct sfzPeq<1> : public sfzFilterPkSh<faustPeq> {};
+template<> struct sfzEq<1> : public sfzFilterEq<faustEq> {};
 
 template<> struct sfzLpf1p<2> : public sfzFilterNoQ<faust2chLpf1p> {};
 template<> struct sfzLpf2p<2> : public sfzFilter<faust2chLpf2p> {};
@@ -176,3 +190,4 @@ template<> struct sfzBrf2pSv<2> : public sfzFilter<faust2chBrf2pSv> {};
 template<> struct sfzLsh<2> : public sfzFilterPkSh<faust2chLsh> {};
 template<> struct sfzHsh<2> : public sfzFilterPkSh<faust2chHsh> {};
 template<> struct sfzPeq<2> : public sfzFilterPkSh<faust2chPeq> {};
+template<> struct sfzEq<2> : public sfzFilterEq<faust2chEq> {};

--- a/src/sfizz/SfzFilterImpls.cxx
+++ b/src/sfizz/SfzFilterImpls.cxx
@@ -65,25 +65,41 @@ struct UI {};
 #pragma GCC diagnostic pop
 #endif
 
+/**
+   Wrapper of the most common kind of resonant filter
+   Parameterized by cutoff and Q
+ */
 template <class F> struct sfzFilter : public F {
     void setCutoff(float v) { F::fCutoff = v; }
     void setQ(float v) { F::fQ = v; }
     void setPkShGain(float) {}
 };
 
+/**
+   Wrapper of non resonant filters
+   Parameterized by cutoff only
+ */
 template <class F> struct sfzFilterNoQ : public F {
     void setCutoff(float v) { F::fCutoff = v; }
     void setQ(float) {}
     void setPkShGain(float) {}
 };
 
+/**
+   Wrapper of fixed filters
+   Not parameterized
+ */
 template <class F> struct sfzFilterNoCutoff : public F {
     void setCutoff(float) {}
     void setQ(float) {}
     void setPkShGain(float) {}
 };
 
-template <class F> struct sfzFilterEq : public F {
+/**
+   Wrapper of resonant filters with a gain control for peak or shelf
+   Parameterized by cutoff, Q, peak/shelf gain
+ */
+template <class F> struct sfzFilterPkSh : public F {
     void setCutoff(float v) { F::fCutoff = v; }
     void setQ(float v) { F::fQ = v; }
     void setPkShGain(float v) { F::fPkShGain = v; }
@@ -133,9 +149,9 @@ template<> struct sfzLpf2pSv<1> : public sfzFilter<faustLpf2pSv> {};
 template<> struct sfzHpf2pSv<1> : public sfzFilter<faustHpf2pSv> {};
 template<> struct sfzBpf2pSv<1> : public sfzFilter<faustBpf2pSv> {};
 template<> struct sfzBrf2pSv<1> : public sfzFilter<faustBrf2pSv> {};
-template<> struct sfzLsh<1> : public sfzFilterEq<faustLsh> {};
-template<> struct sfzHsh<1> : public sfzFilterEq<faustHsh> {};
-template<> struct sfzPeq<1> : public sfzFilterEq<faustPeq> {};
+template<> struct sfzLsh<1> : public sfzFilterPkSh<faustLsh> {};
+template<> struct sfzHsh<1> : public sfzFilterPkSh<faustHsh> {};
+template<> struct sfzPeq<1> : public sfzFilterPkSh<faustPeq> {};
 
 template<> struct sfzLpf1p<2> : public sfzFilterNoQ<faust2chLpf1p> {};
 template<> struct sfzLpf2p<2> : public sfzFilter<faust2chLpf2p> {};
@@ -157,6 +173,6 @@ template<> struct sfzLpf2pSv<2> : public sfzFilter<faust2chLpf2pSv> {};
 template<> struct sfzHpf2pSv<2> : public sfzFilter<faust2chHpf2pSv> {};
 template<> struct sfzBpf2pSv<2> : public sfzFilter<faust2chBpf2pSv> {};
 template<> struct sfzBrf2pSv<2> : public sfzFilter<faust2chBrf2pSv> {};
-template<> struct sfzLsh<2> : public sfzFilterEq<faust2chLsh> {};
-template<> struct sfzHsh<2> : public sfzFilterEq<faust2chHsh> {};
-template<> struct sfzPeq<2> : public sfzFilterEq<faust2chPeq> {};
+template<> struct sfzLsh<2> : public sfzFilterPkSh<faust2chLsh> {};
+template<> struct sfzHsh<2> : public sfzFilterPkSh<faust2chHsh> {};
+template<> struct sfzPeq<2> : public sfzFilterPkSh<faust2chPeq> {};

--- a/src/sfizz/dsp/filters/sfz_filters.dsp
+++ b/src/sfizz/dsp/filters/sfz_filters.dsp
@@ -11,7 +11,7 @@ sk = library("sallenkey_modulable.dsp");
 // Generators
 
 // the SFZ *noise generator
-sfzNoise = no.noise : *(gate) : *(0.25);
+sfzNoise = no.noise : *(0.25);
 
 //==============================================================================
 // Filters
@@ -90,6 +90,12 @@ sfzHsh = fm.rbjHighShelfSmooth(smoothCoefs,cutoff,pkShGain,Q);
 // the SFZ peaking EQ filter
 sfzPeq = fm.rbjPeakingEqSmooth(smoothCoefs,cutoff,pkShGain,Q);
 
+// the SFZ equalizer band
+sfzEq = fm.rbjPeakingEqSmooth(smoothCoefs,cutoff,pkShGain,Q) with {
+  Q = 1./(2.*ma.sinh(0.5*log(2)*bandwidth*w0/sin(w0)));
+  w0 = 2*ma.PI*max(0,cutoff)/ma.SR;
+};
+
 //==============================================================================
 // Filters (stereo)
 
@@ -116,6 +122,7 @@ sfz2chBrf2pSv = par(i,2,sfzBrf2pSv);
 sfz2chLsh = par(i,2,sfzLsh);
 sfz2chHsh = par(i,2,sfzHsh);
 sfz2chPeq = par(i,2,sfzPeq);
+sfz2chEq = par(i,2,sfzEq);
 
 //==============================================================================
 // Filter parameters
@@ -123,6 +130,7 @@ sfz2chPeq = par(i,2,sfzPeq);
 cutoff = hslider("[01] Cutoff [unit:Hz] [scale:log]", 440.0, 50.0, 10000.0, 1.0);
 Q = vslider("[02] Resonance [unit:dB]", 0.0, 0.0, 40.0, 0.1) : ba.db2linear;
 pkShGain = vslider("[03] Peak/shelf gain [unit:dB]", 0.0, 0.0, 40.0, 0.1);
+bandwidth = vslider("[04] Bandwidth [unit:octave]", 1.0, 0.1, 10.0, 0.01);
 
 // smoothing function to prevent fast changes of filter coefficients
 smoothCoefs = si.smoo; // TODO check if this is appropriate otherwise replace

--- a/src/sfizz/gen/filters/sfz2chEq.cxx
+++ b/src/sfizz/gen/filters/sfz2chEq.cxx
@@ -6,20 +6,21 @@ Code generated with Faust 2.20.2 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
-#ifndef  __faust2chPeq_H__
-#define  __faust2chPeq_H__
+#ifndef  __faust2chEq_H__
+#define  __faust2chEq_H__
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
 #endif 
 
+/* link with : "" */
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
 #ifndef FAUSTCLASS 
-#define FAUSTCLASS faust2chPeq
+#define FAUSTCLASS faust2chEq
 #endif
 
 #ifdef __APPLE__ 
@@ -27,14 +28,16 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chPeq : public dsp {
+class faust2chEq : public dsp {
 	
  public:
 	
 	int fSampleRate;
 	double fConst0;
+	double fConst1;
 	FAUSTFLOAT fCutoff;
-	FAUSTFLOAT fQ;
+	double fConst2;
+	FAUSTFLOAT fBandwidth;
 	FAUSTFLOAT fPkShGain;
 	double fRec1[2];
 	double fRec2[2];
@@ -96,12 +99,14 @@ class faust2chPeq : public dsp {
 	
 	 void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
+		fConst1 = (6.2831853071795862 / fConst0);
+		fConst2 = (2.1775860903036022 / fConst0);
 	}
 	
 	 void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
-		fQ = FAUSTFLOAT(0.0);
+		fBandwidth = FAUSTFLOAT(1.0);
 		fPkShGain = FAUSTFLOAT(0.0);
 	}
 	
@@ -136,8 +141,8 @@ class faust2chPeq : public dsp {
 		instanceClear();
 	}
 	
-	 faust2chPeq* clone() {
-		return new faust2chPeq();
+	 faust2chEq* clone() {
+		return new faust2chEq();
 	}
 	
 	 int getSampleRate() {
@@ -152,26 +157,27 @@ class faust2chPeq : public dsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = std::sin(fSlow0);
-		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
-		double fSlow3 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
-		double fSlow4 = (0.5 * (fSlow1 / (fSlow2 * fSlow3)));
-		double fSlow5 = (fSlow4 + 1.0);
-		double fSlow6 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow5));
-		double fSlow7 = (0.0010000000000000009 * ((1.0 - fSlow4) / fSlow5));
-		double fSlow8 = (0.5 * ((fSlow1 * fSlow3) / fSlow2));
-		double fSlow9 = (0.0010000000000000009 * ((fSlow8 + 1.0) / fSlow5));
-		double fSlow10 = (0.0010000000000000009 * ((1.0 - fSlow8) / fSlow5));
+		double fSlow0 = std::max<double>(0.0, double(fCutoff));
+		double fSlow1 = (fConst1 * fSlow0);
+		double fSlow2 = std::sin(fSlow1);
+		double fSlow3 = std::max<double>(0.001, (0.5 / double(sinh(double((fConst2 * ((fSlow0 * double(fBandwidth)) / fSlow2)))))));
+		double fSlow4 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
+		double fSlow5 = (0.5 * (fSlow2 / (fSlow3 * fSlow4)));
+		double fSlow6 = (fSlow5 + 1.0);
+		double fSlow7 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow1))) / fSlow6));
+		double fSlow8 = (0.0010000000000000009 * ((1.0 - fSlow5) / fSlow6));
+		double fSlow9 = (0.5 * ((fSlow2 * fSlow4) / fSlow3));
+		double fSlow10 = (0.0010000000000000009 * ((fSlow9 + 1.0) / fSlow6));
+		double fSlow11 = (0.0010000000000000009 * ((1.0 - fSlow9) / fSlow6));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow6 + (0.999 * fRec1[1]));
+			fRec1[0] = (fSlow7 + (0.999 * fRec1[1]));
 			double fTemp2 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = (fSlow7 + (0.999 * fRec2[1]));
+			fRec2[0] = (fSlow8 + (0.999 * fRec2[1]));
 			fRec0[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow9 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow10 + (0.999 * fRec4[1]));
+			fRec3[0] = (fSlow10 + (0.999 * fRec3[1]));
+			fRec4[0] = (fSlow11 + (0.999 * fRec4[1]));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp2) + (fRec4[0] * fRec0[2])));
 			double fTemp3 = (fRec1[0] * fRec5[1]);
 			fRec5[0] = (fTemp1 - (fTemp3 + (fRec2[0] * fRec5[2])));

--- a/src/sfizz/gen/filters/sfzEq.cxx
+++ b/src/sfizz/gen/filters/sfzEq.cxx
@@ -6,20 +6,21 @@ Code generated with Faust 2.20.2 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
-#ifndef  __faust2chPeq_H__
-#define  __faust2chPeq_H__
+#ifndef  __faustEq_H__
+#define  __faustEq_H__
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
 #endif 
 
+/* link with : "" */
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
 #ifndef FAUSTCLASS 
-#define FAUSTCLASS faust2chPeq
+#define FAUSTCLASS faustEq
 #endif
 
 #ifdef __APPLE__ 
@@ -27,21 +28,22 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chPeq : public dsp {
+class faustEq : public dsp {
 	
  public:
 	
 	int fSampleRate;
 	double fConst0;
+	double fConst1;
 	FAUSTFLOAT fCutoff;
-	FAUSTFLOAT fQ;
+	double fConst2;
+	FAUSTFLOAT fBandwidth;
 	FAUSTFLOAT fPkShGain;
 	double fRec1[2];
 	double fRec2[2];
 	double fRec0[3];
 	double fRec3[2];
 	double fRec4[2];
-	double fRec5[3];
 	
  public:
 	
@@ -49,19 +51,15 @@ class faust2chPeq : public dsp {
 	}
 
 	 int getNumInputs() {
-		return 2;
+		return 1;
 	}
 	 int getNumOutputs() {
-		return 2;
+		return 1;
 	}
 	 int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
-				rate = 1;
-				break;
-			}
-			case 1: {
 				rate = 1;
 				break;
 			}
@@ -79,10 +77,6 @@ class faust2chPeq : public dsp {
 				rate = 1;
 				break;
 			}
-			case 1: {
-				rate = 1;
-				break;
-			}
 			default: {
 				rate = -1;
 				break;
@@ -96,12 +90,14 @@ class faust2chPeq : public dsp {
 	
 	 void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
+		fConst1 = (6.2831853071795862 / fConst0);
+		fConst2 = (2.1775860903036022 / fConst0);
 	}
 	
 	 void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
-		fQ = FAUSTFLOAT(0.0);
+		fBandwidth = FAUSTFLOAT(1.0);
 		fPkShGain = FAUSTFLOAT(0.0);
 	}
 	
@@ -121,9 +117,6 @@ class faust2chPeq : public dsp {
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
 		}
-		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
-			fRec5[l5] = 0.0;
-		}
 	}
 	
 	 void init(int sample_rate) {
@@ -136,8 +129,8 @@ class faust2chPeq : public dsp {
 		instanceClear();
 	}
 	
-	 faust2chPeq* clone() {
-		return new faust2chPeq();
+	 faustEq* clone() {
+		return new faustEq();
 	}
 	
 	 int getSampleRate() {
@@ -149,41 +142,34 @@ class faust2chPeq : public dsp {
 	
 	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
-		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
-		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = std::sin(fSlow0);
-		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
-		double fSlow3 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
-		double fSlow4 = (0.5 * (fSlow1 / (fSlow2 * fSlow3)));
-		double fSlow5 = (fSlow4 + 1.0);
-		double fSlow6 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow5));
-		double fSlow7 = (0.0010000000000000009 * ((1.0 - fSlow4) / fSlow5));
-		double fSlow8 = (0.5 * ((fSlow1 * fSlow3) / fSlow2));
-		double fSlow9 = (0.0010000000000000009 * ((fSlow8 + 1.0) / fSlow5));
-		double fSlow10 = (0.0010000000000000009 * ((1.0 - fSlow8) / fSlow5));
+		double fSlow0 = std::max<double>(0.0, double(fCutoff));
+		double fSlow1 = (fConst1 * fSlow0);
+		double fSlow2 = std::sin(fSlow1);
+		double fSlow3 = std::max<double>(0.001, (0.5 / double(sinh(double((fConst2 * ((fSlow0 * double(fBandwidth)) / fSlow2)))))));
+		double fSlow4 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
+		double fSlow5 = (0.5 * (fSlow2 / (fSlow3 * fSlow4)));
+		double fSlow6 = (fSlow5 + 1.0);
+		double fSlow7 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow1))) / fSlow6));
+		double fSlow8 = (0.0010000000000000009 * ((1.0 - fSlow5) / fSlow6));
+		double fSlow9 = (0.5 * ((fSlow2 * fSlow4) / fSlow3));
+		double fSlow10 = (0.0010000000000000009 * ((fSlow9 + 1.0) / fSlow6));
+		double fSlow11 = (0.0010000000000000009 * ((1.0 - fSlow9) / fSlow6));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow6 + (0.999 * fRec1[1]));
-			double fTemp2 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = (fSlow7 + (0.999 * fRec2[1]));
-			fRec0[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow9 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow10 + (0.999 * fRec4[1]));
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp2) + (fRec4[0] * fRec0[2])));
-			double fTemp3 = (fRec1[0] * fRec5[1]);
-			fRec5[0] = (fTemp1 - (fTemp3 + (fRec2[0] * fRec5[2])));
-			output1[i] = FAUSTFLOAT(((fTemp3 + (fRec3[0] * fRec5[0])) + (fRec4[0] * fRec5[2])));
+			fRec1[0] = (fSlow7 + (0.999 * fRec1[1]));
+			double fTemp1 = (fRec1[0] * fRec0[1]);
+			fRec2[0] = (fSlow8 + (0.999 * fRec2[1]));
+			fRec0[0] = (fTemp0 - (fTemp1 + (fRec2[0] * fRec0[2])));
+			fRec3[0] = (fSlow10 + (0.999 * fRec3[1]));
+			fRec4[0] = (fSlow11 + (0.999 * fRec4[1]));
+			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp1) + (fRec4[0] * fRec0[2])));
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
 			fRec0[2] = fRec0[1];
 			fRec0[1] = fRec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
-			fRec5[2] = fRec5[1];
-			fRec5[1] = fRec5[0];
 		}
 	}
 


### PR DESCRIPTION
This adds the EQ filter. No wrapper at this point, but just here for reference.

In summary:
- the equalizer band is a `peq`
- `eqN_freq` is equivalent of `cutoff`
- `eqN_gain` is equivalent of `fil_gain`
- `eqN_bw` is without equivalent ; it computes a fitting `Q` according to the formula

The formula is "FYI: The relationship between bandwidth and Q is ­— digital filter with BLT"
from the document https://www.w3.org/2011/audio/audio-eq-cookbook.html

After a few tries, it seems matching to ARIA.

Note: the `sinh` part of this formula, which is a k-rate update, is a potential candidate for tabulating