### PR TITLE
Filter benchmarks

### DIFF
--- a/benchmarks/BM_filterModulation.cpp
+++ b/benchmarks/BM_filterModulation.cpp
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "SIMDHelpers.h"
+#include "OnePoleFilter.h"
+#include "SfzFilter.h"
+#include <benchmark/benchmark.h>
+#include <random>
+#include <numeric>
+#include <vector>
+#include <cmath>
+#include <iostream>
+
+constexpr int blockSize { 1024 };
+constexpr float sampleRate { 48000.0f };
+
+class FilterFixture : public benchmark::Fixture {
+public:
+    void SetUp(const ::benchmark::State& state) {
+        input = std::vector<float>(blockSize);
+        output = std::vector<float>(blockSize);
+        cutoff = std::vector<float>(blockSize);
+        q = std::vector<float>(blockSize);
+        pksh = std::vector<float>(blockSize);
+        sfz::linearRamp<float>(absl::MakeSpan(cutoff), 500, 1.0f);
+        sfz::linearRamp<float>(absl::MakeSpan(q), 0.0f, 0.001f);
+        sfz::linearRamp<float>(absl::MakeSpan(pksh), 0.0f, 0.001f);
+        std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
+    }
+
+    void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+
+    }
+    std::random_device rd { };
+    std::mt19937 gen { rd() };
+    std::normal_distribution<float> dist { 0, 0.5 };
+    std::vector<float> cutoff;
+    std::vector<float> q;
+    std::vector<float> pksh;
+    std::vector<float> input;
+    std::vector<float> output;
+};
+
+BENCHMARK_DEFINE_F(FilterFixture, OnePole_VA)(benchmark::State& state) {
+    sfz::OnePoleFilter<float> filter;
+    for (auto _ : state)
+    {
+        const auto step = static_cast<size_t>(state.range(0));
+        auto cutoffIterator = cutoff.begin();
+        auto inputIterator = input.begin();
+        auto outputIterator = output.begin();
+        while (cutoffIterator < cutoff.end())
+        {
+            const auto gain = sfz::OnePoleFilter<float>::normalizedGain(*cutoffIterator, sampleRate);
+            filter.setGain(gain);
+            filter.processLowpass({ inputIterator.base(), step }, { outputIterator.base(), step } );
+            cutoffIterator += step;
+            inputIterator += step;
+            outputIterator += step;
+        }
+    }
+}
+
+BENCHMARK_DEFINE_F(FilterFixture, OnePole_Faust)(benchmark::State& state) {
+    sfz::Filter<1> filter;
+    filter.setType(sfz::FilterType::kFilterLpf1p);
+    for (auto _ : state)
+    {
+        const auto step = static_cast<size_t>(state.range(0));
+        auto cutoffIterator = cutoff.begin();
+        auto inputIterator = input.begin();
+        auto outputIterator = output.begin();
+        while (cutoffIterator < cutoff.end())
+        {
+            filter.process(&inputIterator.base(), &outputIterator.base(), *cutoffIterator, 0.0, 0.0, step);
+            cutoffIterator += step;
+            inputIterator += step;
+            outputIterator += step;
+        }
+    }
+}
+
+BENCHMARK_DEFINE_F(FilterFixture, TwoPole_Faust)(benchmark::State& state) {
+    sfz::Filter<1> filter;
+    filter.setType(sfz::FilterType::kFilterLpf2p);
+    for (auto _ : state)
+    {
+        const auto step = static_cast<size_t>(state.range(0));
+        auto cutoffIterator = cutoff.begin();
+        auto qIterator = q.begin();
+        auto inputIterator = input.begin();
+        auto outputIterator = output.begin();
+        while (cutoffIterator < cutoff.end())
+        {
+            filter.process(&inputIterator.base(), &outputIterator.base(), *cutoffIterator, *qIterator, 0.0, step);
+            qIterator += step;
+            cutoffIterator += step;
+            inputIterator += step;
+            outputIterator += step;
+        }
+    }
+}
+
+BENCHMARK_DEFINE_F(FilterFixture, TwoPoleShelf_Faust)(benchmark::State& state) {
+    sfz::Filter<1> filter;
+    filter.setType(sfz::FilterType::kFilterLsh);
+    for (auto _ : state)
+    {
+        const auto step = static_cast<size_t>(state.range(0));
+        auto cutoffIterator = cutoff.begin();
+        auto qIterator = q.begin();
+        auto pkshIterator = pksh.begin();
+        auto inputIterator = input.begin();
+        auto outputIterator = output.begin();
+        while (cutoffIterator < cutoff.end())
+        {
+            filter.process(&inputIterator.base(), &outputIterator.base(), *cutoffIterator, *qIterator, *pkshIterator, step);
+            qIterator += step;
+            cutoffIterator += step;
+            pkshIterator += step;
+            inputIterator += step;
+            outputIterator += step;
+        }
+    }
+}
+
+BENCHMARK_REGISTER_F(FilterFixture, OnePole_VA)->RangeMultiplier(2)->Range(1, 1 << 8);
+BENCHMARK_REGISTER_F(FilterFixture, OnePole_Faust)->RangeMultiplier(2)->Range(1, 1 << 8);
+BENCHMARK_REGISTER_F(FilterFixture, TwoPole_Faust)->RangeMultiplier(2)->Range(1, 1 << 8);
+BENCHMARK_REGISTER_F(FilterFixture, TwoPoleShelf_Faust)->RangeMultiplier(2)->Range(1, 1 << 8);
+BENCHMARK_MAIN();
+

--- a/benchmarks/BM_filterStereoMono.cpp
+++ b/benchmarks/BM_filterStereoMono.cpp
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "SIMDHelpers.h"
+#include "OnePoleFilter.h"
+#include "SfzFilter.h"
+#include <benchmark/benchmark.h>
+#include <random>
+#include <numeric>
+#include <vector>
+#include <cmath>
+#include <iostream>
+
+constexpr int blockSize { 1024 };
+constexpr float sampleRate { 48000.0f };
+
+class FilterFixture : public benchmark::Fixture {
+public:
+    void SetUp(const ::benchmark::State& state) {
+        inputLeft = std::vector<float>(blockSize);
+        inputRight = std::vector<float>(blockSize);
+        outputLeft = std::vector<float>(blockSize);
+        outputRight = std::vector<float>(blockSize);
+        cutoff = std::vector<float>(blockSize);
+        q = std::vector<float>(blockSize);
+        pksh = std::vector<float>(blockSize);
+        sfz::linearRamp<float>(absl::MakeSpan(cutoff), 500, 1.0f);
+        sfz::linearRamp<float>(absl::MakeSpan(q), 0.0f, 0.001f);
+        sfz::linearRamp<float>(absl::MakeSpan(pksh), 0.0f, 0.001f);
+        std::generate(inputLeft.begin(), inputLeft.end(), [&]() { return dist(gen); });
+        std::generate(inputRight.begin(), inputRight.end(), [&]() { return dist(gen); });
+    }
+
+    void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+
+    }
+    std::random_device rd { };
+    std::mt19937 gen { rd() };
+    std::normal_distribution<float> dist { 0, 0.5 };
+    std::vector<float> cutoff;
+    std::vector<float> q;
+    std::vector<float> pksh;
+    std::vector<float> inputLeft;
+    std::vector<float> inputRight;
+    std::vector<float> outputLeft;
+    std::vector<float> outputRight;
+};
+
+BENCHMARK_DEFINE_F(FilterFixture, OnePole_MonoOnce)(benchmark::State& state) {
+    sfz::Filter<1> filterLeft;
+    sfz::Filter<1> filterRight;
+    filterLeft.setType(sfz::FilterType::kFilterLpf1p);
+    for (auto _ : state)
+    {
+        const auto step = static_cast<size_t>(state.range(0));
+        auto cutoffIterator = cutoff.begin();
+        auto inLIterator = inputLeft.begin();
+        auto outLIterator = outputRight.begin();
+        while (cutoffIterator < cutoff.end())
+        {
+            filterLeft.process( &inLIterator.base(), &outLIterator.base(), *cutoffIterator, 0.0, 0.0, step);
+            cutoffIterator += step;
+            inLIterator += step;
+            outLIterator += step;
+        }
+    }
+}
+
+BENCHMARK_DEFINE_F(FilterFixture, OnePole_MonoTwice)(benchmark::State& state) {
+    sfz::Filter<1> filterLeft;
+    sfz::Filter<1> filterRight;
+    filterLeft.setType(sfz::FilterType::kFilterLpf1p);
+    filterRight.setType(sfz::FilterType::kFilterLpf1p);
+    for (auto _ : state)
+    {
+        const auto step = static_cast<size_t>(state.range(0));
+        auto cutoffIterator = cutoff.begin();
+        auto inLIterator = inputLeft.begin();
+        auto inRIterator = inputRight.begin();
+        auto outRIterator = outputLeft.begin();
+        auto outLIterator = outputRight.begin();
+        while (cutoffIterator < cutoff.end())
+        {
+            filterLeft.process( &inLIterator.base(), &outLIterator.base(), *cutoffIterator, 0.0, 0.0, step);
+            filterRight.process(&inRIterator.base(), &outRIterator.base(), *cutoffIterator, 0.0, 0.0, step);
+            cutoffIterator += step;
+            inLIterator += step;
+            inRIterator += step;
+            outLIterator += step;
+            outRIterator += step;
+        }
+    }
+}
+
+BENCHMARK_DEFINE_F(FilterFixture, OnePole_Stereo)(benchmark::State& state) {
+    sfz::Filter<2> filter;
+    filter.setType(sfz::FilterType::kFilterLpf1p);
+    for (auto _ : state)
+    {
+        const auto step = static_cast<size_t>(state.range(0));
+        auto cutoffIterator = cutoff.begin();
+        auto inLIterator = inputLeft.begin();
+        auto inRIterator = inputRight.begin();
+        auto outRIterator = outputLeft.begin();
+        auto outLIterator = outputRight.begin();
+        while (cutoffIterator < cutoff.end())
+        {
+            float * inputs[2] = { inLIterator.base(), inRIterator.base() };
+            float * outputs[2] = { outLIterator.base(), outRIterator.base() };
+            filter.process(inputs, outputs, *cutoffIterator, 0.0, 0.0, step);
+            cutoffIterator += step;
+            inLIterator += step;
+            inRIterator += step;
+            outLIterator += step;
+            outRIterator += step;
+        }
+    }
+}
+
+BENCHMARK_DEFINE_F(FilterFixture, TwoPole_MonoOnce)(benchmark::State& state) {
+    sfz::Filter<1> filterLeft;
+    sfz::Filter<1> filterRight;
+    filterLeft.setType(sfz::FilterType::kFilterLpf2p);
+    for (auto _ : state)
+    {
+        const auto step = static_cast<size_t>(state.range(0));
+        auto cutoffIterator = cutoff.begin();
+        auto qIterator = q.begin();
+        auto inLIterator = inputLeft.begin();
+        auto outLIterator = outputRight.begin();
+        while (cutoffIterator < cutoff.end())
+        {
+            filterLeft.process(&inLIterator.base(), &outLIterator.base(), *cutoffIterator, *qIterator, 0.0, step);
+            cutoffIterator += step;
+            qIterator += step;
+            inLIterator += step;
+            outLIterator += step;
+        }
+    }
+}
+
+BENCHMARK_DEFINE_F(FilterFixture, TwoPole_MonoTwice)(benchmark::State& state) {
+    sfz::Filter<1> filterLeft;
+    sfz::Filter<1> filterRight;
+    filterLeft.setType(sfz::FilterType::kFilterLpf2p);
+    filterRight.setType(sfz::FilterType::kFilterLpf2p);
+    for (auto _ : state)
+    {
+        const auto step = static_cast<size_t>(state.range(0));
+        auto cutoffIterator = cutoff.begin();
+        auto qIterator = q.begin();
+        auto inLIterator = inputLeft.begin();
+        auto inRIterator = inputRight.begin();
+        auto outRIterator = outputLeft.begin();
+        auto outLIterator = outputRight.begin();
+        while (cutoffIterator < cutoff.end())
+        {
+            filterLeft.process( &inLIterator.base(), &outLIterator.base(), *cutoffIterator, *qIterator, 0.0, step);
+            filterRight.process(&inRIterator.base(), &outRIterator.base(), *cutoffIterator, *qIterator, 0.0, step);
+            cutoffIterator += step;
+            qIterator += step;
+            inLIterator += step;
+            inRIterator += step;
+            outLIterator += step;
+            outRIterator += step;
+        }
+    }
+}
+
+BENCHMARK_DEFINE_F(FilterFixture, TwoPole_Stereo)(benchmark::State& state) {
+    sfz::Filter<2> filter;
+    filter.setType(sfz::FilterType::kFilterLpf2p);
+    for (auto _ : state)
+    {
+        const auto step = static_cast<size_t>(state.range(0));
+        auto cutoffIterator = cutoff.begin();
+        auto qIterator = q.begin();
+        auto inLIterator = inputLeft.begin();
+        auto inRIterator = inputRight.begin();
+        auto outRIterator = outputLeft.begin();
+        auto outLIterator = outputRight.begin();
+        while (cutoffIterator < cutoff.end())
+        {
+            float * inputs[2] = { inLIterator.base(), inRIterator.base() };
+            float * outputs[2] = { outLIterator.base(), outRIterator.base() };
+            filter.process(inputs, outputs, *cutoffIterator, *qIterator, 0.0, step);
+            cutoffIterator += step;
+            qIterator += step;
+            inLIterator += step;
+            inRIterator += step;
+            outLIterator += step;
+            outRIterator += step;
+        }
+    }
+}
+
+BENCHMARK_DEFINE_F(FilterFixture, Shelf_MonoOnce)(benchmark::State& state) {
+    sfz::Filter<1> filterLeft;
+    sfz::Filter<1> filterRight;
+    filterLeft.setType(sfz::FilterType::kFilterLpf2p);
+    for (auto _ : state)
+    {
+        const auto step = static_cast<size_t>(state.range(0));
+        auto cutoffIterator = cutoff.begin();
+        auto qIterator = q.begin();
+        auto pkshIterator = pksh.begin();
+        auto inLIterator = inputLeft.begin();
+        auto outLIterator = outputRight.begin();
+        while (cutoffIterator < cutoff.end())
+        {
+            filterLeft.process(&inLIterator.base(), &outLIterator.base(), *cutoffIterator, *qIterator, *pkshIterator, step);
+            cutoffIterator += step;
+            qIterator += step;
+            pkshIterator += step;
+            inLIterator += step;
+            outLIterator += step;
+        }
+    }
+}
+
+BENCHMARK_DEFINE_F(FilterFixture, Shelf_MonoTwice)(benchmark::State& state) {
+    sfz::Filter<1> filterLeft;
+    sfz::Filter<1> filterRight;
+    filterLeft.setType(sfz::FilterType::kFilterLpf2p);
+    filterRight.setType(sfz::FilterType::kFilterLpf2p);
+    for (auto _ : state)
+    {
+        const auto step = static_cast<size_t>(state.range(0));
+        auto cutoffIterator = cutoff.begin();
+        auto qIterator = q.begin();
+        auto pkshIterator = pksh.begin();
+        auto inLIterator = inputLeft.begin();
+        auto inRIterator = inputRight.begin();
+        auto outRIterator = outputLeft.begin();
+        auto outLIterator = outputRight.begin();
+        while (cutoffIterator < cutoff.end())
+        {
+            filterLeft.process( &inLIterator.base(), &outLIterator.base(), *cutoffIterator, *qIterator, *pkshIterator, step);
+            filterRight.process(&inRIterator.base(), &outRIterator.base(), *cutoffIterator, *qIterator, *pkshIterator, step);
+            cutoffIterator += step;
+            qIterator += step;
+            pkshIterator += step;
+            inLIterator += step;
+            inRIterator += step;
+            outLIterator += step;
+            outRIterator += step;
+        }
+    }
+}
+
+BENCHMARK_DEFINE_F(FilterFixture, Shelf_Stereo)(benchmark::State& state) {
+    sfz::Filter<2> filter;
+    filter.setType(sfz::FilterType::kFilterLpf2p);
+    for (auto _ : state)
+    {
+        const auto step = static_cast<size_t>(state.range(0));
+        auto cutoffIterator = cutoff.begin();
+        auto qIterator = q.begin();
+        auto pkshIterator = pksh.begin();
+        auto inLIterator = inputLeft.begin();
+        auto inRIterator = inputRight.begin();
+        auto outRIterator = outputLeft.begin();
+        auto outLIterator = outputRight.begin();
+        while (cutoffIterator < cutoff.end())
+        {
+            float * inputs[2] = { inLIterator.base(), inRIterator.base() };
+            float * outputs[2] = { outLIterator.base(), outRIterator.base() };
+            filter.process(inputs, outputs, *cutoffIterator, *qIterator, *pkshIterator, step);
+            cutoffIterator += step;
+            qIterator += step;
+            pkshIterator += step;
+            inLIterator += step;
+            inRIterator += step;
+            outLIterator += step;
+            outRIterator += step;
+        }
+    }
+}
+
+BENCHMARK_REGISTER_F(FilterFixture, OnePole_MonoOnce)->RangeMultiplier(2)->Range(1, 1 << 8);
+BENCHMARK_REGISTER_F(FilterFixture, OnePole_MonoTwice)->RangeMultiplier(2)->Range(1, 1 << 8);
+BENCHMARK_REGISTER_F(FilterFixture, OnePole_Stereo)->RangeMultiplier(2)->Range(1, 1 << 8);
+BENCHMARK_REGISTER_F(FilterFixture, TwoPole_MonoOnce)->RangeMultiplier(2)->Range(1, 1 << 8);
+BENCHMARK_REGISTER_F(FilterFixture, TwoPole_MonoTwice)->RangeMultiplier(2)->Range(1, 1 << 8);
+BENCHMARK_REGISTER_F(FilterFixture, TwoPole_Stereo)->RangeMultiplier(2)->Range(1, 1 << 8);
+BENCHMARK_REGISTER_F(FilterFixture, Shelf_MonoOnce)->RangeMultiplier(2)->Range(1, 1 << 8);
+BENCHMARK_REGISTER_F(FilterFixture, Shelf_MonoTwice)->RangeMultiplier(2)->Range(1, 1 << 8);
+BENCHMARK_REGISTER_F(FilterFixture, Shelf_Stereo)->RangeMultiplier(2)->Range(1, 1 << 8);
+BENCHMARK_MAIN();
+

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -120,6 +120,14 @@ add_executable(bm_resampleChunk BM_resampleChunk.cpp ${BENCHMARK_SIMD_SOURCES})
 target_link_libraries(bm_resampleChunk PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main sfizz-sndfile)
 target_include_directories(bm_resampleChunk PRIVATE ../src/sfizz ../src/external)
 
+add_executable(bm_filterModulation BM_filterModulation.cpp ${BENCHMARK_SIMD_SOURCES} ../src/sfizz/SfzFilter.cpp)
+target_link_libraries(bm_filterModulation PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main sfizz-sndfile)
+target_include_directories(bm_filterModulation PRIVATE ../src/sfizz ../src/external)
+
+add_executable(bm_filterStereoMono BM_filterStereoMono.cpp ${BENCHMARK_SIMD_SOURCES} ../src/sfizz/SfzFilter.cpp)
+target_link_libraries(bm_filterStereoMono PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main sfizz-sndfile)
+target_include_directories(bm_filterStereoMono PRIVATE ../src/sfizz ../src/external)
+
 add_custom_target(sfizz_benchmarks)
 add_dependencies(sfizz_benchmarks
 	bm_opf_high_vs_low
@@ -148,6 +156,8 @@ add_dependencies(sfizz_benchmarks
 	bm_envelopes
 	bm_wavfile
 	bm_flacfile
+	bm_filterModulation
+	bm_filterStereoMono
 )
 
 if (NOT WIN32)


### PR DESCRIPTION
This adds a couple benchmarks to:

1. Test the "modulation time step", meaning the number of samples to process before updating the filter coefficients from a purely computation efficiency point of view. I compare also with a simple straightforward "virtual analog" one pole implementation that I did earlier, for my own education if anything.
2. Test whether we should do 2x mono filters vs a stereo filter, once again purely from a computatione efficiency point of view. This has an impact on the complexity of the code since we need to change the processing logic from mono samples to stereo samples and the current filters have a templated number of channels.

This is mostly for supporting further decisions and has no direct impact on the actual library. None of these evaluate the "signal processing quality" of the underlying algorithms or whether large periods in updating the parameters leads to artifacts or instability in the filters.

The names of the benchmark elements should be mostly clear, the number at the end represents the period at which we recompute filter parameters. I will post the perf results on the platforms I have access to.

