### PR TITLE
Filters bis

### DIFF
--- a/scripts/generate_filters.sh
+++ b/scripts/generate_filters.sh
@@ -15,7 +15,7 @@ faustgen() {
     mkdir -p src/sfizz/gen/filters
     local outfile=src/sfizz/gen/filters/sfz"$1".cxx
 
-    local code=`faust $FAUSTARGS -pn sfz"$1" -cn faust"$1" src/sfizz/dsp/filters/sfz_filters.dsp`
+    local code=`faust $FAUSTARGS -pn sfz"$1" -cn faust"$1" -scn sfzFilterDsp src/sfizz/dsp/filters/sfz_filters.dsp`
 
     # find variable names of our controls
     local cutoffVar=`echo "$code" | $SED -r 's%.*\("Cutoff", &[ \t]*([a-zA-Z0-9_]+).*%\1%;t;d'`
@@ -35,8 +35,6 @@ faustgen() {
 
     # direct access to parameter variables
     $SED -r -i 's/\bprivate:/public:/' "$outfile"
-    # no virtuals please
-    $SED -r -i 's/\bvirtual\b//' "$outfile"
 
     # rename the variables for us to access more easily
     if test ! -z "$cutoffVar"; then

--- a/src/sfizz/SfzFilter.cpp
+++ b/src/sfizz/SfzFilter.cpp
@@ -8,8 +8,8 @@
 #include "SfzFilter.h"
 #include "SfzFilterImpls.cxx"
 #include <cstring>
-#include <cassert>
 #include "SIMDHelpers.h"
+#include "Debug.h"
 
 namespace sfz {
 
@@ -160,7 +160,7 @@ unsigned Filter::channels() const
 
 void Filter::setChannels(unsigned channels)
 {
-    assert(channels < Impl::maxChannels);
+    ASSERT(channels < Impl::maxChannels);
     if (P->fChannels != channels) {
         P->fChannels = channels;
         clear();
@@ -330,7 +330,7 @@ unsigned FilterEq::channels() const
 
 void FilterEq::setChannels(unsigned channels)
 {
-    assert(channels < Impl::maxChannels);
+    ASSERT(channels < Impl::maxChannels);
     if (P->fChannels != channels) {
         P->fChannels = channels;
         clear();

--- a/src/sfizz/SfzFilter.cpp
+++ b/src/sfizz/SfzFilter.cpp
@@ -16,229 +16,167 @@ namespace sfz {
 //------------------------------------------------------------------------------
 // SFZ v2 multi-mode filter
 
-template <unsigned NCh>
-struct Filter<NCh>::Impl {
+struct Filter::Impl {
     FilterType fType = kFilterNone;
+    unsigned fChannels = 1;
+    enum { maxChannels = 2 };
 
-    sfzLpf1p<NCh> fDspLpf1p;
-    sfzLpf2p<NCh> fDspLpf2p;
-    sfzLpf4p<NCh> fDspLpf4p;
-    sfzLpf6p<NCh> fDspLpf6p;
-    sfzHpf1p<NCh> fDspHpf1p;
-    sfzHpf2p<NCh> fDspHpf2p;
-    sfzHpf4p<NCh> fDspHpf4p;
-    sfzHpf6p<NCh> fDspHpf6p;
-    sfzBpf1p<NCh> fDspBpf1p;
-    sfzBpf2p<NCh> fDspBpf2p;
-    sfzBpf4p<NCh> fDspBpf4p;
-    sfzBpf6p<NCh> fDspBpf6p;
-    sfzApf1p<NCh> fDspApf1p;
-    sfzBrf1p<NCh> fDspBrf1p;
-    sfzBrf2p<NCh> fDspBrf2p;
-    sfzPink<NCh> fDspPink;
-    sfzLpf2pSv<NCh> fDspLpf2pSv;
-    sfzHpf2pSv<NCh> fDspHpf2pSv;
-    sfzBpf2pSv<NCh> fDspBpf2pSv;
-    sfzBrf2pSv<NCh> fDspBrf2pSv;
-    sfzLsh<NCh> fDspLsh;
-    sfzHsh<NCh> fDspHsh;
-    sfzPeq<NCh> fDspPeq;
+    sfzLpf1p fDspLpf1p;
+    sfzLpf2p fDspLpf2p;
+    sfzLpf4p fDspLpf4p;
+    sfzLpf6p fDspLpf6p;
+    sfzHpf1p fDspHpf1p;
+    sfzHpf2p fDspHpf2p;
+    sfzHpf4p fDspHpf4p;
+    sfzHpf6p fDspHpf6p;
+    sfzBpf1p fDspBpf1p;
+    sfzBpf2p fDspBpf2p;
+    sfzBpf4p fDspBpf4p;
+    sfzBpf6p fDspBpf6p;
+    sfzApf1p fDspApf1p;
+    sfzBrf1p fDspBrf1p;
+    sfzBrf2p fDspBrf2p;
+    sfzPink fDspPink;
+    sfzLpf2pSv fDspLpf2pSv;
+    sfzHpf2pSv fDspHpf2pSv;
+    sfzBpf2pSv fDspBpf2pSv;
+    sfzBrf2pSv fDspBrf2pSv;
+    sfzLsh fDspLsh;
+    sfzHsh fDspHsh;
+    sfzPeq fDspPeq;
 
-    template <class F> static void process(F &filter, const float *const in[NCh], float *const out[NCh], float cutoff, float q, float pksh, unsigned nframes);
-    template <class F> static void processModulated(F &filter, const float *const in[NCh], float *const out[NCh], const float *cutoff, const float *q, const float *pksh, unsigned nframes);
+    sfz2chLpf1p fDsp2chLpf1p;
+    sfz2chLpf2p fDsp2chLpf2p;
+    sfz2chLpf4p fDsp2chLpf4p;
+    sfz2chLpf6p fDsp2chLpf6p;
+    sfz2chHpf1p fDsp2chHpf1p;
+    sfz2chHpf2p fDsp2chHpf2p;
+    sfz2chHpf4p fDsp2chHpf4p;
+    sfz2chHpf6p fDsp2chHpf6p;
+    sfz2chBpf1p fDsp2chBpf1p;
+    sfz2chBpf2p fDsp2chBpf2p;
+    sfz2chBpf4p fDsp2chBpf4p;
+    sfz2chBpf6p fDsp2chBpf6p;
+    sfz2chApf1p fDsp2chApf1p;
+    sfz2chBrf1p fDsp2chBrf1p;
+    sfz2chBrf2p fDsp2chBrf2p;
+    sfz2chPink fDsp2chPink;
+    sfz2chLpf2pSv fDsp2chLpf2pSv;
+    sfz2chHpf2pSv fDsp2chHpf2pSv;
+    sfz2chBpf2pSv fDsp2chBpf2pSv;
+    sfz2chBrf2pSv fDsp2chBrf2pSv;
+    sfz2chLsh fDsp2chLsh;
+    sfz2chHsh fDsp2chHsh;
+    sfz2chPeq fDsp2chPeq;
+
+    sfzFilterDsp *getDsp(unsigned channels, FilterType type);
+
+    static constexpr uint32_t idDsp(unsigned channels, FilterType type)
+    {
+        return static_cast<unsigned>(type)|(channels << 16);
+    }
 };
 
-template <unsigned NCh>
-Filter<NCh>::Filter()
+Filter::Filter()
     : P{new Impl}
 {
 }
 
-template <unsigned NCh>
-Filter<NCh>::~Filter()
+Filter::~Filter()
 {
 }
 
-template <unsigned NCh>
-void Filter<NCh>::init(double sampleRate)
+void Filter::init(double sampleRate)
 {
-    P->fDspLpf1p.init(sampleRate);
-    P->fDspLpf2p.init(sampleRate);
-    P->fDspLpf4p.init(sampleRate);
-    P->fDspLpf6p.init(sampleRate);
-    P->fDspHpf1p.init(sampleRate);
-    P->fDspHpf2p.init(sampleRate);
-    P->fDspHpf4p.init(sampleRate);
-    P->fDspHpf6p.init(sampleRate);
-    P->fDspBpf1p.init(sampleRate);
-    P->fDspBpf2p.init(sampleRate);
-    P->fDspBpf4p.init(sampleRate);
-    P->fDspBpf6p.init(sampleRate);
-    P->fDspApf1p.init(sampleRate);
-    P->fDspBrf1p.init(sampleRate);
-    P->fDspBrf2p.init(sampleRate);
-    P->fDspPink.init(sampleRate);
-    P->fDspLpf2pSv.init(sampleRate);
-    P->fDspHpf2pSv.init(sampleRate);
-    P->fDspBpf2pSv.init(sampleRate);
-    P->fDspBrf2pSv.init(sampleRate);
-    P->fDspLsh.init(sampleRate);
-    P->fDspHsh.init(sampleRate);
-    P->fDspPeq.init(sampleRate);
-}
-
-template <unsigned NCh>
-void Filter<NCh>::clear()
-{
-    switch (P->fType) {
-    case kFilterNone: break;
-    case kFilterApf1p: P->fDspApf1p.instanceClear(); break;
-    case kFilterBpf1p: P->fDspBpf1p.instanceClear(); break;
-    case kFilterBpf2p: P->fDspBpf2p.instanceClear(); break;
-    case kFilterBpf4p: P->fDspBpf4p.instanceClear(); break;
-    case kFilterBpf6p: P->fDspBpf6p.instanceClear(); break;
-    case kFilterBrf1p: P->fDspBrf1p.instanceClear(); break;
-    case kFilterBrf2p: P->fDspBrf2p.instanceClear(); break;
-    case kFilterHpf1p: P->fDspHpf1p.instanceClear(); break;
-    case kFilterHpf2p: P->fDspHpf2p.instanceClear(); break;
-    case kFilterHpf4p: P->fDspHpf4p.instanceClear(); break;
-    case kFilterHpf6p: P->fDspHpf6p.instanceClear(); break;
-    case kFilterLpf1p: P->fDspLpf1p.instanceClear(); break;
-    case kFilterLpf2p: P->fDspLpf2p.instanceClear(); break;
-    case kFilterLpf4p: P->fDspLpf4p.instanceClear(); break;
-    case kFilterLpf6p: P->fDspLpf6p.instanceClear(); break;
-    case kFilterPink: P->fDspPink.instanceClear(); break;
-    case kFilterLpf2pSv: P->fDspLpf2pSv.instanceClear(); break;
-    case kFilterHpf2pSv: P->fDspHpf2pSv.instanceClear(); break;
-    case kFilterBpf2pSv: P->fDspBpf2pSv.instanceClear(); break;
-    case kFilterBrf2pSv: P->fDspBrf2pSv.instanceClear(); break;
-    case kFilterLsh: P->fDspLsh.instanceClear(); break;
-    case kFilterHsh: P->fDspHsh.instanceClear(); break;
-    case kFilterPeq: P->fDspPeq.instanceClear(); break;
+    for (unsigned channels = 1; channels <= Impl::maxChannels; ++channels) {
+        FilterType ftype = static_cast<FilterType>(1);
+        while (sfzFilterDsp *dsp = P->getDsp(channels, ftype)) {
+            dsp->init(sampleRate);
+            ftype = static_cast<FilterType>(static_cast<int>(ftype) + 1);
+        }
     }
 }
 
-template <unsigned NCh>
-template <class F>
-void Filter<NCh>::Impl::process(F &filter, const float *const in[NCh], float *const out[NCh], float cutoff, float q, float pksh, unsigned nframes)
+void Filter::clear()
 {
-    filter.setCutoff(cutoff);
-    filter.setQ(q);
-    filter.setPkShGain(pksh);
-    filter.compute(nframes, const_cast<float **>(in), const_cast<float **>(out));
+    sfzFilterDsp *dsp = P->getDsp(P->fChannels, P->fType);
+
+    if (dsp)
+        dsp->instanceClear();
 }
 
-template <unsigned NCh>
-void Filter<NCh>::process(const float *const in[NCh], float *const out[NCh], float cutoff, float q, float pksh, unsigned nframes)
+void Filter::process(const float *const in[], float *const out[], float cutoff, float q, float pksh, unsigned nframes)
 {
-    if (P->fType == kFilterNone) {
-        for (unsigned c = 0; c < NCh; ++c)
+    unsigned channels = P->fChannels;
+    sfzFilterDsp *dsp = P->getDsp(channels, P->fType);
+
+    if (!dsp) {
+        for (unsigned c = 0; c < channels; ++c)
             copy<float>({ in[c], nframes }, { out[c], nframes });
         return;
     }
 
-    switch (P->fType) {
-    case kFilterApf1p: P->process(P->fDspApf1p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBpf1p: P->process(P->fDspBpf1p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBpf2p: P->process(P->fDspBpf2p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBpf4p: P->process(P->fDspBpf4p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBpf6p: P->process(P->fDspBpf6p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBrf1p: P->process(P->fDspBrf1p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBrf2p: P->process(P->fDspBrf2p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterHpf1p: P->process(P->fDspHpf1p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterHpf2p: P->process(P->fDspHpf2p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterHpf4p: P->process(P->fDspHpf4p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterHpf6p: P->process(P->fDspHpf6p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterLpf1p: P->process(P->fDspLpf1p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterLpf2p: P->process(P->fDspLpf2p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterLpf4p: P->process(P->fDspLpf4p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterLpf6p: P->process(P->fDspLpf6p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterPink: P->process(P->fDspPink, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterLpf2pSv: P->process(P->fDspLpf2pSv, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterHpf2pSv: P->process(P->fDspHpf2pSv, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBpf2pSv: P->process(P->fDspBpf2pSv, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBrf2pSv: P->process(P->fDspBrf2pSv, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterLsh: P->process(P->fDspLsh, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterHsh: P->process(P->fDspHsh, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterPeq: P->process(P->fDspPeq, in, out, cutoff, q, pksh, nframes); break;
-    default: assert(false);
-    }
+    dsp->setCutoff(cutoff);
+    dsp->setQ(q);
+    dsp->setPkShGain(pksh);
+    dsp->compute(nframes, const_cast<float **>(in), const_cast<float **>(out));
 }
 
-template <unsigned NCh>
-template <class F>
-void Filter<NCh>::Impl::processModulated(F &filter, const float *const in[NCh], float *const out[NCh], const float *cutoff, const float *q, const float *pksh, unsigned nframes)
+void Filter::processModulated(const float *const in[], float *const out[], const float *cutoff, const float *q, const float *pksh, unsigned nframes)
 {
-    unsigned frame = 0;
+    unsigned channels = P->fChannels;
+    sfzFilterDsp *dsp = P->getDsp(channels, P->fType);
 
+    if (!dsp) {
+        for (unsigned c = 0; c < channels; ++c)
+            copy<float>({ in[c], nframes }, { out[c], nframes });
+        return;
+    }
+
+    unsigned frame = 0;
     while (frame < nframes) {
         unsigned current = nframes - frame;
 
         if (current > config::filterControlInterval)
             current = config::filterControlInterval;
 
-        const float *current_in[NCh];
-        float *current_out[NCh];
+        const float *current_in[Impl::maxChannels];
+        float *current_out[Impl::maxChannels];
 
-        for (unsigned c = 0; c < NCh; ++c) {
+        for (unsigned c = 0; c < channels; ++c) {
             current_in[c] = in[c] + frame;
             current_out[c] = out[c] + frame;
         }
 
-        filter.setCutoff(cutoff[frame]);
-        filter.setQ(q[frame]);
-        filter.setPkShGain(pksh[frame]);
-        filter.compute(current, const_cast<float **>(current_in), const_cast<float **>(current_out));
+        dsp->setCutoff(cutoff[frame]);
+        dsp->setQ(q[frame]);
+        dsp->setPkShGain(pksh[frame]);
+        dsp->compute(current, const_cast<float **>(current_in), const_cast<float **>(current_out));
 
         frame += current;
     }
 }
 
-template <unsigned NCh>
-void Filter<NCh>::processModulated(const float *const in[NCh], float *const out[NCh], const float *cutoff, const float *q, const float *pksh, unsigned nframes)
+unsigned Filter::channels() const
 {
-    if (P->fType == kFilterNone) {
-        for (unsigned c = 0; c < NCh; ++c)
-            copy<float>({ in[c], nframes }, { out[c], nframes });
-        return;
-    }
+    return P->fChannels;
+}
 
-    switch (P->fType) {
-    case kFilterApf1p: P->processModulated(P->fDspApf1p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBpf1p: P->processModulated(P->fDspBpf1p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBpf2p: P->processModulated(P->fDspBpf2p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBpf4p: P->processModulated(P->fDspBpf4p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBpf6p: P->processModulated(P->fDspBpf6p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBrf1p: P->processModulated(P->fDspBrf1p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBrf2p: P->processModulated(P->fDspBrf2p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterHpf1p: P->processModulated(P->fDspHpf1p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterHpf2p: P->processModulated(P->fDspHpf2p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterHpf4p: P->processModulated(P->fDspHpf4p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterHpf6p: P->processModulated(P->fDspHpf6p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterLpf1p: P->processModulated(P->fDspLpf1p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterLpf2p: P->processModulated(P->fDspLpf2p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterLpf4p: P->processModulated(P->fDspLpf4p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterLpf6p: P->processModulated(P->fDspLpf6p, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterPink: P->processModulated(P->fDspPink, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterLpf2pSv: P->processModulated(P->fDspLpf2pSv, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterHpf2pSv: P->processModulated(P->fDspHpf2pSv, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBpf2pSv: P->processModulated(P->fDspBpf2pSv, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterBrf2pSv: P->processModulated(P->fDspBrf2pSv, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterLsh: P->processModulated(P->fDspLsh, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterHsh: P->processModulated(P->fDspHsh, in, out, cutoff, q, pksh, nframes); break;
-    case kFilterPeq: P->processModulated(P->fDspPeq, in, out, cutoff, q, pksh, nframes); break;
-    default: assert(false);
+void Filter::setChannels(unsigned channels)
+{
+    assert(channels < Impl::maxChannels);
+    if (P->fChannels != channels) {
+        P->fChannels = channels;
+        clear();
     }
 }
 
-template <unsigned NCh>
-FilterType Filter<NCh>::type() const
+FilterType Filter::type() const
 {
     return P->fType;
 }
 
-template <unsigned NCh>
-void Filter<NCh>::setType(FilterType type)
+void Filter::setType(FilterType type)
 {
     if (P->fType != type) {
         P->fType = type;
@@ -246,87 +184,175 @@ void Filter<NCh>::setType(FilterType type)
     }
 }
 
-template class Filter<1>;
-template class Filter<2>;
+sfzFilterDsp *Filter::Impl::getDsp(unsigned channels, FilterType type)
+{
+    switch (idDsp(channels, type)) {
+    default: return nullptr;
+
+    case idDsp(1, kFilterApf1p): return &fDspApf1p;
+    case idDsp(1, kFilterBpf1p): return &fDspBpf1p;
+    case idDsp(1, kFilterBpf2p): return &fDspBpf2p;
+    case idDsp(1, kFilterBpf4p): return &fDspBpf4p;
+    case idDsp(1, kFilterBpf6p): return &fDspBpf6p;
+    case idDsp(1, kFilterBrf1p): return &fDspBrf1p;
+    case idDsp(1, kFilterBrf2p): return &fDspBrf2p;
+    case idDsp(1, kFilterHpf1p): return &fDspHpf1p;
+    case idDsp(1, kFilterHpf2p): return &fDspHpf2p;
+    case idDsp(1, kFilterHpf4p): return &fDspHpf4p;
+    case idDsp(1, kFilterHpf6p): return &fDspHpf6p;
+    case idDsp(1, kFilterLpf1p): return &fDspLpf1p;
+    case idDsp(1, kFilterLpf2p): return &fDspLpf2p;
+    case idDsp(1, kFilterLpf4p): return &fDspLpf4p;
+    case idDsp(1, kFilterLpf6p): return &fDspLpf6p;
+    case idDsp(1, kFilterPink): return &fDspPink;
+    case idDsp(1, kFilterLpf2pSv): return &fDspLpf2pSv;
+    case idDsp(1, kFilterHpf2pSv): return &fDspHpf2pSv;
+    case idDsp(1, kFilterBpf2pSv): return &fDspBpf2pSv;
+    case idDsp(1, kFilterBrf2pSv): return &fDspBrf2pSv;
+    case idDsp(1, kFilterLsh): return &fDspLsh;
+    case idDsp(1, kFilterHsh): return &fDspHsh;
+    case idDsp(1, kFilterPeq): return &fDspPeq;
+
+    case idDsp(2, kFilterApf1p): return &fDsp2chApf1p;
+    case idDsp(2, kFilterBpf1p): return &fDsp2chBpf1p;
+    case idDsp(2, kFilterBpf2p): return &fDsp2chBpf2p;
+    case idDsp(2, kFilterBpf4p): return &fDsp2chBpf4p;
+    case idDsp(2, kFilterBpf6p): return &fDsp2chBpf6p;
+    case idDsp(2, kFilterBrf1p): return &fDsp2chBrf1p;
+    case idDsp(2, kFilterBrf2p): return &fDsp2chBrf2p;
+    case idDsp(2, kFilterHpf1p): return &fDsp2chHpf1p;
+    case idDsp(2, kFilterHpf2p): return &fDsp2chHpf2p;
+    case idDsp(2, kFilterHpf4p): return &fDsp2chHpf4p;
+    case idDsp(2, kFilterHpf6p): return &fDsp2chHpf6p;
+    case idDsp(2, kFilterLpf1p): return &fDsp2chLpf1p;
+    case idDsp(2, kFilterLpf2p): return &fDsp2chLpf2p;
+    case idDsp(2, kFilterLpf4p): return &fDsp2chLpf4p;
+    case idDsp(2, kFilterLpf6p): return &fDsp2chLpf6p;
+    case idDsp(2, kFilterPink): return &fDsp2chPink;
+    case idDsp(2, kFilterLpf2pSv): return &fDsp2chLpf2pSv;
+    case idDsp(2, kFilterHpf2pSv): return &fDsp2chHpf2pSv;
+    case idDsp(2, kFilterBpf2pSv): return &fDsp2chBpf2pSv;
+    case idDsp(2, kFilterBrf2pSv): return &fDsp2chBrf2pSv;
+    case idDsp(2, kFilterLsh): return &fDsp2chLsh;
+    case idDsp(2, kFilterHsh): return &fDsp2chHsh;
+    case idDsp(2, kFilterPeq): return &fDsp2chPeq;
+    }
+}
 
 //------------------------------------------------------------------------------
 // SFZ v1 equalizer filter
 
 
-template <unsigned NCh>
-struct FilterEq<NCh>::Impl {
-    sfzEq<NCh> fDsp;
+struct FilterEq::Impl {
+    unsigned fChannels = 1;
+    enum { maxChannels = 2 };
+
+    sfzEq fDsp;
+    sfz2chEq fDsp2ch;
+
+    sfzFilterDsp *getDsp(unsigned channels);
 };
 
-template <unsigned NCh>
-FilterEq<NCh>::FilterEq()
+FilterEq::FilterEq()
     : P{new Impl}
 {
 }
 
-template <unsigned NCh>
-FilterEq<NCh>::~FilterEq()
+FilterEq::~FilterEq()
 {
 }
 
-template <unsigned NCh>
-void FilterEq<NCh>::init(double sampleRate)
+void FilterEq::init(double sampleRate)
 {
-    sfzEq<NCh> &filter = P->fDsp;
-
-    filter.init(sampleRate);
+    for (unsigned channels = 1; channels <= Impl::maxChannels; ++channels) {
+        sfzFilterDsp *dsp = P->getDsp(channels);
+        dsp->init(sampleRate);
+    }
 }
 
-template <unsigned NCh>
-void FilterEq<NCh>::clear()
+void FilterEq::clear()
 {
-    sfzEq<NCh> &filter = P->fDsp;
+    sfzFilterDsp *dsp = P->getDsp(P->fChannels);
 
-    filter.instanceClear();
+    if (dsp)
+        dsp->instanceClear();
 }
 
-template <unsigned NCh>
-void FilterEq<NCh>::process(const float *const in[NCh], float *const out[NCh], float cutoff, float bw, float pksh, unsigned nframes)
+void FilterEq::process(const float *const in[], float *const out[], float cutoff, float bw, float pksh, unsigned nframes)
 {
-    sfzEq<NCh> &filter = P->fDsp;
+    unsigned channels = P->fChannels;
+    sfzFilterDsp *dsp = P->getDsp(channels);
 
-    filter.setCutoff(cutoff);
-    filter.setBandwidth(bw);
-    filter.setPkShGain(pksh);
-    filter.compute(nframes, const_cast<float **>(in), const_cast<float **>(out));
+    if (!dsp) {
+        for (unsigned c = 0; c < channels; ++c)
+            copy<float>({ in[c], nframes }, { out[c], nframes });
+        return;
+    }
+
+    dsp->setCutoff(cutoff);
+    dsp->setBandwidth(bw);
+    dsp->setPkShGain(pksh);
+    dsp->compute(nframes, const_cast<float **>(in), const_cast<float **>(out));
 }
 
-template <unsigned NCh>
-void FilterEq<NCh>::processModulated(const float *const in[NCh], float *const out[NCh], const float *cutoff, const float *bw, const float *pksh, unsigned nframes)
+void FilterEq::processModulated(const float *const in[], float *const out[], const float *cutoff, const float *bw, const float *pksh, unsigned nframes)
 {
-    sfzEq<NCh> &filter = P->fDsp;
+    unsigned channels = P->fChannels;
+    sfzFilterDsp *dsp = P->getDsp(channels);
+
+    if (!dsp) {
+        for (unsigned c = 0; c < channels; ++c)
+            copy<float>({ in[c], nframes }, { out[c], nframes });
+        return;
+    }
 
     unsigned frame = 0;
-
     while (frame < nframes) {
         unsigned current = nframes - frame;
 
         if (current > config::filterControlInterval)
             current = config::filterControlInterval;
 
-        const float *current_in[NCh];
-        float *current_out[NCh];
+        const float *current_in[Impl::maxChannels];
+        float *current_out[Impl::maxChannels];
 
-        for (unsigned c = 0; c < NCh; ++c) {
+        for (unsigned c = 0; c < channels; ++c) {
             current_in[c] = in[c] + frame;
             current_out[c] = out[c] + frame;
         }
 
-        filter.setCutoff(cutoff[frame]);
-        filter.setBandwidth(bw[frame]);
-        filter.setPkShGain(pksh[frame]);
-        filter.compute(current, const_cast<float **>(current_in), const_cast<float **>(current_out));
+        dsp->setCutoff(cutoff[frame]);
+        dsp->setBandwidth(bw[frame]);
+        dsp->setPkShGain(pksh[frame]);
+        dsp->compute(current, const_cast<float **>(current_in), const_cast<float **>(current_out));
 
         frame += current;
     }
 }
 
-template class FilterEq<1>;
-template class FilterEq<2>;
+
+unsigned FilterEq::channels() const
+{
+    return P->fChannels;
+}
+
+void FilterEq::setChannels(unsigned channels)
+{
+    assert(channels < Impl::maxChannels);
+    if (P->fChannels != channels) {
+        P->fChannels = channels;
+        clear();
+    }
+}
+
+sfzFilterDsp *FilterEq::Impl::getDsp(unsigned channels)
+{
+    switch (channels) {
+    default: return nullptr;
+
+    case 1: return &fDsp;
+    case 2: return &fDsp2ch;
+    }
+}
 
 } // namespace sfz

--- a/src/sfizz/SfzFilter.cpp
+++ b/src/sfizz/SfzFilter.cpp
@@ -116,9 +116,7 @@ void Filter::process(const float *const in[], float *const out[], float cutoff, 
         return;
     }
 
-    dsp->setCutoff(cutoff);
-    dsp->setQ(q);
-    dsp->setPkShGain(pksh);
+    dsp->configureStandard(cutoff, q, pksh);
     dsp->compute(nframes, const_cast<float **>(in), const_cast<float **>(out));
 }
 
@@ -148,9 +146,7 @@ void Filter::processModulated(const float *const in[], float *const out[], const
             current_out[c] = out[c] + frame;
         }
 
-        dsp->setCutoff(cutoff[frame]);
-        dsp->setQ(q[frame]);
-        dsp->setPkShGain(pksh[frame]);
+        dsp->configureStandard(cutoff[frame], q[frame], pksh[frame]);
         dsp->compute(current, const_cast<float **>(current_in), const_cast<float **>(current_out));
 
         frame += current;
@@ -289,9 +285,7 @@ void FilterEq::process(const float *const in[], float *const out[], float cutoff
         return;
     }
 
-    dsp->setCutoff(cutoff);
-    dsp->setBandwidth(bw);
-    dsp->setPkShGain(pksh);
+    dsp->configureEq(cutoff, bw, pksh);
     dsp->compute(nframes, const_cast<float **>(in), const_cast<float **>(out));
 }
 
@@ -321,9 +315,7 @@ void FilterEq::processModulated(const float *const in[], float *const out[], con
             current_out[c] = out[c] + frame;
         }
 
-        dsp->setCutoff(cutoff[frame]);
-        dsp->setBandwidth(bw[frame]);
-        dsp->setPkShGain(pksh[frame]);
+        dsp->configureEq(cutoff[frame], bw[frame], pksh[frame]);
         dsp->compute(current, const_cast<float **>(current_in), const_cast<float **>(current_out));
 
         frame += current;

--- a/src/sfizz/SfzFilter.h
+++ b/src/sfizz/SfzFilter.h
@@ -13,14 +13,13 @@ enum FilterType : int;
 
 /**
    Multi-mode filter for SFZ v2
-   Available for mono and stereo. (NCh=1, NCh=2)
+   Available for mono and stereo. (channels=1, channels=2)
 
    Parameters:
      `cutoff`: it's the opcode `filN_cutoff` (Hz)
      `q`: it's the opcode `filN_resonance` (dB)
      `pksh`: it's the opcode `filN_gain` (dB)
  */
-template <unsigned NCh>
 class Filter {
 public:
     Filter();
@@ -44,7 +43,7 @@ public:
        `pksh` is a peak/shelf gain expressed in dB.
        `in[i]` and `out[i]` may refer to identical buffers, for in-place processing
      */
-    void process(const float *const in[NCh], float *const out[NCh], float cutoff, float q, float pksh, unsigned nframes);
+    void process(const float *const in[], float *const out[], float cutoff, float q, float pksh, unsigned nframes);
 
     /**
        Process one cycle of the filter with cutoff and Q values varying over time.
@@ -53,7 +52,17 @@ public:
        `pksh` is a peak/shelf gain expressed in dB.
        `in[i]` and `out[i]` may refer to identical buffers, for in-place processing
      */
-    void processModulated(const float *const in[NCh], float *const out[NCh], const float *cutoff, const float *q, const float *pksh, unsigned nframes);
+    void processModulated(const float *const in[], float *const out[], const float *cutoff, const float *q, const float *pksh, unsigned nframes);
+
+    /**
+       Get the number of channels.
+     */
+    unsigned channels() const;
+
+    /**
+       Set the number of channels.
+     */
+    void setChannels(unsigned channels);
 
     /**
        Get the type of filter.
@@ -99,14 +108,13 @@ enum FilterType : int {
 
 /**
    Equalizer filter for SFZ v1
-   Available for mono and stereo. (NCh=1, NCh=2)
+   Available for mono and stereo. (channels=1, channels=2)
 
    Parameters:
      `cutoff`: it's the opcode `egN_freq` (Hz)
      `bw`: it's the opcode `eqN_bw` (octave)
      `pksh`: it's the opcode `eqN_gain` (dB)
  */
-template <unsigned NCh>
 class FilterEq {
 public:
     FilterEq();
@@ -130,7 +138,7 @@ public:
        `pksh` is a peak/shelf gain expressed in dB.
        `in[i]` and `out[i]` may refer to identical buffers, for in-place processing
      */
-    void process(const float *const in[NCh], float *const out[NCh], float cutoff, float bw, float pksh, unsigned nframes);
+    void process(const float *const in[], float *const out[], float cutoff, float bw, float pksh, unsigned nframes);
 
     /**
        Process one cycle of the filter with cutoff and bandwidth values varying over time.
@@ -139,7 +147,17 @@ public:
        `pksh` is a peak/shelf gain expressed in dB.
        `in[i]` and `out[i]` may refer to identical buffers, for in-place processing
      */
-    void processModulated(const float *const in[NCh], float *const out[NCh], const float *cutoff, const float *bw, const float *pksh, unsigned nframes);
+    void processModulated(const float *const in[], float *const out[], const float *cutoff, const float *bw, const float *pksh, unsigned nframes);
+
+    /**
+       Get the number of channels.
+     */
+    unsigned channels() const;
+
+    /**
+       Set the number of channels.
+     */
+    void setChannels(unsigned channels);
 
 private:
     struct Impl;

--- a/src/sfizz/SfzFilterImpls.cxx
+++ b/src/sfizz/SfzFilterImpls.cxx
@@ -4,9 +4,25 @@
 // license. You should have receive a LICENSE.md file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
-struct dsp {};
 struct Meta {};
 struct UI {};
+
+/**
+   Base of the faust DSP for filters
+ */
+struct sfzFilterDsp {
+public:
+    virtual ~sfzFilterDsp() {}
+
+    virtual void init(int) = 0;
+    virtual void instanceClear() = 0;
+    virtual void compute(int, float **, float **) = 0;
+
+    virtual void setCutoff(float) {}
+    virtual void setQ(float) {}
+    virtual void setBandwidth(float) {}
+    virtual void setPkShGain(float) {}
+};
 
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -72,9 +88,8 @@ struct UI {};
    Parameterized by cutoff and Q
  */
 template <class F> struct sfzFilter : public F {
-    void setCutoff(float v) { F::fCutoff = v; }
-    void setQ(float v) { F::fQ = v; }
-    void setPkShGain(float) {}
+    void setCutoff(float v) override { F::fCutoff = v; }
+    void setQ(float v) override { F::fQ = v; }
 };
 
 /**
@@ -82,9 +97,7 @@ template <class F> struct sfzFilter : public F {
    Parameterized by cutoff only
  */
 template <class F> struct sfzFilterNoQ : public F {
-    void setCutoff(float v) { F::fCutoff = v; }
-    void setQ(float) {}
-    void setPkShGain(float) {}
+    void setCutoff(float v) override { F::fCutoff = v; }
 };
 
 /**
@@ -92,9 +105,6 @@ template <class F> struct sfzFilterNoQ : public F {
    Not parameterized
  */
 template <class F> struct sfzFilterNoCutoff : public F {
-    void setCutoff(float) {}
-    void setQ(float) {}
-    void setPkShGain(float) {}
 };
 
 /**
@@ -102,9 +112,9 @@ template <class F> struct sfzFilterNoCutoff : public F {
    Parameterized by cutoff, Q, peak/shelf gain
  */
 template <class F> struct sfzFilterPkSh : public F {
-    void setCutoff(float v) { F::fCutoff = v; }
-    void setQ(float v) { F::fQ = v; }
-    void setPkShGain(float v) { F::fPkShGain = v; }
+    void setCutoff(float v) override { F::fCutoff = v; }
+    void setQ(float v) override { F::fQ = v; }
+    void setPkShGain(float v) override { F::fPkShGain = v; }
 };
 
 /**
@@ -112,82 +122,57 @@ template <class F> struct sfzFilterPkSh : public F {
    Parameterized by cutoff, bandwidth, peak/shelf gain
  */
 template <class F> struct sfzFilterEq : public F {
-    void setCutoff(float v) { F::fCutoff = v; }
-    void setBandwidth(float v) { F::fBandwidth = v; }
-    void setPkShGain(float v) { F::fPkShGain = v; }
+    void setCutoff(float v) override { F::fCutoff = v; }
+    void setBandwidth(float v) override { F::fBandwidth = v; }
+    void setPkShGain(float v) override { F::fPkShGain = v; }
 };
 
-template <unsigned NCh> struct sfzLpf1p;
-template <unsigned NCh> struct sfzLpf2p;
-template <unsigned NCh> struct sfzLpf4p;
-template <unsigned NCh> struct sfzLpf6p;
-template <unsigned NCh> struct sfzHpf1p;
-template <unsigned NCh> struct sfzHpf2p;
-template <unsigned NCh> struct sfzHpf4p;
-template <unsigned NCh> struct sfzHpf6p;
-template <unsigned NCh> struct sfzBpf1p;
-template <unsigned NCh> struct sfzBpf2p;
-template <unsigned NCh> struct sfzBpf4p;
-template <unsigned NCh> struct sfzBpf6p;
-template <unsigned NCh> struct sfzApf1p;
-template <unsigned NCh> struct sfzBrf1p;
-template <unsigned NCh> struct sfzBrf2p;
-template <unsigned NCh> struct sfzPink;
-template <unsigned NCh> struct sfzLpf2pSv;
-template <unsigned NCh> struct sfzHpf2pSv;
-template <unsigned NCh> struct sfzBpf2pSv;
-template <unsigned NCh> struct sfzBrf2pSv;
-template <unsigned NCh> struct sfzLsh;
-template <unsigned NCh> struct sfzHsh;
-template <unsigned NCh> struct sfzPeq;
-template <unsigned NCh> struct sfzEq;
+struct sfzLpf1p final : public sfzFilterNoQ<faustLpf1p> {};
+struct sfzLpf2p final : public sfzFilter<faustLpf2p> {};
+struct sfzLpf4p final : public sfzFilter<faustLpf4p> {};
+struct sfzLpf6p final : public sfzFilter<faustLpf6p> {};
+struct sfzHpf1p final : public sfzFilterNoQ<faustHpf1p> {};
+struct sfzHpf2p final : public sfzFilter<faustHpf2p> {};
+struct sfzHpf4p final : public sfzFilter<faustHpf4p> {};
+struct sfzHpf6p final : public sfzFilter<faustHpf6p> {};
+struct sfzBpf1p final : public sfzFilterNoQ<faustBpf1p> {};
+struct sfzBpf2p final : public sfzFilter<faustBpf2p> {};
+struct sfzBpf4p final : public sfzFilter<faustBpf4p> {};
+struct sfzBpf6p final : public sfzFilter<faustBpf6p> {};
+struct sfzApf1p final : public sfzFilterNoQ<faustApf1p> {};
+struct sfzBrf1p final : public sfzFilterNoQ<faustBrf1p> {};
+struct sfzBrf2p final : public sfzFilter<faustBrf2p> {};
+struct sfzPink final : public sfzFilterNoCutoff<faustPink> {};
+struct sfzLpf2pSv final : public sfzFilter<faustLpf2pSv> {};
+struct sfzHpf2pSv final : public sfzFilter<faustHpf2pSv> {};
+struct sfzBpf2pSv final : public sfzFilter<faustBpf2pSv> {};
+struct sfzBrf2pSv final : public sfzFilter<faustBrf2pSv> {};
+struct sfzLsh final : public sfzFilterPkSh<faustLsh> {};
+struct sfzHsh final : public sfzFilterPkSh<faustHsh> {};
+struct sfzPeq final : public sfzFilterPkSh<faustPeq> {};
+struct sfzEq final : public sfzFilterEq<faustEq> {};
 
-template<> struct sfzLpf1p<1> : public sfzFilterNoQ<faustLpf1p> {};
-template<> struct sfzLpf2p<1> : public sfzFilter<faustLpf2p> {};
-template<> struct sfzLpf4p<1> : public sfzFilter<faustLpf4p> {};
-template<> struct sfzLpf6p<1> : public sfzFilter<faustLpf6p> {};
-template<> struct sfzHpf1p<1> : public sfzFilterNoQ<faustHpf1p> {};
-template<> struct sfzHpf2p<1> : public sfzFilter<faustHpf2p> {};
-template<> struct sfzHpf4p<1> : public sfzFilter<faustHpf4p> {};
-template<> struct sfzHpf6p<1> : public sfzFilter<faustHpf6p> {};
-template<> struct sfzBpf1p<1> : public sfzFilterNoQ<faustBpf1p> {};
-template<> struct sfzBpf2p<1> : public sfzFilter<faustBpf2p> {};
-template<> struct sfzBpf4p<1> : public sfzFilter<faustBpf4p> {};
-template<> struct sfzBpf6p<1> : public sfzFilter<faustBpf6p> {};
-template<> struct sfzApf1p<1> : public sfzFilterNoQ<faustApf1p> {};
-template<> struct sfzBrf1p<1> : public sfzFilterNoQ<faustBrf1p> {};
-template<> struct sfzBrf2p<1> : public sfzFilter<faustBrf2p> {};
-template<> struct sfzPink<1> : public sfzFilterNoCutoff<faustPink> {};
-template<> struct sfzLpf2pSv<1> : public sfzFilter<faustLpf2pSv> {};
-template<> struct sfzHpf2pSv<1> : public sfzFilter<faustHpf2pSv> {};
-template<> struct sfzBpf2pSv<1> : public sfzFilter<faustBpf2pSv> {};
-template<> struct sfzBrf2pSv<1> : public sfzFilter<faustBrf2pSv> {};
-template<> struct sfzLsh<1> : public sfzFilterPkSh<faustLsh> {};
-template<> struct sfzHsh<1> : public sfzFilterPkSh<faustHsh> {};
-template<> struct sfzPeq<1> : public sfzFilterPkSh<faustPeq> {};
-template<> struct sfzEq<1> : public sfzFilterEq<faustEq> {};
-
-template<> struct sfzLpf1p<2> : public sfzFilterNoQ<faust2chLpf1p> {};
-template<> struct sfzLpf2p<2> : public sfzFilter<faust2chLpf2p> {};
-template<> struct sfzLpf4p<2> : public sfzFilter<faust2chLpf4p> {};
-template<> struct sfzLpf6p<2> : public sfzFilter<faust2chLpf6p> {};
-template<> struct sfzHpf1p<2> : public sfzFilterNoQ<faust2chHpf1p> {};
-template<> struct sfzHpf2p<2> : public sfzFilter<faust2chHpf2p> {};
-template<> struct sfzHpf4p<2> : public sfzFilter<faust2chHpf4p> {};
-template<> struct sfzHpf6p<2> : public sfzFilter<faust2chHpf6p> {};
-template<> struct sfzBpf1p<2> : public sfzFilterNoQ<faust2chBpf1p> {};
-template<> struct sfzBpf2p<2> : public sfzFilter<faust2chBpf2p> {};
-template<> struct sfzBpf4p<2> : public sfzFilter<faust2chBpf4p> {};
-template<> struct sfzBpf6p<2> : public sfzFilter<faust2chBpf6p> {};
-template<> struct sfzApf1p<2> : public sfzFilterNoQ<faust2chApf1p> {};
-template<> struct sfzBrf1p<2> : public sfzFilterNoQ<faust2chBrf1p> {};
-template<> struct sfzBrf2p<2> : public sfzFilter<faust2chBrf2p> {};
-template<> struct sfzPink<2> : public sfzFilterNoCutoff<faust2chPink> {};
-template<> struct sfzLpf2pSv<2> : public sfzFilter<faust2chLpf2pSv> {};
-template<> struct sfzHpf2pSv<2> : public sfzFilter<faust2chHpf2pSv> {};
-template<> struct sfzBpf2pSv<2> : public sfzFilter<faust2chBpf2pSv> {};
-template<> struct sfzBrf2pSv<2> : public sfzFilter<faust2chBrf2pSv> {};
-template<> struct sfzLsh<2> : public sfzFilterPkSh<faust2chLsh> {};
-template<> struct sfzHsh<2> : public sfzFilterPkSh<faust2chHsh> {};
-template<> struct sfzPeq<2> : public sfzFilterPkSh<faust2chPeq> {};
-template<> struct sfzEq<2> : public sfzFilterEq<faust2chEq> {};
+struct sfz2chLpf1p final : public sfzFilterNoQ<faust2chLpf1p> {};
+struct sfz2chLpf2p final : public sfzFilter<faust2chLpf2p> {};
+struct sfz2chLpf4p final : public sfzFilter<faust2chLpf4p> {};
+struct sfz2chLpf6p final : public sfzFilter<faust2chLpf6p> {};
+struct sfz2chHpf1p final : public sfzFilterNoQ<faust2chHpf1p> {};
+struct sfz2chHpf2p final : public sfzFilter<faust2chHpf2p> {};
+struct sfz2chHpf4p final : public sfzFilter<faust2chHpf4p> {};
+struct sfz2chHpf6p final : public sfzFilter<faust2chHpf6p> {};
+struct sfz2chBpf1p final : public sfzFilterNoQ<faust2chBpf1p> {};
+struct sfz2chBpf2p final : public sfzFilter<faust2chBpf2p> {};
+struct sfz2chBpf4p final : public sfzFilter<faust2chBpf4p> {};
+struct sfz2chBpf6p final : public sfzFilter<faust2chBpf6p> {};
+struct sfz2chApf1p final : public sfzFilterNoQ<faust2chApf1p> {};
+struct sfz2chBrf1p final : public sfzFilterNoQ<faust2chBrf1p> {};
+struct sfz2chBrf2p final : public sfzFilter<faust2chBrf2p> {};
+struct sfz2chPink final : public sfzFilterNoCutoff<faust2chPink> {};
+struct sfz2chLpf2pSv final : public sfzFilter<faust2chLpf2pSv> {};
+struct sfz2chHpf2pSv final : public sfzFilter<faust2chHpf2pSv> {};
+struct sfz2chBpf2pSv final : public sfzFilter<faust2chBpf2pSv> {};
+struct sfz2chBrf2pSv final : public sfzFilter<faust2chBrf2pSv> {};
+struct sfz2chLsh final : public sfzFilterPkSh<faust2chLsh> {};
+struct sfz2chHsh final : public sfzFilterPkSh<faust2chHsh> {};
+struct sfz2chPeq final : public sfzFilterPkSh<faust2chPeq> {};
+struct sfz2chEq final : public sfzFilterEq<faust2chEq> {};

--- a/src/sfizz/SfzFilterImpls.cxx
+++ b/src/sfizz/SfzFilterImpls.cxx
@@ -18,10 +18,8 @@ public:
     virtual void instanceClear() = 0;
     virtual void compute(int, float **, float **) = 0;
 
-    virtual void setCutoff(float) {}
-    virtual void setQ(float) {}
-    virtual void setBandwidth(float) {}
-    virtual void setPkShGain(float) {}
+    virtual void configureStandard(float, float, float) {}
+    virtual void configureEq(float, float, float) {}
 };
 
 #if defined(__GNUC__) || defined(__clang__)
@@ -88,8 +86,12 @@ public:
    Parameterized by cutoff and Q
  */
 template <class F> struct sfzFilter : public F {
-    void setCutoff(float v) override { F::fCutoff = v; }
-    void setQ(float v) override { F::fQ = v; }
+    void configureStandard(float cutoff, float q, float pksh) override
+    {
+        F::fCutoff = cutoff;
+        F::fQ = q;
+        (void)pksh;
+    }
 };
 
 /**
@@ -97,7 +99,12 @@ template <class F> struct sfzFilter : public F {
    Parameterized by cutoff only
  */
 template <class F> struct sfzFilterNoQ : public F {
-    void setCutoff(float v) override { F::fCutoff = v; }
+    void configureStandard(float cutoff, float q, float pksh) override
+    {
+        F::fCutoff = cutoff;
+        (void)q;
+        (void)pksh;
+    }
 };
 
 /**
@@ -105,6 +112,12 @@ template <class F> struct sfzFilterNoQ : public F {
    Not parameterized
  */
 template <class F> struct sfzFilterNoCutoff : public F {
+    void configureStandard(float cutoff, float q, float pksh) override
+    {
+        (void)cutoff;
+        (void)q;
+        (void)pksh;
+    }
 };
 
 /**
@@ -112,9 +125,12 @@ template <class F> struct sfzFilterNoCutoff : public F {
    Parameterized by cutoff, Q, peak/shelf gain
  */
 template <class F> struct sfzFilterPkSh : public F {
-    void setCutoff(float v) override { F::fCutoff = v; }
-    void setQ(float v) override { F::fQ = v; }
-    void setPkShGain(float v) override { F::fPkShGain = v; }
+    void configureStandard(float cutoff, float q, float pksh) override
+    {
+        F::fCutoff = cutoff;
+        F::fQ = q;
+        F::fPkShGain = pksh;
+    }
 };
 
 /**
@@ -122,9 +138,12 @@ template <class F> struct sfzFilterPkSh : public F {
    Parameterized by cutoff, bandwidth, peak/shelf gain
  */
 template <class F> struct sfzFilterEq : public F {
-    void setCutoff(float v) override { F::fCutoff = v; }
-    void setBandwidth(float v) override { F::fBandwidth = v; }
-    void setPkShGain(float v) override { F::fPkShGain = v; }
+    void configureEq(float cutoff, float bw, float pksh) override
+    {
+        F::fCutoff = cutoff;
+        F::fBandwidth = bw;
+        F::fPkShGain = pksh;
+    }
 };
 
 struct sfzLpf1p final : public sfzFilterNoQ<faustLpf1p> {};

--- a/src/sfizz/gen/filters/sfz2chApf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chApf1p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chApf1p : public dsp {
+class faust2chApf1p : public sfzFilterDsp {
 	
  public:
 	
@@ -43,13 +43,13 @@ class faust2chApf1p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -67,7 +67,7 @@ class faust2chApf1p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -89,16 +89,16 @@ class faust2chApf1p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -110,28 +110,28 @@ class faust2chApf1p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chApf1p* clone() {
+	virtual faust2chApf1p* clone() {
 		return new faust2chApf1p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chBpf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf1p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chBpf1p : public dsp {
+class faust2chBpf1p : public sfzFilterDsp {
 	
  public:
 	
@@ -45,13 +45,13 @@ class faust2chBpf1p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -69,7 +69,7 @@ class faust2chBpf1p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -91,16 +91,16 @@ class faust2chBpf1p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (1.0 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec2[l0] = 0.0;
 		}
@@ -118,28 +118,28 @@ class faust2chBpf1p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chBpf1p* clone() {
+	virtual faust2chBpf1p* clone() {
 		return new faust2chBpf1p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chBpf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf2p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chBpf2p : public dsp {
+class faust2chBpf2p : public sfzFilterDsp {
 	
  public:
 	
@@ -48,13 +48,13 @@ class faust2chBpf2p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -72,7 +72,7 @@ class faust2chBpf2p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -94,17 +94,17 @@ class faust2chBpf2p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -128,28 +128,28 @@ class faust2chBpf2p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chBpf2p* clone() {
+	virtual faust2chBpf2p* clone() {
 		return new faust2chBpf2p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chBpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf2pSv.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chBpf2pSv : public dsp {
+class faust2chBpf2pSv : public sfzFilterDsp {
 	
  public:
 	
@@ -49,13 +49,13 @@ class faust2chBpf2pSv : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -73,7 +73,7 @@ class faust2chBpf2pSv : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -95,17 +95,17 @@ class faust2chBpf2pSv : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec3[l0] = 0.0;
 		}
@@ -132,28 +132,28 @@ class faust2chBpf2pSv : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chBpf2pSv* clone() {
+	virtual faust2chBpf2pSv* clone() {
 		return new faust2chBpf2pSv();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chBpf4p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf4p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chBpf4p : public dsp {
+class faust2chBpf4p : public sfzFilterDsp {
 	
  public:
 	
@@ -50,13 +50,13 @@ class faust2chBpf4p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -74,7 +74,7 @@ class faust2chBpf4p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -96,17 +96,17 @@ class faust2chBpf4p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -136,28 +136,28 @@ class faust2chBpf4p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chBpf4p* clone() {
+	virtual faust2chBpf4p* clone() {
 		return new faust2chBpf4p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chBpf6p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf6p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chBpf6p : public dsp {
+class faust2chBpf6p : public sfzFilterDsp {
 	
  public:
 	
@@ -52,13 +52,13 @@ class faust2chBpf6p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -76,7 +76,7 @@ class faust2chBpf6p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -98,17 +98,17 @@ class faust2chBpf6p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -144,28 +144,28 @@ class faust2chBpf6p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chBpf6p* clone() {
+	virtual faust2chBpf6p* clone() {
 		return new faust2chBpf6p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chBrf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBrf1p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chBrf1p : public dsp {
+class faust2chBrf1p : public sfzFilterDsp {
 	
  public:
 	
@@ -45,13 +45,13 @@ class faust2chBrf1p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -69,7 +69,7 @@ class faust2chBrf1p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -91,16 +91,16 @@ class faust2chBrf1p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec2[l0] = 0.0;
 		}
@@ -118,28 +118,28 @@ class faust2chBrf1p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chBrf1p* clone() {
+	virtual faust2chBrf1p* clone() {
 		return new faust2chBrf1p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chBrf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBrf2p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chBrf2p : public dsp {
+class faust2chBrf2p : public sfzFilterDsp {
 	
  public:
 	
@@ -46,13 +46,13 @@ class faust2chBrf2p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -70,7 +70,7 @@ class faust2chBrf2p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -92,17 +92,17 @@ class faust2chBrf2p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -120,28 +120,28 @@ class faust2chBrf2p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chBrf2p* clone() {
+	virtual faust2chBrf2p* clone() {
 		return new faust2chBrf2p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chBrf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chBrf2pSv.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chBrf2pSv : public dsp {
+class faust2chBrf2pSv : public sfzFilterDsp {
 	
  public:
 	
@@ -48,13 +48,13 @@ class faust2chBrf2pSv : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -72,7 +72,7 @@ class faust2chBrf2pSv : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -94,17 +94,17 @@ class faust2chBrf2pSv : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec5[l0] = 0.0;
 		}
@@ -128,28 +128,28 @@ class faust2chBrf2pSv : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chBrf2pSv* clone() {
+	virtual faust2chBrf2pSv* clone() {
 		return new faust2chBrf2pSv();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chEq.cxx
+++ b/src/sfizz/gen/filters/sfz2chEq.cxx
@@ -28,7 +28,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chEq : public dsp {
+class faust2chEq : public sfzFilterDsp {
 	
  public:
 	
@@ -51,13 +51,13 @@ class faust2chEq : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -75,7 +75,7 @@ class faust2chEq : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -97,20 +97,20 @@ class faust2chEq : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = (6.2831853071795862 / fConst0);
 		fConst2 = (2.1775860903036022 / fConst0);
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fBandwidth = FAUSTFLOAT(1.0);
 		fPkShGain = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -131,28 +131,28 @@ class faust2chEq : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chEq* clone() {
+	virtual faust2chEq* clone() {
 		return new faust2chEq();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chHpf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf1p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chHpf1p : public dsp {
+class faust2chHpf1p : public sfzFilterDsp {
 	
  public:
 	
@@ -43,13 +43,13 @@ class faust2chHpf1p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -67,7 +67,7 @@ class faust2chHpf1p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -89,16 +89,16 @@ class faust2chHpf1p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (1.0 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -110,28 +110,28 @@ class faust2chHpf1p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chHpf1p* clone() {
+	virtual faust2chHpf1p* clone() {
 		return new faust2chHpf1p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chHpf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf2p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chHpf2p : public dsp {
+class faust2chHpf2p : public sfzFilterDsp {
 	
  public:
 	
@@ -47,13 +47,13 @@ class faust2chHpf2p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -71,7 +71,7 @@ class faust2chHpf2p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -93,17 +93,17 @@ class faust2chHpf2p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -124,28 +124,28 @@ class faust2chHpf2p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chHpf2p* clone() {
+	virtual faust2chHpf2p* clone() {
 		return new faust2chHpf2p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chHpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf2pSv.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chHpf2pSv : public dsp {
+class faust2chHpf2pSv : public sfzFilterDsp {
 	
  public:
 	
@@ -48,13 +48,13 @@ class faust2chHpf2pSv : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -72,7 +72,7 @@ class faust2chHpf2pSv : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -94,17 +94,17 @@ class faust2chHpf2pSv : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec4[l0] = 0.0;
 		}
@@ -128,28 +128,28 @@ class faust2chHpf2pSv : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chHpf2pSv* clone() {
+	virtual faust2chHpf2pSv* clone() {
 		return new faust2chHpf2pSv();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chHpf4p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf4p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chHpf4p : public dsp {
+class faust2chHpf4p : public sfzFilterDsp {
 	
  public:
 	
@@ -49,13 +49,13 @@ class faust2chHpf4p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -73,7 +73,7 @@ class faust2chHpf4p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -95,17 +95,17 @@ class faust2chHpf4p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -132,28 +132,28 @@ class faust2chHpf4p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chHpf4p* clone() {
+	virtual faust2chHpf4p* clone() {
 		return new faust2chHpf4p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chHpf6p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf6p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chHpf6p : public dsp {
+class faust2chHpf6p : public sfzFilterDsp {
 	
  public:
 	
@@ -51,13 +51,13 @@ class faust2chHpf6p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -75,7 +75,7 @@ class faust2chHpf6p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -97,17 +97,17 @@ class faust2chHpf6p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -140,28 +140,28 @@ class faust2chHpf6p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chHpf6p* clone() {
+	virtual faust2chHpf6p* clone() {
 		return new faust2chHpf6p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chHsh.cxx
+++ b/src/sfizz/gen/filters/sfz2chHsh.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chHsh : public dsp {
+class faust2chHsh : public sfzFilterDsp {
 	
  public:
 	
@@ -49,13 +49,13 @@ class faust2chHsh : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -73,7 +73,7 @@ class faust2chHsh : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -95,18 +95,18 @@ class faust2chHsh : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fPkShGain = FAUSTFLOAT(0.0);
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -130,28 +130,28 @@ class faust2chHsh : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chHsh* clone() {
+	virtual faust2chHsh* clone() {
 		return new faust2chHsh();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chLpf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf1p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chLpf1p : public dsp {
+class faust2chLpf1p : public sfzFilterDsp {
 	
  public:
 	
@@ -43,13 +43,13 @@ class faust2chLpf1p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -67,7 +67,7 @@ class faust2chLpf1p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -89,16 +89,16 @@ class faust2chLpf1p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (1.0 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -110,28 +110,28 @@ class faust2chLpf1p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chLpf1p* clone() {
+	virtual faust2chLpf1p* clone() {
 		return new faust2chLpf1p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chLpf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf2p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chLpf2p : public dsp {
+class faust2chLpf2p : public sfzFilterDsp {
 	
  public:
 	
@@ -47,13 +47,13 @@ class faust2chLpf2p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -71,7 +71,7 @@ class faust2chLpf2p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -93,17 +93,17 @@ class faust2chLpf2p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -124,28 +124,28 @@ class faust2chLpf2p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chLpf2p* clone() {
+	virtual faust2chLpf2p* clone() {
 		return new faust2chLpf2p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chLpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf2pSv.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chLpf2pSv : public dsp {
+class faust2chLpf2pSv : public sfzFilterDsp {
 	
  public:
 	
@@ -48,13 +48,13 @@ class faust2chLpf2pSv : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -72,7 +72,7 @@ class faust2chLpf2pSv : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -94,17 +94,17 @@ class faust2chLpf2pSv : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec3[l0] = 0.0;
 		}
@@ -128,28 +128,28 @@ class faust2chLpf2pSv : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chLpf2pSv* clone() {
+	virtual faust2chLpf2pSv* clone() {
 		return new faust2chLpf2pSv();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chLpf4p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf4p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chLpf4p : public dsp {
+class faust2chLpf4p : public sfzFilterDsp {
 	
  public:
 	
@@ -49,13 +49,13 @@ class faust2chLpf4p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -73,7 +73,7 @@ class faust2chLpf4p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -95,17 +95,17 @@ class faust2chLpf4p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -132,28 +132,28 @@ class faust2chLpf4p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chLpf4p* clone() {
+	virtual faust2chLpf4p* clone() {
 		return new faust2chLpf4p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chLpf6p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf6p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chLpf6p : public dsp {
+class faust2chLpf6p : public sfzFilterDsp {
 	
  public:
 	
@@ -51,13 +51,13 @@ class faust2chLpf6p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -75,7 +75,7 @@ class faust2chLpf6p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -97,17 +97,17 @@ class faust2chLpf6p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -140,28 +140,28 @@ class faust2chLpf6p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chLpf6p* clone() {
+	virtual faust2chLpf6p* clone() {
 		return new faust2chLpf6p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chLsh.cxx
+++ b/src/sfizz/gen/filters/sfz2chLsh.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chLsh : public dsp {
+class faust2chLsh : public sfzFilterDsp {
 	
  public:
 	
@@ -49,13 +49,13 @@ class faust2chLsh : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -73,7 +73,7 @@ class faust2chLsh : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -95,18 +95,18 @@ class faust2chLsh : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fPkShGain = FAUSTFLOAT(0.0);
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -130,28 +130,28 @@ class faust2chLsh : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chLsh* clone() {
+	virtual faust2chLsh* clone() {
 		return new faust2chLsh();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chPeq.cxx
+++ b/src/sfizz/gen/filters/sfz2chPeq.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chPeq : public dsp {
+class faust2chPeq : public sfzFilterDsp {
 	
  public:
 	
@@ -48,13 +48,13 @@ class faust2chPeq : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -72,7 +72,7 @@ class faust2chPeq : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -94,18 +94,18 @@ class faust2chPeq : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 		fPkShGain = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -126,28 +126,28 @@ class faust2chPeq : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chPeq* clone() {
+	virtual faust2chPeq* clone() {
 		return new faust2chPeq();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfz2chPink.cxx
+++ b/src/sfizz/gen/filters/sfz2chPink.cxx
@@ -26,7 +26,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faust2chPink : public dsp {
+class faust2chPink : public sfzFilterDsp {
 	
  public:
 	
@@ -39,13 +39,13 @@ class faust2chPink : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 2;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 2;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -63,7 +63,7 @@ class faust2chPink : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -85,14 +85,14 @@ class faust2chPink : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 4); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -101,28 +101,28 @@ class faust2chPink : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faust2chPink* clone() {
+	virtual faust2chPink* clone() {
 		return new faust2chPink();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];

--- a/src/sfizz/gen/filters/sfzApf1p.cxx
+++ b/src/sfizz/gen/filters/sfzApf1p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustApf1p : public dsp {
+class faustApf1p : public sfzFilterDsp {
 	
  public:
 	
@@ -42,13 +42,13 @@ class faustApf1p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -62,7 +62,7 @@ class faustApf1p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -80,16 +80,16 @@ class faustApf1p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -98,28 +98,28 @@ class faustApf1p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustApf1p* clone() {
+	virtual faustApf1p* clone() {
 		return new faustApf1p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (0.0010000000000000009 * ((fConst0 * double(fCutoff)) + -1.0));

--- a/src/sfizz/gen/filters/sfzBpf1p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf1p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustBpf1p : public dsp {
+class faustBpf1p : public sfzFilterDsp {
 	
  public:
 	
@@ -43,13 +43,13 @@ class faustBpf1p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -63,7 +63,7 @@ class faustBpf1p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -81,16 +81,16 @@ class faustBpf1p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (1.0 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec2[l0] = 0.0;
 		}
@@ -102,28 +102,28 @@ class faustBpf1p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustBpf1p* clone() {
+	virtual faustBpf1p* clone() {
 		return new faustBpf1p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (0.0010000000000000009 * std::exp((fConst0 * (0.0 - (6.2831853071795862 * double(fCutoff))))));

--- a/src/sfizz/gen/filters/sfzBpf2p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf2p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustBpf2p : public dsp {
+class faustBpf2p : public sfzFilterDsp {
 	
  public:
 	
@@ -47,13 +47,13 @@ class faustBpf2p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -67,7 +67,7 @@ class faustBpf2p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -85,17 +85,17 @@ class faustBpf2p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -116,28 +116,28 @@ class faustBpf2p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustBpf2p* clone() {
+	virtual faustBpf2p* clone() {
 		return new faustBpf2p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));

--- a/src/sfizz/gen/filters/sfzBpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzBpf2pSv.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustBpf2pSv : public dsp {
+class faustBpf2pSv : public sfzFilterDsp {
 	
  public:
 	
@@ -47,13 +47,13 @@ class faustBpf2pSv : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -67,7 +67,7 @@ class faustBpf2pSv : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -85,17 +85,17 @@ class faustBpf2pSv : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec3[l0] = 0.0;
 		}
@@ -116,28 +116,28 @@ class faustBpf2pSv : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustBpf2pSv* clone() {
+	virtual faustBpf2pSv* clone() {
 		return new faustBpf2pSv();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (0.0010000000000000009 * std::tan((fConst0 * double(fCutoff))));

--- a/src/sfizz/gen/filters/sfzBpf4p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf4p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustBpf4p : public dsp {
+class faustBpf4p : public sfzFilterDsp {
 	
  public:
 	
@@ -48,13 +48,13 @@ class faustBpf4p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -68,7 +68,7 @@ class faustBpf4p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -86,17 +86,17 @@ class faustBpf4p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -120,28 +120,28 @@ class faustBpf4p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustBpf4p* clone() {
+	virtual faustBpf4p* clone() {
 		return new faustBpf4p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));

--- a/src/sfizz/gen/filters/sfzBpf6p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf6p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustBpf6p : public dsp {
+class faustBpf6p : public sfzFilterDsp {
 	
  public:
 	
@@ -49,13 +49,13 @@ class faustBpf6p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -69,7 +69,7 @@ class faustBpf6p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -87,17 +87,17 @@ class faustBpf6p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -124,28 +124,28 @@ class faustBpf6p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustBpf6p* clone() {
+	virtual faustBpf6p* clone() {
 		return new faustBpf6p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));

--- a/src/sfizz/gen/filters/sfzBrf1p.cxx
+++ b/src/sfizz/gen/filters/sfzBrf1p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustBrf1p : public dsp {
+class faustBrf1p : public sfzFilterDsp {
 	
  public:
 	
@@ -43,13 +43,13 @@ class faustBrf1p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -63,7 +63,7 @@ class faustBrf1p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -81,16 +81,16 @@ class faustBrf1p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec2[l0] = 0.0;
 		}
@@ -102,28 +102,28 @@ class faustBrf1p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustBrf1p* clone() {
+	virtual faustBrf1p* clone() {
 		return new faustBrf1p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (0.0010000000000000009 * ((fConst0 * double(fCutoff)) + -1.0));

--- a/src/sfizz/gen/filters/sfzBrf2p.cxx
+++ b/src/sfizz/gen/filters/sfzBrf2p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustBrf2p : public dsp {
+class faustBrf2p : public sfzFilterDsp {
 	
  public:
 	
@@ -45,13 +45,13 @@ class faustBrf2p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -65,7 +65,7 @@ class faustBrf2p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -83,17 +83,17 @@ class faustBrf2p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -108,28 +108,28 @@ class faustBrf2p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustBrf2p* clone() {
+	virtual faustBrf2p* clone() {
 		return new faustBrf2p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));

--- a/src/sfizz/gen/filters/sfzBrf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzBrf2pSv.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustBrf2pSv : public dsp {
+class faustBrf2pSv : public sfzFilterDsp {
 	
  public:
 	
@@ -46,13 +46,13 @@ class faustBrf2pSv : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -66,7 +66,7 @@ class faustBrf2pSv : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -84,17 +84,17 @@ class faustBrf2pSv : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec5[l0] = 0.0;
 		}
@@ -112,28 +112,28 @@ class faustBrf2pSv : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustBrf2pSv* clone() {
+	virtual faustBrf2pSv* clone() {
 		return new faustBrf2pSv();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (0.0010000000000000009 * std::tan((fConst0 * double(fCutoff))));

--- a/src/sfizz/gen/filters/sfzEq.cxx
+++ b/src/sfizz/gen/filters/sfzEq.cxx
@@ -28,7 +28,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustEq : public dsp {
+class faustEq : public sfzFilterDsp {
 	
  public:
 	
@@ -50,13 +50,13 @@ class faustEq : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -70,7 +70,7 @@ class faustEq : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -88,20 +88,20 @@ class faustEq : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = (6.2831853071795862 / fConst0);
 		fConst2 = (2.1775860903036022 / fConst0);
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fBandwidth = FAUSTFLOAT(1.0);
 		fPkShGain = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -119,28 +119,28 @@ class faustEq : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustEq* clone() {
+	virtual faustEq* clone() {
 		return new faustEq();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = std::max<double>(0.0, double(fCutoff));

--- a/src/sfizz/gen/filters/sfzHpf1p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf1p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustHpf1p : public dsp {
+class faustHpf1p : public sfzFilterDsp {
 	
  public:
 	
@@ -42,13 +42,13 @@ class faustHpf1p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -62,7 +62,7 @@ class faustHpf1p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -80,16 +80,16 @@ class faustHpf1p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (1.0 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -98,28 +98,28 @@ class faustHpf1p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustHpf1p* clone() {
+	virtual faustHpf1p* clone() {
 		return new faustHpf1p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (0.0010000000000000009 * std::exp((fConst0 * (0.0 - (6.2831853071795862 * double(fCutoff))))));

--- a/src/sfizz/gen/filters/sfzHpf2p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf2p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustHpf2p : public dsp {
+class faustHpf2p : public sfzFilterDsp {
 	
  public:
 	
@@ -46,13 +46,13 @@ class faustHpf2p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -66,7 +66,7 @@ class faustHpf2p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -84,17 +84,17 @@ class faustHpf2p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -112,28 +112,28 @@ class faustHpf2p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustHpf2p* clone() {
+	virtual faustHpf2p* clone() {
 		return new faustHpf2p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));

--- a/src/sfizz/gen/filters/sfzHpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzHpf2pSv.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustHpf2pSv : public dsp {
+class faustHpf2pSv : public sfzFilterDsp {
 	
  public:
 	
@@ -46,13 +46,13 @@ class faustHpf2pSv : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -66,7 +66,7 @@ class faustHpf2pSv : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -84,17 +84,17 @@ class faustHpf2pSv : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec4[l0] = 0.0;
 		}
@@ -112,28 +112,28 @@ class faustHpf2pSv : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustHpf2pSv* clone() {
+	virtual faustHpf2pSv* clone() {
 		return new faustHpf2pSv();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (0.0010000000000000009 * std::tan((fConst0 * double(fCutoff))));

--- a/src/sfizz/gen/filters/sfzHpf4p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf4p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustHpf4p : public dsp {
+class faustHpf4p : public sfzFilterDsp {
 	
  public:
 	
@@ -47,13 +47,13 @@ class faustHpf4p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -67,7 +67,7 @@ class faustHpf4p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -85,17 +85,17 @@ class faustHpf4p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -116,28 +116,28 @@ class faustHpf4p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustHpf4p* clone() {
+	virtual faustHpf4p* clone() {
 		return new faustHpf4p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));

--- a/src/sfizz/gen/filters/sfzHpf6p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf6p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustHpf6p : public dsp {
+class faustHpf6p : public sfzFilterDsp {
 	
  public:
 	
@@ -48,13 +48,13 @@ class faustHpf6p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -68,7 +68,7 @@ class faustHpf6p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -86,17 +86,17 @@ class faustHpf6p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -120,28 +120,28 @@ class faustHpf6p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustHpf6p* clone() {
+	virtual faustHpf6p* clone() {
 		return new faustHpf6p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));

--- a/src/sfizz/gen/filters/sfzHsh.cxx
+++ b/src/sfizz/gen/filters/sfzHsh.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustHsh : public dsp {
+class faustHsh : public sfzFilterDsp {
 	
  public:
 	
@@ -48,13 +48,13 @@ class faustHsh : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -68,7 +68,7 @@ class faustHsh : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -86,18 +86,18 @@ class faustHsh : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fPkShGain = FAUSTFLOAT(0.0);
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -118,28 +118,28 @@ class faustHsh : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustHsh* clone() {
+	virtual faustHsh* clone() {
 		return new faustHsh();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));

--- a/src/sfizz/gen/filters/sfzLpf1p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf1p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustLpf1p : public dsp {
+class faustLpf1p : public sfzFilterDsp {
 	
  public:
 	
@@ -42,13 +42,13 @@ class faustLpf1p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -62,7 +62,7 @@ class faustLpf1p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -80,16 +80,16 @@ class faustLpf1p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (1.0 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -98,28 +98,28 @@ class faustLpf1p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustLpf1p* clone() {
+	virtual faustLpf1p* clone() {
 		return new faustLpf1p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (0.0010000000000000009 * std::exp((fConst0 * (0.0 - (6.2831853071795862 * double(fCutoff))))));

--- a/src/sfizz/gen/filters/sfzLpf2p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf2p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustLpf2p : public dsp {
+class faustLpf2p : public sfzFilterDsp {
 	
  public:
 	
@@ -46,13 +46,13 @@ class faustLpf2p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -66,7 +66,7 @@ class faustLpf2p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -84,17 +84,17 @@ class faustLpf2p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -112,28 +112,28 @@ class faustLpf2p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustLpf2p* clone() {
+	virtual faustLpf2p* clone() {
 		return new faustLpf2p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));

--- a/src/sfizz/gen/filters/sfzLpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzLpf2pSv.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustLpf2pSv : public dsp {
+class faustLpf2pSv : public sfzFilterDsp {
 	
  public:
 	
@@ -46,13 +46,13 @@ class faustLpf2pSv : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -66,7 +66,7 @@ class faustLpf2pSv : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -84,17 +84,17 @@ class faustLpf2pSv : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec3[l0] = 0.0;
 		}
@@ -112,28 +112,28 @@ class faustLpf2pSv : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustLpf2pSv* clone() {
+	virtual faustLpf2pSv* clone() {
 		return new faustLpf2pSv();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (0.0010000000000000009 * std::tan((fConst0 * double(fCutoff))));

--- a/src/sfizz/gen/filters/sfzLpf4p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf4p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustLpf4p : public dsp {
+class faustLpf4p : public sfzFilterDsp {
 	
  public:
 	
@@ -47,13 +47,13 @@ class faustLpf4p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -67,7 +67,7 @@ class faustLpf4p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -85,17 +85,17 @@ class faustLpf4p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -116,28 +116,28 @@ class faustLpf4p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustLpf4p* clone() {
+	virtual faustLpf4p* clone() {
 		return new faustLpf4p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));

--- a/src/sfizz/gen/filters/sfzLpf6p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf6p.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustLpf6p : public dsp {
+class faustLpf6p : public sfzFilterDsp {
 	
  public:
 	
@@ -48,13 +48,13 @@ class faustLpf6p : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -68,7 +68,7 @@ class faustLpf6p : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -86,17 +86,17 @@ class faustLpf6p : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
@@ -120,28 +120,28 @@ class faustLpf6p : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustLpf6p* clone() {
+	virtual faustLpf6p* clone() {
 		return new faustLpf6p();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));

--- a/src/sfizz/gen/filters/sfzLsh.cxx
+++ b/src/sfizz/gen/filters/sfzLsh.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustLsh : public dsp {
+class faustLsh : public sfzFilterDsp {
 	
  public:
 	
@@ -48,13 +48,13 @@ class faustLsh : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -68,7 +68,7 @@ class faustLsh : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -86,18 +86,18 @@ class faustLsh : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fPkShGain = FAUSTFLOAT(0.0);
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -118,28 +118,28 @@ class faustLsh : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustLsh* clone() {
+	virtual faustLsh* clone() {
 		return new faustLsh();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));

--- a/src/sfizz/gen/filters/sfzPeq.cxx
+++ b/src/sfizz/gen/filters/sfzPeq.cxx
@@ -27,7 +27,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustPeq : public dsp {
+class faustPeq : public sfzFilterDsp {
 	
  public:
 	
@@ -47,13 +47,13 @@ class faustPeq : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -67,7 +67,7 @@ class faustPeq : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -85,18 +85,18 @@ class faustPeq : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 		fPkShGain = FAUSTFLOAT(0.0);
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
 		}
@@ -114,28 +114,28 @@ class faustPeq : public dsp {
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustPeq* clone() {
+	virtual faustPeq* clone() {
 		return new faustPeq();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));

--- a/src/sfizz/gen/filters/sfzPink.cxx
+++ b/src/sfizz/gen/filters/sfzPink.cxx
@@ -26,7 +26,7 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #define exp10 __exp10
 #endif
 
-class faustPink : public dsp {
+class faustPink : public sfzFilterDsp {
 	
  public:
 	
@@ -38,13 +38,13 @@ class faustPink : public dsp {
 	void metadata(Meta* m) { 
 	}
 
-	 int getNumInputs() {
+	virtual int getNumInputs() {
 		return 1;
 	}
-	 int getNumOutputs() {
+	virtual int getNumOutputs() {
 		return 1;
 	}
-	 int getInputRate(int channel) {
+	virtual int getInputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -58,7 +58,7 @@ class faustPink : public dsp {
 		}
 		return rate;
 	}
-	 int getOutputRate(int channel) {
+	virtual int getOutputRate(int channel) {
 		int rate;
 		switch ((channel)) {
 			case 0: {
@@ -76,41 +76,41 @@ class faustPink : public dsp {
 	static void classInit(int sample_rate) {
 	}
 	
-	 void instanceConstants(int sample_rate) {
+	virtual void instanceConstants(int sample_rate) {
 		fSampleRate = sample_rate;
 	}
 	
-	 void instanceResetUserInterface() {
+	virtual void instanceResetUserInterface() {
 	}
 	
-	 void instanceClear() {
+	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 4); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
 		}
 	}
 	
-	 void init(int sample_rate) {
+	virtual void init(int sample_rate) {
 		classInit(sample_rate);
 		instanceInit(sample_rate);
 	}
-	 void instanceInit(int sample_rate) {
+	virtual void instanceInit(int sample_rate) {
 		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
 	
-	 faustPink* clone() {
+	virtual faustPink* clone() {
 		return new faustPink();
 	}
 	
-	 int getSampleRate() {
+	virtual int getSampleRate() {
 		return fSampleRate;
 	}
 	
-	 void buildUserInterface(UI* ui_interface) {
+	virtual void buildUserInterface(UI* ui_interface) {
 	}
 	
-	 void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
+	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		for (int i = 0; (i < count); i = (i + 1)) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,4 +31,17 @@ target_link_libraries(sfizz_tests PRIVATE sfizz::sfizz)
 sfizz_enable_lto_if_needed(sfizz_tests)
 # target_link_libraries(sfizz_tests PRIVATE absl::strings absl::str_format absl::flat_hash_map cnpy absl::span absl::algorithm)
 
+find_package(PkgConfig)
+if(PKGCONFIG_FOUND)
+    pkg_check_modules(JACK "jack")
+endif()
+find_package(Qt5 COMPONENTS Widgets)
+
+if(JACK_FOUND AND TARGET Qt5::Widgets)
+    add_executable(sfizz_demo_filters DemoFilters.cpp)
+    target_include_directories(sfizz_demo_filters PRIVATE ${JACK_INCLUDE_DIRS})
+    target_link_libraries(sfizz_demo_filters PRIVATE sfizz::sfizz Qt5::Widgets ${JACK_LIBRARIES})
+    set_target_properties(sfizz_demo_filters PROPERTIES AUTOUIC ON)
+endif()
+
 file(COPY "." DESTINATION ${CMAKE_BINARY_DIR}/tests)

--- a/tests/DemoFilters.cpp
+++ b/tests/DemoFilters.cpp
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "sfizz/SfzFilter.h"
+#include "ui_DemoFilters.h"
+#include <QApplication>
+#include <QMainWindow>
+#include <QMessageBox>
+#include <QButtonGroup>
+#include <QDebug>
+#include <jack/jack.h>
+#include <memory>
+
+///
+struct jack_delete {
+    void operator()(jack_client_t *x) const noexcept { jack_client_close(x); }
+};
+
+typedef std::unique_ptr<jack_client_t, jack_delete> jack_client_u;
+
+///
+class DemoApp : public QApplication {
+public:
+    DemoApp(int &argc, char **argv);
+    bool initSound();
+    void initWindow();
+
+private:
+    static int processAudio(jack_nframes_t nframes, void *cbdata);
+
+private:
+    void valueChangedType(int value);
+    void valueChangedCutoff(int value);
+    void valueChangedResonance(int value);
+    void valueChangedPkShGain(int value);
+    void valueChangedBandwidth(int value);
+    void valueChangedFilterMode(int value);
+
+private:
+    QMainWindow *fWindow = nullptr;
+    Ui::DemoFiltersWindow fUi;
+
+    static constexpr int cutoffMin = 10.0;
+    static constexpr int cutoffMax = 20000.0;
+
+    static constexpr int resoMin = 0.0;
+    static constexpr int resoMax = 40.0;
+
+    static constexpr int pkshMin = -40.0;
+    static constexpr int pkshMax = 40.0;
+
+    static constexpr int bwMin = 1.0;
+    static constexpr int bwMax = 10.0;
+
+    int fType = sfz::kFilterNone;
+    int fCutoff = 500.0;
+    int fReso = 0.0;
+    int fPksh = 20.0;
+    int fBw = 1.0;
+
+    sfz::Filter fFilter;
+    sfz::FilterEq fFilterEq;
+
+    enum FilterMode {
+        kFilterModeMulti,
+        kFilterModeEq,
+    };
+    FilterMode fFilterMode = kFilterModeMulti;
+
+    jack_client_u fClient;
+    jack_port_t *fPorts[4] = {};
+};
+
+DemoApp::DemoApp(int &argc, char **argv)
+    : QApplication(argc, argv)
+{
+    setApplicationName(tr("Sfizz Filters"));
+}
+
+bool DemoApp::initSound()
+{
+    jack_client_t *client = jack_client_open(
+        applicationName().toUtf8().data(), JackNoStartServer, nullptr);
+    if (!client) {
+        QMessageBox::critical(nullptr, tr("Error"), tr("Cannot open JACK audio."));
+        return false;
+    }
+
+    fClient.reset(client);
+
+    double sampleRate = jack_get_sample_rate(client);
+
+    fFilter.init(sampleRate);
+    fFilter.setChannels(2);
+
+    fFilterEq.init(sampleRate);
+    fFilterEq.setChannels(2);
+
+    fPorts[0] = jack_port_register(client, "in_left", JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
+    fPorts[1] = jack_port_register(client, "in_right", JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
+    fPorts[2] = jack_port_register(client, "out_left", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+    fPorts[3] = jack_port_register(client, "out_right", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+
+    if (!(fPorts[0] && fPorts[1] && fPorts[2] && fPorts[3])) {
+        QMessageBox::critical(nullptr, tr("Error"), tr("Cannot register JACK ports."));
+        return false;
+    }
+
+    jack_set_process_callback(client, &processAudio, this);
+
+    if (jack_activate(client) != 0) {
+        QMessageBox::critical(nullptr, tr("Error"), tr("Cannot activate JACK client."));
+        return false;
+    }
+
+    return true;
+}
+
+void DemoApp::initWindow()
+{
+    QMainWindow *window = new QMainWindow;
+    fWindow = window;
+    fUi.setupUi(window);
+    window->setWindowTitle(applicationDisplayName());
+
+    QComboBox *cbTypes = fUi.comboBox;
+    cbTypes->addItem("None", static_cast<int>(sfz::kFilterNone));
+    cbTypes->addItem("Apf1p", static_cast<int>(sfz::kFilterApf1p));
+    cbTypes->addItem("Bpf1p", static_cast<int>(sfz::kFilterBpf1p));
+    cbTypes->addItem("Bpf2p", static_cast<int>(sfz::kFilterBpf2p));
+    cbTypes->addItem("Bpf4p", static_cast<int>(sfz::kFilterBpf4p));
+    cbTypes->addItem("Bpf6p", static_cast<int>(sfz::kFilterBpf6p));
+    cbTypes->addItem("Brf1p", static_cast<int>(sfz::kFilterBrf1p));
+    cbTypes->addItem("Brf2p", static_cast<int>(sfz::kFilterBrf2p));
+    cbTypes->addItem("Hpf1p", static_cast<int>(sfz::kFilterHpf1p));
+    cbTypes->addItem("Hpf2p", static_cast<int>(sfz::kFilterHpf2p));
+    cbTypes->addItem("Hpf4p", static_cast<int>(sfz::kFilterHpf4p));
+    cbTypes->addItem("Hpf6p", static_cast<int>(sfz::kFilterHpf6p));
+    cbTypes->addItem("Lpf1p", static_cast<int>(sfz::kFilterLpf1p));
+    cbTypes->addItem("Lpf2p", static_cast<int>(sfz::kFilterLpf2p));
+    cbTypes->addItem("Lpf4p", static_cast<int>(sfz::kFilterLpf4p));
+    cbTypes->addItem("Lpf6p", static_cast<int>(sfz::kFilterLpf6p));
+    cbTypes->addItem("Pink", static_cast<int>(sfz::kFilterPink));
+    cbTypes->addItem("Lpf2pSv", static_cast<int>(sfz::kFilterLpf2pSv));
+    cbTypes->addItem("Hpf2pSv", static_cast<int>(sfz::kFilterHpf2pSv));
+    cbTypes->addItem("Bpf2pSv", static_cast<int>(sfz::kFilterBpf2pSv));
+    cbTypes->addItem("Brf2pSv", static_cast<int>(sfz::kFilterBrf2pSv));
+    cbTypes->addItem("Lsh", static_cast<int>(sfz::kFilterLsh));
+    cbTypes->addItem("Hsh", static_cast<int>(sfz::kFilterHsh));
+    cbTypes->addItem("Peq", static_cast<int>(sfz::kFilterPeq));
+
+    cbTypes->setCurrentIndex(cbTypes->findData(fType));
+    fUi.lcdType->display(fType);
+
+    connect(
+        cbTypes, QOverload<int>::of(&QComboBox::currentIndexChanged),
+        this, [this, cbTypes](int index) { valueChangedType(cbTypes->itemData(index).toInt()); });
+
+    fUi.dialCutoff->setRange(cutoffMin, cutoffMax);
+    fUi.dialResonance->setRange(resoMin, resoMax);
+    fUi.dialPkShGain->setRange(pkshMin, pkshMax);
+    fUi.dialBandwidth->setRange(bwMin, bwMax);
+    fUi.spinCutoff->setRange(cutoffMin, cutoffMax);
+    fUi.spinResonance->setRange(resoMin, resoMax);
+    fUi.spinPkShGain->setRange(pkshMin, pkshMax);
+    fUi.spinBandwidth->setRange(bwMin, bwMax);
+
+    fUi.dialCutoff->setValue(fCutoff);
+    fUi.dialResonance->setValue(fReso);
+    fUi.dialPkShGain->setValue(fPksh);
+    fUi.dialBandwidth->setValue(fBw);
+    fUi.spinCutoff->setValue(fCutoff);
+    fUi.spinResonance->setValue(fReso);
+    fUi.spinPkShGain->setValue(fPksh);
+    fUi.spinBandwidth->setValue(fBw);
+
+    connect(
+        fUi.dialCutoff, &QDial::valueChanged,
+        this, [this](int value) { valueChangedCutoff(value); });
+    connect(
+        fUi.spinCutoff, QOverload<int>::of(&QSpinBox::valueChanged),
+        this, [this](int value) { valueChangedCutoff(value); });
+    connect(
+        fUi.dialResonance, &QDial::valueChanged,
+        this, [this](int value) { valueChangedResonance(value); });
+    connect(
+        fUi.spinResonance, QOverload<int>::of(&QSpinBox::valueChanged),
+        this, [this](int value) { valueChangedResonance(value); });
+    connect(
+        fUi.dialPkShGain, &QDial::valueChanged,
+        this, [this](int value) { valueChangedPkShGain(value); });
+    connect(
+        fUi.spinPkShGain, QOverload<int>::of(&QSpinBox::valueChanged),
+        this, [this](int value) { valueChangedPkShGain(value); });
+    connect(
+        fUi.dialBandwidth, &QDial::valueChanged,
+        this, [this](int value) { valueChangedBandwidth(value); });
+    connect(
+        fUi.spinBandwidth, QOverload<int>::of(&QSpinBox::valueChanged),
+        this, [this](int value) { valueChangedBandwidth(value); });
+
+    QButtonGroup *grpMode = new QButtonGroup(this);
+    grpMode->addButton(fUi.btnMultiMode, kFilterModeMulti);
+    grpMode->addButton(fUi.btnEqMode, kFilterModeEq);
+    fUi.btnMultiMode->setChecked(true);
+    grpMode->setExclusive(true);
+
+    connect(
+        grpMode, QOverload<int, bool>::of(&QButtonGroup::buttonToggled), this,
+        [this](int id, bool toggled) {
+            if (toggled)
+                valueChangedFilterMode(id);
+        });
+
+    window->adjustSize();
+    window->setFixedSize(window->size());
+
+    window->show();
+}
+
+int DemoApp::processAudio(jack_nframes_t nframes, void *cbdata)
+{
+    DemoApp *self = reinterpret_cast<DemoApp *>(cbdata);
+
+    const float *ins[2];
+    float *outs[2];
+
+    ins[0] = reinterpret_cast<float *>(jack_port_get_buffer(self->fPorts[0], nframes));
+    ins[1] = reinterpret_cast<float *>(jack_port_get_buffer(self->fPorts[1], nframes));
+    outs[0] = reinterpret_cast<float *>(jack_port_get_buffer(self->fPorts[2], nframes));
+    outs[1] = reinterpret_cast<float *>(jack_port_get_buffer(self->fPorts[3], nframes));
+
+    switch (self->fFilterMode) {
+    default:
+    case kFilterModeMulti:
+        self->fFilter.setType(static_cast<sfz::FilterType>(self->fType));
+        self->fFilter.process(ins, outs, self->fCutoff, self->fReso, self->fPksh, nframes);
+        break;
+    case kFilterModeEq:
+        self->fFilterEq.process(ins, outs, self->fCutoff, self->fBw, self->fPksh, nframes);
+        break;
+    }
+
+    return 0;
+}
+
+void DemoApp::valueChangedType(int value)
+{
+    fType = value;
+    fUi.lcdType->display(value);
+}
+
+void DemoApp::valueChangedCutoff(int value)
+{
+    fUi.dialCutoff->blockSignals(true);
+    fUi.dialCutoff->setValue(value);
+    fUi.dialCutoff->blockSignals(false);
+
+    fUi.spinCutoff->blockSignals(true);
+    fUi.spinCutoff->setValue(value);
+    fUi.spinCutoff->blockSignals(false);
+
+    fCutoff = value;
+}
+
+void DemoApp::valueChangedResonance(int value)
+{
+    fUi.dialResonance->blockSignals(true);
+    fUi.dialResonance->setValue(value);
+    fUi.dialResonance->blockSignals(false);
+
+    fUi.spinResonance->blockSignals(true);
+    fUi.spinResonance->setValue(value);
+    fUi.spinResonance->blockSignals(false);
+
+    fReso = value;
+}
+
+void DemoApp::valueChangedPkShGain(int value)
+{
+    fUi.dialPkShGain->blockSignals(true);
+    fUi.dialPkShGain->setValue(value);
+    fUi.dialPkShGain->blockSignals(false);
+
+    fUi.spinPkShGain->blockSignals(true);
+    fUi.spinPkShGain->setValue(value);
+    fUi.spinPkShGain->blockSignals(false);
+
+    fPksh = value;
+}
+
+void DemoApp::valueChangedBandwidth(int value)
+{
+    fUi.dialBandwidth->blockSignals(true);
+    fUi.dialBandwidth->setValue(value);
+    fUi.dialBandwidth->blockSignals(false);
+
+    fUi.spinBandwidth->blockSignals(true);
+    fUi.spinBandwidth->setValue(value);
+    fUi.spinBandwidth->blockSignals(false);
+
+    fBw = value;
+}
+
+void DemoApp::valueChangedFilterMode(int value)
+{
+    fUi.stackedWidget->setCurrentIndex(value);
+
+    fFilterMode = static_cast<FilterMode>(value);
+}
+
+int main(int argc, char *argv[])
+{
+    DemoApp app(argc, argv);
+
+    if (!app.initSound())
+        return 1;
+
+    app.initWindow();
+
+    return app.exec();
+}

--- a/tests/DemoFilters.ui
+++ b/tests/DemoFilters.ui
@@ -82,7 +82,7 @@
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="widget">
+      <widget class="QWidget" name="widget_2">
        <layout class="QGridLayout" name="gridLayout_3">
         <property name="leftMargin">
          <number>0</number>
@@ -120,7 +120,7 @@
          </widget>
         </item>
         <item row="0" column="1" rowspan="3">
-         <widget class="QWidget" name="widget" native="true"/>
+         <widget class="QWidget" name="widget_3" native="true"/>
         </item>
        </layout>
       </widget>

--- a/tests/DemoFilters.ui
+++ b/tests/DemoFilters.ui
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DemoFiltersWindow</class>
+ <widget class="QMainWindow" name="DemoFiltersWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>415</width>
+    <height>216</height>
+   </rect>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QGridLayout" name="gridLayout_2">
+    <item row="0" column="0">
+     <widget class="QDial" name="dialCutoff"/>
+    </item>
+    <item row="0" column="1">
+     <widget class="QDial" name="dialPkShGain"/>
+    </item>
+    <item row="0" column="2" rowspan="3">
+     <widget class="QStackedWidget" name="stackedWidget">
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QWidget" name="widget">
+       <layout class="QGridLayout" name="gridLayout">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QDial" name="dialResonance"/>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLCDNumber" name="lcdType">
+          <property name="digitCount">
+           <number>2</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QSpinBox" name="spinResonance">
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="suffix">
+           <string> dB</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="comboBox"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Resonance</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Type</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="widget">
+       <layout class="QGridLayout" name="gridLayout_3">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QDial" name="dialBandwidth"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Bandwidth</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QSpinBox" name="spinBandwidth">
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="suffix">
+           <string> oct</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1" rowspan="3">
+         <widget class="QWidget" name="widget" native="true"/>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QSpinBox" name="spinCutoff">
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+      <property name="suffix">
+       <string> Hz</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QSpinBox" name="spinPkShGain">
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+      <property name="suffix">
+       <string> dB</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>Cutoff</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="QLabel" name="label_4">
+      <property name="text">
+       <string>Peak/shelf gain</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="0" colspan="3">
+     <widget class="QFrame" name="frame">
+      <property name="frameShape">
+       <enum>QFrame::StyledPanel</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="btnMultiMode">
+         <property name="text">
+          <string>Multi-mode</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="btnEqMode">
+         <property name="text">
+          <string>Equalizer</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Filter interface without use of templates.
Mono and stereo are instanciated within a single object. (cf. setChannels)

Add the filter demo program as Jack-Qt client.
It's to check everything to be OK after changes.

Also, the demo program supports the `FilterEq`.