### PR TITLE
Fast pan with lookup table

### DIFF
--- a/src/sfizz/SIMDHelpers.h
+++ b/src/sfizz/SIMDHelpers.h
@@ -746,7 +746,7 @@ namespace _internals {
     inline void snippetPan(const T*& pan, T*& left, T*& right)
     {
         T p = ((*pan++) + T{1.0}) * T{0.5};
-        p = std::max<T>(0, std::min<T>(p, 1));
+        p = clamp<T>(p, 0, 1);
 
         auto lookUp = [](T pan) -> T
         {

--- a/src/sfizz/SIMDHelpers.h
+++ b/src/sfizz/SIMDHelpers.h
@@ -43,6 +43,7 @@
 #include "MathHelpers.h"
 #include <absl/algorithm/container.h>
 #include <absl/types/span.h>
+#include <array>
 #include <cmath>
 
 namespace sfz {


### PR DESCRIPTION
Make the pan function fast by tabulating the computation.

```
2020-02-08 20:18:05
Running ./build/benchmarks/bm_pan
Run on (8 X 3600 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 64K (x4)
  L2 Unified 512K (x4)
  L3 Unified 4096K (x1)
Load Average: 0.30, 0.44, 0.48
-----------------------------------------------------------------
Benchmark                       Time             CPU   Iterations
-----------------------------------------------------------------
PanArray/Scalar/4            9.49 ns         9.46 ns     71346449
PanArray/Scalar/16           41.2 ns         41.1 ns     17006257
PanArray/Scalar/64            153 ns          152 ns      4580605
PanArray/Scalar/256           601 ns          599 ns      1152500
PanArray/Scalar/1024         2386 ns         2379 ns       292343
PanArray/Scalar/4096         9779 ns         9748 ns        68576
PanArray/SIMD/4              42.5 ns         42.3 ns     50103003
PanArray/SIMD/16             97.9 ns         97.6 ns      7548050
PanArray/SIMD/64              375 ns          374 ns      1894586
PanArray/SIMD/256            1338 ns         1333 ns       516654
PanArray/SIMD/1024           5831 ns         5811 ns       131457
PanArray/SIMD/4096          22563 ns        22489 ns        32169
PanArray/BlockOps/4          66.2 ns         66.0 ns     10550550
PanArray/BlockOps/16          175 ns          175 ns      4007112
PanArray/BlockOps/64          649 ns          647 ns      1067034
PanArray/BlockOps/256        2443 ns         2436 ns       287942
PanArray/BlockOps/1024       9497 ns         9469 ns        73633
PanArray/BlockOps/4096      38080 ns        37968 ns        18362
```