### PR TITLE
Benchmarks

### DIFF
--- a/benchmarks/BM.h
+++ b/benchmarks/BM.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include "ScopedFTZ.h"
+#include <benchmark/benchmark.h>
+
+/**
+   Override the benchmark entry point to disable the denormals on entry.
+ */
+#undef BENCHMARK_MAIN
+#define BENCHMARK_MAIN()                                            \
+    int main(int argc, char** argv) {                               \
+        ::benchmark::Initialize(&argc, argv);                       \
+        if (::benchmark::ReportUnrecognizedArguments(argc, argv))   \
+            return 1;                                               \
+        ScopedFTZ ftz;                                              \
+        ::benchmark::RunSpecifiedBenchmarks();                      \
+    }                                                               \
+    int main(int, char**)

--- a/benchmarks/BM_ADSR.cpp
+++ b/benchmarks/BM_ADSR.cpp
@@ -6,7 +6,7 @@
 
 #include "Config.h"
 #include "ADSREnvelope.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <algorithm>
 #include <random>
 #include <numeric>

--- a/benchmarks/BM_OPF_high_vs_low.cpp
+++ b/benchmarks/BM_OPF_high_vs_low.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "Config.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <absl/types/span.h>
 #include <random>
 #include <algorithm>

--- a/benchmarks/BM_add.cpp
+++ b/benchmarks/BM_add.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <random>
 #include <numeric>
 #include <vector>

--- a/benchmarks/BM_copy.cpp
+++ b/benchmarks/BM_copy.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <random>
 #include <numeric>
 #include <vector>

--- a/benchmarks/BM_cumsum.cpp
+++ b/benchmarks/BM_cumsum.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <random>
 #include <numeric>
 #include <vector>

--- a/benchmarks/BM_diff.cpp
+++ b/benchmarks/BM_diff.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <random>
 #include <numeric>
 #include <vector>

--- a/benchmarks/BM_divide.cpp
+++ b/benchmarks/BM_divide.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <random>
 #include <numeric>
 #include <vector>

--- a/benchmarks/BM_envelopes.cpp
+++ b/benchmarks/BM_envelopes.cpp
@@ -4,7 +4,7 @@
 // license. You should have receive a LICENSE.md file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <random>
 #include <numeric>
 #include <vector>

--- a/benchmarks/BM_fill.cpp
+++ b/benchmarks/BM_fill.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include "Buffer.h"
 #include <algorithm>
 #include <random>

--- a/benchmarks/BM_flacfile.cpp
+++ b/benchmarks/BM_flacfile.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "Buffer.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <sndfile.hh>
 #define DR_FLAC_IMPLEMENTATION
 #include "dr_flac.h"

--- a/benchmarks/BM_gain.cpp
+++ b/benchmarks/BM_gain.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <random>
 #include <numeric>
 #include <vector>

--- a/benchmarks/BM_interpolationCast.cpp
+++ b/benchmarks/BM_interpolationCast.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <vector>
 #include <random>
 #include <numeric>

--- a/benchmarks/BM_looping.cpp
+++ b/benchmarks/BM_looping.cpp
@@ -4,7 +4,7 @@
 // license. You should have receive a LICENSE.md file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include "SIMDHelpers.h"
 #include <vector>
 #include <random>

--- a/benchmarks/BM_mathfuns.cpp
+++ b/benchmarks/BM_mathfuns.cpp
@@ -6,7 +6,7 @@
 
 #include "SIMDHelpers.h"
 #include "absl/types/span.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <cmath>
 #include <iostream>
 #include <numeric>

--- a/benchmarks/BM_mean.cpp
+++ b/benchmarks/BM_mean.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <cmath>
 #include <iostream>
 #include <numeric>

--- a/benchmarks/BM_meanSquared.cpp
+++ b/benchmarks/BM_meanSquared.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <cmath>
 #include <iostream>
 #include <numeric>

--- a/benchmarks/BM_multiplyAdd.cpp
+++ b/benchmarks/BM_multiplyAdd.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <random>
 #include <numeric>
 #include <vector>

--- a/benchmarks/BM_pan.cpp
+++ b/benchmarks/BM_pan.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <random>
 #include <numeric>
 #include <vector>

--- a/benchmarks/BM_pointerIterationOrOffsets.cpp
+++ b/benchmarks/BM_pointerIterationOrOffsets.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <random>
 #include <absl/algorithm/container.h>
 #include "absl/types/span.h"

--- a/benchmarks/BM_ramp.cpp
+++ b/benchmarks/BM_ramp.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <random>
 #include "Buffer.h"
 

--- a/benchmarks/BM_readChunk.cpp
+++ b/benchmarks/BM_readChunk.cpp
@@ -6,7 +6,7 @@
 
 #include "SIMDHelpers.h"
 #include "Buffer.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <sndfile.hh>
 #include "ghc/filesystem.hpp"
 #define DR_WAV_IMPLEMENTATION

--- a/benchmarks/BM_readInterleaved.cpp
+++ b/benchmarks/BM_readInterleaved.cpp
@@ -6,7 +6,7 @@
 
 #include "SIMDHelpers.h"
 #include "Buffer.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <algorithm>
 #include <numeric>
 #include <absl/types/span.h>

--- a/benchmarks/BM_resample.cpp
+++ b/benchmarks/BM_resample.cpp
@@ -7,7 +7,7 @@
 #include "Buffer.h"
 #include "AudioBuffer.h"
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <memory>
 #include <samplerate.h>
 #include <sndfile.hh>

--- a/benchmarks/BM_resampleChunk.cpp
+++ b/benchmarks/BM_resampleChunk.cpp
@@ -6,7 +6,7 @@
 
 #include "Buffer.h"
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <sndfile.hh>
 #include "ghc/filesystem.hpp"
 #include "Oversampler.h"

--- a/benchmarks/BM_saturating.cpp
+++ b/benchmarks/BM_saturating.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <vector>
 #include <random>
 #include <numeric>

--- a/benchmarks/BM_subtract.cpp
+++ b/benchmarks/BM_subtract.cpp
@@ -5,7 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <random>
 #include <numeric>
 #include <vector>

--- a/benchmarks/BM_wavfile.cpp
+++ b/benchmarks/BM_wavfile.cpp
@@ -4,7 +4,7 @@
 // license. You should have receive a LICENSE.md file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 #include "Buffer.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <sndfile.hh>
 #define DR_WAV_IMPLEMENTATION
 #include "dr_wav.h"

--- a/benchmarks/BM_writeInterleaved.cpp
+++ b/benchmarks/BM_writeInterleaved.cpp
@@ -6,7 +6,7 @@
 
 #include "SIMDHelpers.h"
 #include "Buffer.h"
-#include <benchmark/benchmark.h>
+#include "BM.h"
 #include <algorithm>
 #include <numeric>
 #include <absl/types/span.h>

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -2,123 +2,58 @@ project(sfizz)
 
 # Check SIMD
 include (SfizzSIMDSourceFilesCheck)
-set(BENCHMARK_SIMD_SOURCES ${SFIZZ_SIMD_SOURCES})
-list(TRANSFORM BENCHMARK_SIMD_SOURCES PREPEND "../src/")
 find_package(benchmark CONFIG REQUIRED)
 
-add_executable(bm_opf_high_vs_low BM_OPF_high_vs_low.cpp)
-target_link_libraries(bm_opf_high_vs_low PRIVATE absl::span benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_opf_high_vs_low PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_write BM_writeInterleaved.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_write PRIVATE absl::span benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_write PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_read BM_readInterleaved.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_read PRIVATE absl::span benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_read PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_fill BM_fill.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_fill PRIVATE absl::span benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_fill PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_mathfuns BM_mathfuns.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_mathfuns PRIVATE absl::span benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_mathfuns PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_gain BM_gain.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_gain PRIVATE absl::span benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_gain PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_divide BM_divide.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_divide PRIVATE absl::span benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_divide PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_looping BM_looping.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_looping PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_looping PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_saturating BM_saturating.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_saturating PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_saturating PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_ramp BM_ramp.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_ramp PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_ramp PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_ADSR BM_ADSR.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_ADSR PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_ADSR PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_add BM_add.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_add PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_add PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_multiplyAdd BM_multiplyAdd.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_multiplyAdd PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_multiplyAdd PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_subtract BM_subtract.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_subtract PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_subtract PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_copy BM_copy.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_copy PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_copy PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_pan BM_pan.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_pan PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_pan PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_mean BM_mean.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_mean PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_mean PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_meanSquared BM_meanSquared.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_meanSquared PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_meanSquared PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_cumsum BM_cumsum.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_cumsum PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_cumsum PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_diff BM_diff.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_diff PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_diff PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_interpolationCast BM_interpolationCast.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_interpolationCast PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_interpolationCast PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_pointerIterationOrOffsets BM_pointerIterationOrOffsets.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_pointerIterationOrOffsets PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_pointerIterationOrOffsets PRIVATE ../src/sfizz ../src/external)
-
-if (NOT WIN32)
-	add_executable(bm_resample BM_resample.cpp ${BENCHMARK_SIMD_SOURCES})
-	target_link_libraries(bm_resample PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main samplerate sfizz-sndfile)
-	target_include_directories(bm_resample PRIVATE ../src/sfizz ../src/external)
+# Check libsamplerate
+find_library(SAMPLERATE_LIBRARY "samplerate")
+find_path(SAMPLERATE_INCLUDE_DIR "samplerate.h")
+message(STATUS "Checking samplerate library: ${SAMPLERATE_LIBRARY}")
+message(STATUS "Checking samplerate includes: ${SAMPLERATE_INCLUDE_DIR}")
+if(SAMPLERATE_LIBRARY AND SAMPLERATE_INCLUDE_DIR)
+    add_library(sfizz-samplerate INTERFACE)
+    target_include_directories(sfizz-samplerate INTERFACE "${SAMPLERATE_INCLUDE_DIR}")
+    target_link_libraries(sfizz-samplerate INTERFACE "${SAMPLERATE_LIBRARY}")
 endif()
 
-add_executable(bm_envelopes BM_envelopes.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_envelopes PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main)
-target_include_directories(bm_envelopes PRIVATE ../src/sfizz ../src/external)
+macro(sfizz_add_benchmark TARGET)
+	add_executable("${TARGET}" ${ARGN})
+	target_link_libraries("${TARGET}" PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main sfizz_static)
+	target_include_directories("${TARGET}" PRIVATE ../src/sfizz ../src/external)
+endmacro()
 
-add_executable(bm_wavfile BM_wavfile.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_wavfile PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main sfizz-sndfile)
-target_include_directories(bm_wavfile PRIVATE ../src/sfizz ../src/external)
+sfizz_add_benchmark(bm_opf_high_vs_low BM_OPF_high_vs_low.cpp)
+sfizz_add_benchmark(bm_write BM_writeInterleaved.cpp)
+sfizz_add_benchmark(bm_read BM_readInterleaved.cpp)
+sfizz_add_benchmark(bm_fill BM_fill.cpp)
+sfizz_add_benchmark(bm_mathfuns BM_mathfuns.cpp)
+sfizz_add_benchmark(bm_gain BM_gain.cpp)
+sfizz_add_benchmark(bm_divide BM_divide.cpp)
+sfizz_add_benchmark(bm_looping BM_looping.cpp)
+sfizz_add_benchmark(bm_saturating BM_saturating.cpp)
+sfizz_add_benchmark(bm_ramp BM_ramp.cpp)
+sfizz_add_benchmark(bm_ADSR BM_ADSR.cpp)
+sfizz_add_benchmark(bm_add BM_add.cpp)
+sfizz_add_benchmark(bm_multiplyAdd BM_multiplyAdd.cpp)
+sfizz_add_benchmark(bm_subtract BM_subtract.cpp)
+sfizz_add_benchmark(bm_copy BM_copy.cpp)
+sfizz_add_benchmark(bm_pan BM_pan.cpp)
+sfizz_add_benchmark(bm_mean BM_mean.cpp)
+sfizz_add_benchmark(bm_meanSquared BM_meanSquared.cpp)
+sfizz_add_benchmark(bm_cumsum BM_cumsum.cpp)
+sfizz_add_benchmark(bm_diff BM_diff.cpp)
+sfizz_add_benchmark(bm_interpolationCast BM_interpolationCast.cpp)
+sfizz_add_benchmark(bm_pointerIterationOrOffsets BM_pointerIterationOrOffsets.cpp)
 
-add_executable(bm_flacfile BM_flacfile.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_flacfile PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main sfizz-sndfile)
-target_include_directories(bm_flacfile PRIVATE ../src/sfizz ../src/external)
+if (TARGET sfizz-samplerate)
+	sfizz_add_benchmark(bm_resample BM_resample.cpp)
+	target_link_libraries(bm_resample PRIVATE sfizz-samplerate)
+endif()
 
-add_executable(bm_readChunk BM_readChunk.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_readChunk PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main sfizz-sndfile)
-target_include_directories(bm_readChunk PRIVATE ../src/sfizz ../src/external)
-
-add_executable(bm_resampleChunk BM_resampleChunk.cpp ${BENCHMARK_SIMD_SOURCES})
-target_link_libraries(bm_resampleChunk PRIVATE absl::span absl::algorithm benchmark::benchmark benchmark::benchmark_main sfizz-sndfile)
-target_include_directories(bm_resampleChunk PRIVATE ../src/sfizz ../src/external)
+sfizz_add_benchmark(bm_envelopes BM_envelopes.cpp)
+sfizz_add_benchmark(bm_wavfile BM_wavfile.cpp)
+sfizz_add_benchmark(bm_flacfile BM_flacfile.cpp)
+sfizz_add_benchmark(bm_readChunk BM_readChunk.cpp)
+sfizz_add_benchmark(bm_resampleChunk BM_resampleChunk.cpp)
 
 add_custom_target(sfizz_benchmarks)
 add_dependencies(sfizz_benchmarks
@@ -150,7 +85,7 @@ add_dependencies(sfizz_benchmarks
 	bm_flacfile
 )
 
-if (NOT WIN32)
+if (TARGET bm_resample)
 	add_dependencies(sfizz_benchmarks bm_resample)
 endif()
 

--- a/src/sfizz/ScopedFTZ.h
+++ b/src/sfizz/ScopedFTZ.h
@@ -4,6 +4,8 @@
 // license. You should have receive a LICENSE.md file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
+#pragma once
+
 /**
  * @brief Flush floating points to zero and disable denormals as an RAII helper.
  *


### PR DESCRIPTION
This provides use of ScopedFTZ for the benchmarks.
I redefine `BENCHMARK_MAIN` to enable it globally. I'm not aware of a better way.

ScopedFTZ code is not linked by benchmarks, so it can be a problem.

I have decided to modify the benchmark cmakelists and make vast simplifications.
- eliminated lots of redundancy
- link sfizz_static from all benchmarks ; enables to test any individual part ; also pulls sndfile
- proper check of libsamplerate independent of target
