### PR TITLE
Fix Sfizz crash in Ardour when no file is loaded

### DIFF
--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -708,6 +708,9 @@ fs::file_time_type sfz::Synth::checkModificationTime()
 {
     auto returnedTime = modificationTime;
     for (auto file: getIncludedFiles()) {
+        if (file.empty()) {
+            return fs::file_time_type::min();
+            }
         const auto fileTime = fs::last_write_time(file);
         if (returnedTime < fileTime)
             returnedTime = fileTime;


### PR DESCRIPTION
stop sfizz from crashing host (ardour) if no SFZ file is loaded and project is reloaded