### PR TITLE
Add floating point helpers, and the fast ilog2

### DIFF
--- a/benchmarks/BM_mathfuns.cpp
+++ b/benchmarks/BM_mathfuns.cpp
@@ -22,6 +22,7 @@ public:
         std::uniform_real_distribution<float> dist { 0.1f, 1.0f };
         source = std::vector<float>(state.range(0));
         result = std::vector<float>(state.range(0));
+        intResult = std::vector<int>(state.range(0));
         std::generate(source.begin(), source.end(), [&]() { return dist(gen); });
     }
 
@@ -31,6 +32,7 @@ public:
 
     std::vector<float> source;
     std::vector<float> result;
+    std::vector<int> intResult;
 };
 
 BENCHMARK_DEFINE_F(MyFixture, Dummy)
@@ -133,6 +135,29 @@ BENCHMARK_DEFINE_F(MyFixture, SIMDCos)
     }
 }
 
+BENCHMARK_DEFINE_F(MyFixture, ScalarLibmFloorLog2)
+(benchmark::State& state)
+{
+    for (auto _ : state) {
+        for (size_t i = 0, n = source.size(); i < n; ++i) {
+            intResult[i] = static_cast<int>(
+                std::floor(std::log2(std::fabs(source[i]))));
+        }
+        benchmark::DoNotOptimize(intResult);
+    }
+}
+
+BENCHMARK_DEFINE_F(MyFixture, ScalarFastFloorLog2)
+(benchmark::State& state)
+{
+    for (auto _ : state) {
+        for (size_t i = 0, n = source.size(); i < n; ++i) {
+            intResult[i] = fp_exponent(source[i]);
+        }
+        benchmark::DoNotOptimize(intResult);
+    }
+}
+
 BENCHMARK_REGISTER_F(MyFixture, Dummy)->RangeMultiplier(4)->Range(1 << 6, 1 << 10);
 BENCHMARK_REGISTER_F(MyFixture, ScalarExp)->RangeMultiplier(4)->Range(1 << 6, 1 << 10);
 BENCHMARK_REGISTER_F(MyFixture, SIMDExp)->RangeMultiplier(4)->Range(1 << 6, 1 << 10);
@@ -144,5 +169,7 @@ BENCHMARK_REGISTER_F(MyFixture, ScalarSin)->RangeMultiplier(4)->Range(1 << 6, 1 
 BENCHMARK_REGISTER_F(MyFixture, SIMDSin)->RangeMultiplier(4)->Range(1 << 6, 1 << 10);
 BENCHMARK_REGISTER_F(MyFixture, ScalarCos)->RangeMultiplier(4)->Range(1 << 6, 1 << 10);
 BENCHMARK_REGISTER_F(MyFixture, SIMDCos)->RangeMultiplier(4)->Range(1 << 6, 1 << 10);
+BENCHMARK_REGISTER_F(MyFixture, ScalarLibmFloorLog2)->RangeMultiplier(4)->Range(1 << 6, 1 << 10);
+BENCHMARK_REGISTER_F(MyFixture, ScalarFastFloorLog2)->RangeMultiplier(4)->Range(1 << 6, 1 << 10);
 
 BENCHMARK_MAIN();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SFIZZ_TEST_SOURCES
     MainT.cpp
     SynthT.cpp
     RegionTriggersT.cpp
+    FloatHelpersT.cpp
 )
 
 add_executable(sfizz_tests ${SFIZZ_TEST_SOURCES})

--- a/tests/FloatHelpersT.cpp
+++ b/tests/FloatHelpersT.cpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "catch2/catch.hpp"
+#include "sfizz/MathHelpers.h"
+#include <cmath>
+
+TEST_CASE("[FloatMath] Fast ilog2 (float)")
+{
+    for (float x = -100.0f; x < +100.0f; x += 0.01f) {
+        int ex1 = fp_exponent(x);
+        int ex2 = static_cast<int>(std::floor(std::log2(std::fabs(x))));
+        REQUIRE(ex1 == ex2);
+    }
+}
+
+TEST_CASE("[FloatMath] Fast ilog2 (double)")
+{
+    for (double x = -100.0; x < +100.0; x += 0.01) {
+        int ex1 = fp_exponent(x);
+        int ex2 = static_cast<int>(std::floor(std::log2(std::fabs(x))));
+        REQUIRE(ex1 == ex2);
+    }
+}
+
+TEST_CASE("[FloatMath] Break apart and reconstruct (float)")
+{
+    for (int p = 0; p < 128; ++p) {
+        float f = 440.0 * std::pow(2.0, (p - 69.0) / 12.0);
+
+        bool sgn = fp_sign(f);
+        int ex = fp_exponent(f);
+        Fraction<uint64_t> mant = fp_mantissa(f);
+
+        REQUIRE(fp_from_parts<float>(sgn, ex, mant.num) == f);
+    }
+}
+
+TEST_CASE("[FloatMath] Break apart and reconstruct (double)")
+{
+    for (int p = 0; p < 128; ++p) {
+        double f = 440.0 * std::pow(2.0, (p - 69.0) / 12.0);
+
+        bool sgn = fp_sign(f);
+        int ex = fp_exponent(f);
+        Fraction<uint64_t> mant = fp_mantissa(f);
+
+        REQUIRE(fp_from_parts<double>(sgn, ex, mant.num) == f);
+    }
+}


### PR DESCRIPTION
This adds some utility functions which permits to work with floating point at bits level.

The purpose is to implement fast logarithm base 2 with integer result.

I think of using this helper for implementing more efficient oscillator wavetables later.
Here is an article from a series on this topic.
https://www.earlevel.com/main/2012/05/09/a-wavetable-oscillator-part-3/

The motivation is because the variable-rate resampler is not really fit for big changes of pitch that would be necessary for a single wavetable. As such, I think to go with the multisamples as in the article, and moreover this makes lerp reasonable using this method.

When pitch is changed under this method, there is potentially a need to jump between multiple tables to lookup from. Tables are searched by pitch ; it's in this case where log2 in just a couple instructions becomes useful.

The variable-rate resampler will be reserved for non-oscillator cases.

Includes test and benchmark (here a speedup around factor 10)