### PR TITLE
Filter smoothing

### DIFF
--- a/src/sfizz/dsp/filters/filters_modulable.dsp
+++ b/src/sfizz/dsp/filters/filters_modulable.dsp
@@ -66,7 +66,8 @@ ap1Smooth(s,f) = fi.iir((a,1.),(a)) with {
 //------------------------------------------------------------------------------
 // Example
 //------------------------------------------------------------------------------
-// process = rbjLpfSmooth(si.smoo, cutoff, 0.0, resonance : ba.db2linear) with {
-//   cutoff = hslider("[1] Cutoff [unit:Hz] [scale:log]", 440.0, 50.0, 10000.0, 1.0);
-//   resonance = hslider("[2] Resonance [unit:dB]", 0.0, 0.0, 40.0, 0.1);
-// };
+process = rbjPeakingEqSmooth(si.smooth(ba.tau2pole(0.001)), cutoff, gain, resonance) with {
+  cutoff = hslider("[1] Cutoff [unit:Hz] [scale:log]", 50.0, 50.0, 10000.0, 1.0);
+    resonance = hslider("[2] Resonance [unit:dB]", 1.0, 0.0, 40.0, 0.1);
+	gain = hslider("[2] gain [unit:dB]", 1.0, -80.0, 80.0, 0.1);
+ };

--- a/src/sfizz/dsp/filters/filters_modulable.dsp
+++ b/src/sfizz/dsp/filters/filters_modulable.dsp
@@ -62,12 +62,3 @@ hp1Smooth(s,f) = fi.iir((0.5*(1.+p),-0.5*(1+p)),(0.-p)) with {
 ap1Smooth(s,f) = fi.iir((a,1.),(a)) with {
   a = (-1.+2.*ma.PI*f/ma.SR) : s;
 };
-
-//------------------------------------------------------------------------------
-// Example
-//------------------------------------------------------------------------------
-process = rbjPeakingEqSmooth(si.smooth(ba.tau2pole(0.001)), cutoff, gain, resonance) with {
-  cutoff = hslider("[1] Cutoff [unit:Hz] [scale:log]", 50.0, 50.0, 10000.0, 1.0);
-    resonance = hslider("[2] Resonance [unit:dB]", 1.0, 0.0, 40.0, 0.1);
-	gain = hslider("[2] gain [unit:dB]", 1.0, -80.0, 80.0, 0.1);
- };

--- a/src/sfizz/dsp/filters/sfz_filters.dsp
+++ b/src/sfizz/dsp/filters/sfz_filters.dsp
@@ -15,6 +15,9 @@ sfzNoise = no.noise : *(0.25);
 
 //==============================================================================
 // Filters
+// To generate a specific filter from this file, use:
+//      faust2jack -double -pn sfzPeq src/sfizz/dsp/filters/sfz_filters.dsp
+// and replace sfzPeq by the filter you want
 
 // the SFZ lowpass 1-pole filter
 sfzLpf1p = fm.lp1Smooth(smoothCoefs,cutoff);

--- a/src/sfizz/dsp/filters/sfz_filters.dsp
+++ b/src/sfizz/dsp/filters/sfz_filters.dsp
@@ -133,4 +133,14 @@ pkShGain = vslider("[03] Peak/shelf gain [unit:dB]", 0.0, 0.0, 40.0, 0.1);
 bandwidth = vslider("[04] Bandwidth [unit:octave]", 1.0, 0.1, 10.0, 0.01);
 
 // smoothing function to prevent fast changes of filter coefficients
-smoothCoefs = si.smoo; // TODO check if this is appropriate otherwise replace
+// The basic si.smoo is a bit longish and creates strange modulation sounds
+// The smoothing coefficients seem to start at 0, and thus there's a small
+// time where the coefficients go e.g. from 0 to cutoff.
+// smoothCoefs = si.smoo;
+
+// The below line uses no smoothing at all. This could require smoothing in code
+// done on the filter parameters rather than directly on the biquad's coefficients.
+// smoothCoefs = _ ; // No smoothing applied at all
+
+// This applies a quicker smoothing but which may render the filter unstable
+smoothCoefs = si.smooth(ba.tau2pole(0.001)) ; // time constant = 1ms

--- a/src/sfizz/gen/filters/sfz2chApf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chApf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chApf1p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chApf1p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faust2chApf1p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec1[2];
 	double fRec0[2];
@@ -45,13 +47,15 @@ class faust2chApf1p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -64,12 +68,14 @@ class faust2chApf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -82,40 +88,53 @@ class faust2chApf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec0[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec2[l2] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -125,10 +144,12 @@ class faust2chApf1p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -136,11 +157,11 @@ class faust2chApf1p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (0.0010000000000000009 * ((fConst0 * double(fCutoff)) + -1.0));
+		double fSlow0 = (fConst2 * ((fConst3 * double(fCutoff)) + -1.0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow0 + (0.999 * fRec1[1]));
+			fRec1[0] = (fSlow0 + (fConst1 * fRec1[1]));
 			fRec0[0] = (fTemp0 - (fRec1[0] * fRec0[1]));
 			output0[i] = FAUSTFLOAT((fRec0[1] + (fRec1[0] * fRec0[0])));
 			fRec2[0] = (fTemp1 - (fRec1[0] * fRec2[1]));
@@ -148,7 +169,9 @@ class faust2chApf1p : public sfzFilterDsp {
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBpf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBpf1p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chBpf1p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faust2chBpf1p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec2[2];
 	double fRec1[2];
@@ -47,13 +49,15 @@ class faust2chBpf1p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -66,12 +70,14 @@ class faust2chBpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -84,46 +90,61 @@ class faust2chBpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (1.0 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (1.0 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec2[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec1[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec4[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec3[l4] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -133,10 +154,12 @@ class faust2chBpf1p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -144,18 +167,18 @@ class faust2chBpf1p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (0.0010000000000000009 * std::exp((fConst0 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
+		double fSlow0 = (fConst2 * std::exp((fConst3 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec2[0] = (fSlow0 + (0.999 * fRec2[1]));
-			fRec1[0] = (fTemp0 + (fRec2[0] * fRec1[1]));
+			fRec2[0] = (fSlow0 + (fConst1 * fRec2[1]));
+			fRec1[0] = ((fRec2[0] * fRec1[1]) + fTemp0);
 			double fTemp2 = (1.0 - fRec2[0]);
 			fRec0[0] = ((fRec1[0] * fTemp2) + (fRec2[0] * fRec0[1]));
 			double fTemp3 = (fRec2[0] + 1.0);
 			double fTemp4 = (0.0 - (0.5 * fTemp3));
 			output0[i] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp3)) + (fRec0[1] * fTemp4)));
-			fRec4[0] = (fTemp1 + (fRec2[0] * fRec4[1]));
+			fRec4[0] = ((fRec2[0] * fRec4[1]) + fTemp1);
 			fRec3[0] = ((fRec4[0] * fTemp2) + (fRec2[0] * fRec3[1]));
 			output1[i] = FAUSTFLOAT(((0.5 * (fRec3[0] * fTemp3)) + (fTemp4 * fRec3[1])));
 			fRec2[1] = fRec2[0];
@@ -163,7 +186,9 @@ class faust2chBpf1p : public sfzFilterDsp {
 			fRec0[1] = fRec0[0];
 			fRec4[1] = fRec4[0];
 			fRec3[1] = fRec3[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBpf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBpf2p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chBpf2p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,13 +30,17 @@ class faust2chBpf2p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec1[2];
 	double fRec2[2];
 	double fRec0[3];
+	double fConst4;
 	double fRec3[2];
 	double fRec4[2];
 	double fRec5[2];
@@ -50,13 +53,15 @@ class faust2chBpf2p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -69,12 +74,14 @@ class faust2chBpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -87,53 +94,71 @@ class faust2chBpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (0.5 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec6[l6] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -143,10 +168,12 @@ class faust2chBpf2p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -154,25 +181,25 @@ class faust2chBpf2p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::sin(fSlow0);
 		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow3 = (0.5 * (fSlow1 / fSlow2));
 		double fSlow4 = (fSlow3 + 1.0);
-		double fSlow5 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
-		double fSlow6 = (0.0010000000000000009 * ((1.0 - fSlow3) / fSlow4));
-		double fSlow7 = (fSlow1 / (fSlow2 * fSlow4));
-		double fSlow8 = (0.00050000000000000044 * fSlow7);
-		double fSlow9 = (0.0010000000000000009 * (0.0 - (0.5 * fSlow7)));
+		double fSlow5 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
+		double fSlow6 = (fConst2 * ((1.0 - fSlow3) / fSlow4));
+		double fSlow7 = (fSlow1 / (fSlow4 * fSlow2));
+		double fSlow8 = (fConst4 * fSlow7);
+		double fSlow9 = (fConst2 * (0.0 - (0.5 * fSlow7)));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow5 + (0.999 * fRec1[1]));
-			fRec2[0] = (fSlow6 + (0.999 * fRec2[1]));
+			fRec1[0] = (fSlow5 + (fConst1 * fRec1[1]));
+			fRec2[0] = (fSlow6 + (fConst1 * fRec2[1]));
 			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow8 + (0.999 * fRec3[1]));
-			fRec4[0] = (0.999 * fRec4[1]);
-			fRec5[0] = (fSlow9 + (0.999 * fRec5[1]));
+			fRec3[0] = (fSlow8 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fConst1 * fRec4[1]);
+			fRec5[0] = (fSlow9 + (fConst1 * fRec5[1]));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec6[0] = (fTemp1 - ((fRec1[0] * fRec6[1]) + (fRec2[0] * fRec6[2])));
 			output1[i] = FAUSTFLOAT((((fRec3[0] * fRec6[0]) + (fRec4[0] * fRec6[1])) + (fRec5[0] * fRec6[2])));
@@ -185,7 +212,9 @@ class faust2chBpf2p : public sfzFilterDsp {
 			fRec5[1] = fRec5[0];
 			fRec6[2] = fRec6[1];
 			fRec6[1] = fRec6[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBpf2pSv_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chBpf2pSv
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec3[2];
 	FAUSTFLOAT fQ;
@@ -51,13 +53,15 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -70,12 +74,14 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -88,56 +94,74 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (3.1415926535897931 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec3[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec2[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec6[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
 			fRec8[l6] = 0.0;
+			
 		}
 		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
 			fRec9[l7] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -147,10 +171,12 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -158,18 +184,18 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (0.0010000000000000009 * std::tan((fConst0 * double(fCutoff))));
+		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
 		double fSlow1 = std::pow(10.0, (0.050000000000000003 * double(fQ)));
 		double fSlow2 = (1.0 / fSlow1);
-		double fSlow3 = (0.0010000000000000009 / fSlow1);
+		double fSlow3 = (fConst2 / fSlow1);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec3[0] = (fSlow0 + (0.999 * fRec3[1]));
+			fRec3[0] = (fSlow0 + (fConst1 * fRec3[1]));
 			double fTemp2 = (fSlow2 + fRec3[0]);
-			fRec4[0] = ((0.999 * fRec4[1]) + (0.0010000000000000009 / ((fRec3[0] * fTemp2) + 1.0)));
+			fRec4[0] = ((fConst1 * fRec4[1]) + (fConst2 / ((fRec3[0] * fTemp2) + 1.0)));
 			double fTemp3 = (fRec3[0] * fRec4[0]);
-			fRec5[0] = ((0.999 * fRec5[1]) + (0.0010000000000000009 * fTemp2));
+			fRec5[0] = ((fConst1 * fRec5[1]) + (fConst2 * fTemp2));
 			double fTemp4 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fTemp5 = (fTemp3 * fTemp4);
 			double fTemp6 = (fRec2[1] + fTemp5);
@@ -177,7 +203,7 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 			fRec1[0] = (fRec1[1] + (2.0 * (fRec3[0] * fTemp6)));
 			double fTemp7 = (fRec2[1] + (2.0 * fTemp5));
 			fRec2[0] = fTemp7;
-			fRec6[0] = (fSlow3 + (0.999 * fRec6[1]));
+			fRec6[0] = (fSlow3 + (fConst1 * fRec6[1]));
 			output0[i] = FAUSTFLOAT((fRec0 * fRec6[0]));
 			double fTemp8 = (fTemp1 - (fRec8[1] + (fRec5[0] * fRec9[1])));
 			double fTemp9 = (fTemp3 * fTemp8);
@@ -195,7 +221,9 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 			fRec6[1] = fRec6[0];
 			fRec8[1] = fRec8[0];
 			fRec9[1] = fRec9[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBpf4p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf4p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBpf4p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chBpf4p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,12 @@ class faust2chBpf4p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
+	double fConst4;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
@@ -52,13 +55,15 @@ class faust2chBpf4p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -71,12 +76,14 @@ class faust2chBpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -89,59 +96,79 @@ class faust2chBpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (0.5 * fConst2);
+		fConst4 = (6.2831853071795862 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec4[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec5[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec6[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec1[l6] = 0.0;
+			
 		}
 		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
 			fRec8[l7] = 0.0;
+			
 		}
 		for (int l8 = 0; (l8 < 3); l8 = (l8 + 1)) {
 			fRec7[l8] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -151,10 +178,12 @@ class faust2chBpf4p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -162,25 +191,25 @@ class faust2chBpf4p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst4 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::sin(fSlow0);
 		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow3 = (0.5 * (fSlow1 / fSlow2));
 		double fSlow4 = (fSlow3 + 1.0);
-		double fSlow5 = (fSlow1 / (fSlow2 * fSlow4));
-		double fSlow6 = (0.00050000000000000044 * fSlow5);
-		double fSlow7 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
-		double fSlow8 = (0.0010000000000000009 * ((1.0 - fSlow3) / fSlow4));
-		double fSlow9 = (0.0010000000000000009 * (0.0 - (0.5 * fSlow5)));
+		double fSlow5 = (fSlow1 / (fSlow4 * fSlow2));
+		double fSlow6 = (fConst3 * fSlow5);
+		double fSlow7 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
+		double fSlow8 = (fConst2 * ((1.0 - fSlow3) / fSlow4));
+		double fSlow9 = (fConst2 * (0.0 - (0.5 * fSlow5)));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow6 + (0.999 * fRec0[1]));
-			fRec3[0] = (fSlow7 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow8 + (0.999 * fRec4[1]));
+			fRec0[0] = (fSlow6 + (fConst1 * fRec0[1]));
+			fRec3[0] = (fSlow7 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fSlow8 + (fConst1 * fRec4[1]));
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = (0.999 * fRec5[1]);
-			fRec6[0] = (fSlow9 + (0.999 * fRec6[1]));
+			fRec5[0] = (fConst1 * fRec5[1]);
+			fRec6[0] = (fSlow9 + (fConst1 * fRec6[1]));
 			fRec1[0] = ((((fRec2[0] * fRec0[0]) + (fRec5[0] * fRec2[1])) + (fRec6[0] * fRec2[2])) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec5[0] * fRec1[1])) + (fRec6[0] * fRec1[2])));
 			fRec8[0] = (fTemp1 - ((fRec3[0] * fRec8[1]) + (fRec4[0] * fRec8[2])));
@@ -199,7 +228,9 @@ class faust2chBpf4p : public sfzFilterDsp {
 			fRec8[1] = fRec8[0];
 			fRec7[2] = fRec7[1];
 			fRec7[1] = fRec7[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBpf6p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf6p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBpf6p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chBpf6p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,12 @@ class faust2chBpf6p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
+	double fConst4;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
@@ -54,13 +57,15 @@ class faust2chBpf6p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -73,12 +78,14 @@ class faust2chBpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -91,65 +98,87 @@ class faust2chBpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (0.5 * fConst2);
+		fConst4 = (6.2831853071795862 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec6[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec7[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec2[l6] = 0.0;
+			
 		}
 		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
 			fRec1[l7] = 0.0;
+			
 		}
 		for (int l8 = 0; (l8 < 3); l8 = (l8 + 1)) {
 			fRec10[l8] = 0.0;
+			
 		}
 		for (int l9 = 0; (l9 < 3); l9 = (l9 + 1)) {
 			fRec9[l9] = 0.0;
+			
 		}
 		for (int l10 = 0; (l10 < 3); l10 = (l10 + 1)) {
 			fRec8[l10] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -159,10 +188,12 @@ class faust2chBpf6p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -170,25 +201,25 @@ class faust2chBpf6p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst4 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::sin(fSlow0);
 		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow3 = (0.5 * (fSlow1 / fSlow2));
 		double fSlow4 = (fSlow3 + 1.0);
-		double fSlow5 = (fSlow1 / (fSlow2 * fSlow4));
-		double fSlow6 = (0.00050000000000000044 * fSlow5);
-		double fSlow7 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
-		double fSlow8 = (0.0010000000000000009 * ((1.0 - fSlow3) / fSlow4));
-		double fSlow9 = (0.0010000000000000009 * (0.0 - (0.5 * fSlow5)));
+		double fSlow5 = (fSlow1 / (fSlow4 * fSlow2));
+		double fSlow6 = (fConst3 * fSlow5);
+		double fSlow7 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
+		double fSlow8 = (fConst2 * ((1.0 - fSlow3) / fSlow4));
+		double fSlow9 = (fConst2 * (0.0 - (0.5 * fSlow5)));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow6 + (0.999 * fRec0[1]));
-			fRec4[0] = (fSlow7 + (0.999 * fRec4[1]));
-			fRec5[0] = (fSlow8 + (0.999 * fRec5[1]));
+			fRec0[0] = (fSlow6 + (fConst1 * fRec0[1]));
+			fRec4[0] = (fSlow7 + (fConst1 * fRec4[1]));
+			fRec5[0] = (fSlow8 + (fConst1 * fRec5[1]));
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (0.999 * fRec6[1]);
-			fRec7[0] = (fSlow9 + (0.999 * fRec7[1]));
+			fRec6[0] = (fConst1 * fRec6[1]);
+			fRec7[0] = (fSlow9 + (fConst1 * fRec7[1]));
 			fRec2[0] = ((((fRec3[0] * fRec0[0]) + (fRec6[0] * fRec3[1])) + (fRec7[0] * fRec3[2])) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = ((((fRec0[0] * fRec2[0]) + (fRec6[0] * fRec2[1])) + (fRec7[0] * fRec2[2])) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec6[0] * fRec1[1])) + (fRec7[0] * fRec1[2])));
@@ -213,7 +244,9 @@ class faust2chBpf6p : public sfzFilterDsp {
 			fRec9[1] = fRec9[0];
 			fRec8[2] = fRec8[1];
 			fRec8[1] = fRec8[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBrf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBrf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBrf1p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chBrf1p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faust2chBrf1p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec2[2];
 	double fRec1[2];
@@ -47,13 +49,15 @@ class faust2chBrf1p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -66,12 +70,14 @@ class faust2chBrf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -84,46 +90,61 @@ class faust2chBrf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec2[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec1[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec4[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec3[l4] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -133,10 +154,12 @@ class faust2chBrf1p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -144,23 +167,25 @@ class faust2chBrf1p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (0.0010000000000000009 * ((fConst0 * double(fCutoff)) + -1.0));
+		double fSlow0 = (fConst2 * ((fConst3 * double(fCutoff)) + -1.0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec2[0] = (fSlow0 + (0.999 * fRec2[1]));
+			fRec2[0] = (fSlow0 + (fConst1 * fRec2[1]));
 			fRec1[0] = (fTemp0 - (fRec2[0] * fRec1[1]));
 			fRec0[0] = (fRec1[1] + (fRec2[0] * (fRec1[0] - fRec0[1])));
-			output0[i] = FAUSTFLOAT((fTemp0 + (fRec0[1] + (fRec2[0] * fRec0[0]))));
+			output0[i] = FAUSTFLOAT(((fRec0[1] + (fRec2[0] * fRec0[0])) + fTemp0));
 			fRec4[0] = (fTemp1 - (fRec2[0] * fRec4[1]));
 			fRec3[0] = (fRec4[1] + (fRec2[0] * (fRec4[0] - fRec3[1])));
-			output1[i] = FAUSTFLOAT((fTemp1 + (fRec3[1] + (fRec2[0] * fRec3[0]))));
+			output1[i] = FAUSTFLOAT(((fRec3[1] + (fRec2[0] * fRec3[0])) + fTemp1));
 			fRec2[1] = fRec2[0];
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
 			fRec4[1] = fRec4[0];
 			fRec3[1] = fRec3[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBrf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBrf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBrf2p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chBrf2p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faust2chBrf2p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
@@ -48,13 +50,15 @@ class faust2chBrf2p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -67,12 +71,14 @@ class faust2chBrf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -85,47 +91,62 @@ class faust2chBrf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec1[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 3); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -135,10 +156,12 @@ class faust2chBrf2p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -146,20 +169,20 @@ class faust2chBrf2p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow2 = (fSlow1 + 1.0);
-		double fSlow3 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow2));
-		double fSlow4 = (0.0010000000000000009 * ((1.0 - fSlow1) / fSlow2));
-		double fSlow5 = (0.0010000000000000009 / fSlow2);
+		double fSlow3 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow2));
+		double fSlow4 = (fConst2 * ((1.0 - fSlow1) / fSlow2));
+		double fSlow5 = (fConst2 / fSlow2);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow3 + (0.999 * fRec0[1]));
+			fRec0[0] = (fSlow3 + (fConst1 * fRec0[1]));
 			double fTemp2 = (fRec0[0] * fRec1[1]);
-			fRec2[0] = (fSlow4 + (0.999 * fRec2[1]));
+			fRec2[0] = (fSlow4 + (fConst1 * fRec2[1]));
 			fRec1[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec1[2])));
-			fRec3[0] = (fSlow5 + (0.999 * fRec3[1]));
+			fRec3[0] = (fSlow5 + (fConst1 * fRec3[1]));
 			output0[i] = FAUSTFLOAT((fTemp2 + (fRec3[0] * (fRec1[0] + fRec1[2]))));
 			double fTemp3 = (fRec0[0] * fRec4[1]);
 			fRec4[0] = (fTemp1 - (fTemp3 + (fRec2[0] * fRec4[2])));
@@ -171,7 +194,9 @@ class faust2chBrf2p : public sfzFilterDsp {
 			fRec3[1] = fRec3[0];
 			fRec4[2] = fRec4[1];
 			fRec4[1] = fRec4[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBrf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chBrf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBrf2pSv_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chBrf2pSv
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec5[2];
 	FAUSTFLOAT fQ;
@@ -50,13 +52,15 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -69,12 +73,14 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -87,53 +93,70 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (3.1415926535897931 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec5[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec6[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec3[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec9[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
 			fRec10[l6] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -143,10 +166,12 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -154,15 +179,15 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (0.0010000000000000009 * std::tan((fConst0 * double(fCutoff))));
+		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
 		double fSlow1 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec5[0] = (fSlow0 + (0.999 * fRec5[1]));
+			fRec5[0] = (fSlow0 + (fConst1 * fRec5[1]));
 			double fTemp2 = (fSlow1 + fRec5[0]);
-			fRec4[0] = ((0.999 * fRec4[1]) + (0.0010000000000000009 / ((fRec5[0] * fTemp2) + 1.0)));
-			fRec6[0] = ((0.999 * fRec6[1]) + (0.0010000000000000009 * fTemp2));
+			fRec4[0] = ((fConst1 * fRec4[1]) + (fConst2 / ((fRec5[0] * fTemp2) + 1.0)));
+			fRec6[0] = ((fConst1 * fRec6[1]) + (fConst2 * fTemp2));
 			double fTemp3 = (fTemp0 - (fRec2[1] + (fRec6[0] * fRec3[1])));
 			double fRec0 = (fRec4[0] * fTemp3);
 			double fTemp4 = (fRec5[0] * fRec4[0]);
@@ -189,7 +214,9 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 			fRec3[1] = fRec3[0];
 			fRec9[1] = fRec9[0];
 			fRec10[1] = fRec10[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chEq.cxx
+++ b/src/sfizz/gen/filters/sfz2chEq.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chEq_H__
@@ -22,7 +22,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chEq
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -32,11 +31,13 @@ class faust2chEq : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
 	double fConst1;
-	FAUSTFLOAT fCutoff;
 	double fConst2;
+	double fConst3;
+	FAUSTFLOAT fCutoff;
+	double fConst4;
 	FAUSTFLOAT fBandwidth;
 	FAUSTFLOAT fPkShGain;
 	double fRec1[2];
@@ -53,13 +54,15 @@ class faust2chEq : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -72,12 +75,14 @@ class faust2chEq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -90,53 +95,68 @@ class faust2chEq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
-		fConst1 = (6.2831853071795862 / fConst0);
-		fConst2 = (2.1775860903036022 / fConst0);
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (2.1775860903036022 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fBandwidth = FAUSTFLOAT(1.0);
 		fPkShGain = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -146,10 +166,12 @@ class faust2chEq : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -158,29 +180,29 @@ class faust2chEq : public sfzFilterDsp {
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
 		double fSlow0 = std::max<double>(0.0, double(fCutoff));
-		double fSlow1 = (fConst1 * fSlow0);
+		double fSlow1 = (fConst3 * fSlow0);
 		double fSlow2 = std::sin(fSlow1);
-		double fSlow3 = std::max<double>(0.001, (0.5 / double(sinh(double((fConst2 * ((fSlow0 * double(fBandwidth)) / fSlow2)))))));
+		double fSlow3 = std::max<double>(0.001, (0.5 / double(sinh(double((fConst4 * ((fSlow0 * double(fBandwidth)) / fSlow2)))))));
 		double fSlow4 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
 		double fSlow5 = (0.5 * (fSlow2 / (fSlow3 * fSlow4)));
 		double fSlow6 = (fSlow5 + 1.0);
-		double fSlow7 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow1))) / fSlow6));
-		double fSlow8 = (0.0010000000000000009 * ((1.0 - fSlow5) / fSlow6));
+		double fSlow7 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow1))) / fSlow6));
+		double fSlow8 = (fConst2 * ((1.0 - fSlow5) / fSlow6));
 		double fSlow9 = (0.5 * ((fSlow2 * fSlow4) / fSlow3));
-		double fSlow10 = (0.0010000000000000009 * ((fSlow9 + 1.0) / fSlow6));
-		double fSlow11 = (0.0010000000000000009 * ((1.0 - fSlow9) / fSlow6));
+		double fSlow10 = (fConst2 * ((fSlow9 + 1.0) / fSlow6));
+		double fSlow11 = (fConst2 * ((1.0 - fSlow9) / fSlow6));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow7 + (0.999 * fRec1[1]));
+			fRec1[0] = (fSlow7 + (fConst1 * fRec1[1]));
 			double fTemp2 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = (fSlow8 + (0.999 * fRec2[1]));
+			fRec2[0] = (fSlow8 + (fConst1 * fRec2[1]));
 			fRec0[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow10 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow11 + (0.999 * fRec4[1]));
+			fRec3[0] = (fSlow10 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fSlow11 + (fConst1 * fRec4[1]));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp2) + (fRec4[0] * fRec0[2])));
 			double fTemp3 = (fRec1[0] * fRec5[1]);
-			fRec5[0] = (fTemp1 - (fTemp3 + (fRec2[0] * fRec5[2])));
+			fRec5[0] = (fTemp1 - ((fRec2[0] * fRec5[2]) + fTemp3));
 			output1[i] = FAUSTFLOAT(((fTemp3 + (fRec3[0] * fRec5[0])) + (fRec4[0] * fRec5[2])));
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
@@ -190,7 +212,9 @@ class faust2chEq : public sfzFilterDsp {
 			fRec4[1] = fRec4[0];
 			fRec5[2] = fRec5[1];
 			fRec5[1] = fRec5[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chHpf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chHpf1p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chHpf1p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faust2chHpf1p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec1[2];
 	double fRec0[2];
@@ -45,13 +47,15 @@ class faust2chHpf1p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -64,12 +68,14 @@ class faust2chHpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -82,40 +88,53 @@ class faust2chHpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (1.0 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (1.0 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec0[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec2[l2] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -125,10 +144,12 @@ class faust2chHpf1p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -136,21 +157,23 @@ class faust2chHpf1p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (0.0010000000000000009 * std::exp((fConst0 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
+		double fSlow0 = (fConst2 * std::exp((fConst3 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow0 + (0.999 * fRec1[1]));
-			fRec0[0] = (fTemp0 + (fRec1[0] * fRec0[1]));
+			fRec1[0] = (fSlow0 + (fConst1 * fRec1[1]));
+			fRec0[0] = ((fRec1[0] * fRec0[1]) + fTemp0);
 			double fTemp2 = (fRec1[0] + 1.0);
 			double fTemp3 = (0.0 - (0.5 * fTemp2));
 			output0[i] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp2)) + (fRec0[1] * fTemp3)));
-			fRec2[0] = (fTemp1 + (fRec1[0] * fRec2[1]));
+			fRec2[0] = ((fRec1[0] * fRec2[1]) + fTemp1);
 			output1[i] = FAUSTFLOAT(((0.5 * (fRec2[0] * fTemp2)) + (fTemp3 * fRec2[1])));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chHpf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chHpf2p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chHpf2p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,14 +30,18 @@ class faust2chHpf2p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec2[2];
 	double fRec3[2];
 	double fRec1[3];
+	double fConst4;
 	double fRec4[2];
 	double fRec5[3];
 	
@@ -49,13 +52,15 @@ class faust2chHpf2p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -68,12 +73,14 @@ class faust2chHpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -86,50 +93,67 @@ class faust2chHpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (0.5 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec3[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -139,10 +163,12 @@ class faust2chHpf2p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -150,22 +176,22 @@ class faust2chHpf2p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
-		double fSlow4 = (0.0010000000000000009 * ((-1.0 - fSlow1) / fSlow3));
-		double fSlow5 = (0.0010000000000000009 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow6 = (0.0010000000000000009 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow7 = (0.00050000000000000044 * ((fSlow1 + 1.0) / fSlow3));
+		double fSlow4 = (fConst2 * ((-1.0 - fSlow1) / fSlow3));
+		double fSlow5 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
+		double fSlow6 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
+		double fSlow7 = (fConst4 * ((fSlow1 + 1.0) / fSlow3));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow4 + (0.999 * fRec0[1]));
-			fRec2[0] = (fSlow5 + (0.999 * fRec2[1]));
-			fRec3[0] = (fSlow6 + (0.999 * fRec3[1]));
+			fRec0[0] = (fSlow4 + (fConst1 * fRec0[1]));
+			fRec2[0] = (fSlow5 + (fConst1 * fRec2[1]));
+			fRec3[0] = (fSlow6 + (fConst1 * fRec3[1]));
 			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
-			fRec4[0] = (fSlow7 + (0.999 * fRec4[1]));
+			fRec4[0] = (fSlow7 + (fConst1 * fRec4[1]));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec4[0] * (fRec1[0] + fRec1[2]))));
 			fRec5[0] = (fTemp1 - ((fRec2[0] * fRec5[1]) + (fRec3[0] * fRec5[2])));
 			output1[i] = FAUSTFLOAT(((fRec0[0] * fRec5[1]) + (fRec4[0] * (fRec5[0] + fRec5[2]))));
@@ -177,7 +203,9 @@ class faust2chHpf2p : public sfzFilterDsp {
 			fRec4[1] = fRec4[0];
 			fRec5[2] = fRec5[1];
 			fRec5[1] = fRec5[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chHpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chHpf2pSv_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chHpf2pSv
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec4[2];
 	FAUSTFLOAT fQ;
@@ -50,13 +52,15 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -69,12 +73,14 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -87,53 +93,70 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (3.1415926535897931 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec4[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec2[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec7[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
 			fRec8[l6] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -143,10 +166,12 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -154,15 +179,15 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (0.0010000000000000009 * std::tan((fConst0 * double(fCutoff))));
+		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
 		double fSlow1 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec4[0] = (fSlow0 + (0.999 * fRec4[1]));
+			fRec4[0] = (fSlow0 + (fConst1 * fRec4[1]));
 			double fTemp2 = (fSlow1 + fRec4[0]);
-			fRec3[0] = ((0.999 * fRec3[1]) + (0.0010000000000000009 / ((fRec4[0] * fTemp2) + 1.0)));
-			fRec5[0] = ((0.999 * fRec5[1]) + (0.0010000000000000009 * fTemp2));
+			fRec3[0] = ((fConst2 / ((fRec4[0] * fTemp2) + 1.0)) + (fConst1 * fRec3[1]));
+			fRec5[0] = ((fConst1 * fRec5[1]) + (fConst2 * fTemp2));
 			double fTemp3 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fRec0 = (fRec3[0] * fTemp3);
 			double fTemp4 = (fRec4[0] * fRec3[0]);
@@ -187,7 +212,9 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 			fRec2[1] = fRec2[0];
 			fRec7[1] = fRec7[0];
 			fRec8[1] = fRec8[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chHpf4p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf4p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chHpf4p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chHpf4p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,14 +30,18 @@ class faust2chHpf4p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec3[2];
 	double fRec4[2];
 	double fRec2[3];
+	double fConst4;
 	double fRec5[2];
 	double fRec1[3];
 	double fRec7[3];
@@ -51,13 +54,15 @@ class faust2chHpf4p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -70,12 +75,14 @@ class faust2chHpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -88,56 +95,75 @@ class faust2chHpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (0.5 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec4[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec5[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec1[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec7[l6] = 0.0;
+			
 		}
 		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
 			fRec6[l7] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -147,10 +173,12 @@ class faust2chHpf4p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -158,22 +186,22 @@ class faust2chHpf4p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
-		double fSlow4 = (0.0010000000000000009 * ((-1.0 - fSlow1) / fSlow3));
-		double fSlow5 = (0.0010000000000000009 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow6 = (0.0010000000000000009 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow7 = (0.00050000000000000044 * ((fSlow1 + 1.0) / fSlow3));
+		double fSlow4 = (fConst2 * ((-1.0 - fSlow1) / fSlow3));
+		double fSlow5 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
+		double fSlow6 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
+		double fSlow7 = (fConst4 * ((fSlow1 + 1.0) / fSlow3));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow4 + (0.999 * fRec0[1]));
-			fRec3[0] = (fSlow5 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow6 + (0.999 * fRec4[1]));
+			fRec0[0] = (fSlow4 + (fConst1 * fRec0[1]));
+			fRec3[0] = (fSlow5 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fSlow6 + (fConst1 * fRec4[1]));
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = (fSlow7 + (0.999 * fRec5[1]));
+			fRec5[0] = (fSlow7 + (fConst1 * fRec5[1]));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec5[0] * (fRec1[0] + fRec1[2]))));
 			fRec7[0] = (fTemp1 - ((fRec3[0] * fRec7[1]) + (fRec4[0] * fRec7[2])));
@@ -191,7 +219,9 @@ class faust2chHpf4p : public sfzFilterDsp {
 			fRec7[1] = fRec7[0];
 			fRec6[2] = fRec6[1];
 			fRec6[1] = fRec6[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chHpf6p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf6p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chHpf6p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chHpf6p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,14 +30,18 @@ class faust2chHpf6p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec4[2];
 	double fRec5[2];
 	double fRec3[3];
+	double fConst4;
 	double fRec6[2];
 	double fRec2[3];
 	double fRec1[3];
@@ -53,13 +56,15 @@ class faust2chHpf6p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -72,12 +77,14 @@ class faust2chHpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -90,62 +97,83 @@ class faust2chHpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (0.5 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec6[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec2[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec1[l6] = 0.0;
+			
 		}
 		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
 			fRec9[l7] = 0.0;
+			
 		}
 		for (int l8 = 0; (l8 < 3); l8 = (l8 + 1)) {
 			fRec8[l8] = 0.0;
+			
 		}
 		for (int l9 = 0; (l9 < 3); l9 = (l9 + 1)) {
 			fRec7[l9] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -155,10 +183,12 @@ class faust2chHpf6p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -166,22 +196,22 @@ class faust2chHpf6p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
-		double fSlow4 = (0.0010000000000000009 * ((-1.0 - fSlow1) / fSlow3));
-		double fSlow5 = (0.0010000000000000009 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow6 = (0.0010000000000000009 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow7 = (0.00050000000000000044 * ((fSlow1 + 1.0) / fSlow3));
+		double fSlow4 = (fConst2 * ((-1.0 - fSlow1) / fSlow3));
+		double fSlow5 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
+		double fSlow6 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
+		double fSlow7 = (fConst4 * ((fSlow1 + 1.0) / fSlow3));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow4 + (0.999 * fRec0[1]));
-			fRec4[0] = (fSlow5 + (0.999 * fRec4[1]));
-			fRec5[0] = (fSlow6 + (0.999 * fRec5[1]));
+			fRec0[0] = (fSlow4 + (fConst1 * fRec0[1]));
+			fRec4[0] = (fSlow5 + (fConst1 * fRec4[1]));
+			fRec5[0] = (fSlow6 + (fConst1 * fRec5[1]));
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (fSlow7 + (0.999 * fRec6[1]));
+			fRec6[0] = (fSlow7 + (fConst1 * fRec6[1]));
 			fRec2[0] = (((fRec0[0] * fRec3[1]) + (fRec6[0] * (fRec3[0] + fRec3[2]))) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec6[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec6[0] * (fRec1[0] + fRec1[2]))));
@@ -205,7 +235,9 @@ class faust2chHpf6p : public sfzFilterDsp {
 			fRec8[1] = fRec8[0];
 			fRec7[2] = fRec7[1];
 			fRec7[1] = fRec7[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chHsh.cxx
+++ b/src/sfizz/gen/filters/sfz2chHsh.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chHsh_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chHsh
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,9 +30,13 @@ class faust2chHsh : public sfzFilterDsp {
 	
  public:
 	
-	FAUSTFLOAT fPkShGain;
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
+	FAUSTFLOAT fPkShGain;
+	double fConst4;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec1[2];
@@ -51,13 +54,15 @@ class faust2chHsh : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -70,12 +75,14 @@ class faust2chHsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -88,54 +95,72 @@ class faust2chHsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (2.0 * fConst2);
+		fConst4 = (6.2831853071795862 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fPkShGain = FAUSTFLOAT(0.0);
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec6[l6] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -145,10 +170,12 @@ class faust2chHsh : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -157,27 +184,27 @@ class faust2chHsh : public sfzFilterDsp {
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
 		double fSlow0 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
-		double fSlow1 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow1 = (fConst4 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::cos(fSlow1);
-		double fSlow3 = (fSlow2 * (fSlow0 + 1.0));
+		double fSlow3 = ((fSlow0 + 1.0) * fSlow2);
 		double fSlow4 = ((std::sqrt(fSlow0) * std::sin(fSlow1)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
-		double fSlow5 = (fSlow2 * (fSlow0 + -1.0));
+		double fSlow5 = ((fSlow0 + -1.0) * fSlow2);
 		double fSlow6 = ((fSlow0 + fSlow4) + (1.0 - fSlow5));
-		double fSlow7 = (0.0020000000000000018 * ((fSlow0 + (-1.0 - fSlow3)) / fSlow6));
-		double fSlow8 = (0.0010000000000000009 * ((fSlow0 + (1.0 - (fSlow4 + fSlow5))) / fSlow6));
-		double fSlow9 = (fSlow0 + fSlow5);
-		double fSlow10 = (0.0010000000000000009 * ((fSlow0 * ((fSlow4 + fSlow9) + 1.0)) / fSlow6));
-		double fSlow11 = (0.0010000000000000009 * (((0.0 - (2.0 * fSlow0)) * ((fSlow0 + fSlow3) + -1.0)) / fSlow6));
-		double fSlow12 = (0.0010000000000000009 * ((fSlow0 * (fSlow9 + (1.0 - fSlow4))) / fSlow6));
+		double fSlow7 = (fConst3 * ((fSlow0 + (-1.0 - fSlow3)) / fSlow6));
+		double fSlow8 = (fConst2 * ((fSlow0 + (1.0 - (fSlow5 + fSlow4))) / fSlow6));
+		double fSlow9 = (fSlow5 + fSlow0);
+		double fSlow10 = (fConst2 * ((((fSlow9 + fSlow4) + 1.0) * fSlow0) / fSlow6));
+		double fSlow11 = (fConst2 * (((0.0 - (2.0 * fSlow0)) * ((fSlow3 + fSlow0) + -1.0)) / fSlow6));
+		double fSlow12 = (fConst2 * (((fSlow9 + (1.0 - fSlow4)) * fSlow0) / fSlow6));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow7 + (0.999 * fRec1[1]));
-			fRec2[0] = (fSlow8 + (0.999 * fRec2[1]));
+			fRec1[0] = (fSlow7 + (fConst1 * fRec1[1]));
+			fRec2[0] = (fSlow8 + (fConst1 * fRec2[1]));
 			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow10 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow11 + (0.999 * fRec4[1]));
-			fRec5[0] = (fSlow12 + (0.999 * fRec5[1]));
+			fRec3[0] = (fSlow10 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fSlow11 + (fConst1 * fRec4[1]));
+			fRec5[0] = (fSlow12 + (fConst1 * fRec5[1]));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec6[0] = (fTemp1 - ((fRec1[0] * fRec6[1]) + (fRec2[0] * fRec6[2])));
 			output1[i] = FAUSTFLOAT((((fRec3[0] * fRec6[0]) + (fRec4[0] * fRec6[1])) + (fRec5[0] * fRec6[2])));
@@ -190,7 +217,9 @@ class faust2chHsh : public sfzFilterDsp {
 			fRec5[1] = fRec5[0];
 			fRec6[2] = fRec6[1];
 			fRec6[1] = fRec6[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chLpf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chLpf1p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chLpf1p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faust2chLpf1p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec1[2];
 	double fRec0[2];
@@ -45,13 +47,15 @@ class faust2chLpf1p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -64,12 +68,14 @@ class faust2chLpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -82,40 +88,53 @@ class faust2chLpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (1.0 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (1.0 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec0[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec2[l2] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -125,10 +144,12 @@ class faust2chLpf1p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -136,20 +157,22 @@ class faust2chLpf1p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (0.0010000000000000009 * std::exp((fConst0 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
+		double fSlow0 = (fConst2 * std::exp((fConst3 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow0 + (0.999 * fRec1[1]));
-			fRec0[0] = (fTemp0 + (fRec1[0] * fRec0[1]));
+			fRec1[0] = (fSlow0 + (fConst1 * fRec1[1]));
+			fRec0[0] = ((fRec1[0] * fRec0[1]) + fTemp0);
 			double fTemp2 = (1.0 - fRec1[0]);
 			output0[i] = FAUSTFLOAT((fRec0[0] * fTemp2));
-			fRec2[0] = (fTemp1 + (fRec1[0] * fRec2[1]));
+			fRec2[0] = ((fRec1[0] * fRec2[1]) + fTemp1);
 			output1[i] = FAUSTFLOAT((fRec2[0] * fTemp2));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chLpf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chLpf2p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chLpf2p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,14 +30,18 @@ class faust2chLpf2p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec2[2];
 	double fRec3[2];
 	double fRec1[3];
+	double fConst4;
 	double fRec4[2];
 	double fRec5[3];
 	
@@ -49,13 +52,15 @@ class faust2chLpf2p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -68,12 +73,14 @@ class faust2chLpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -86,50 +93,67 @@ class faust2chLpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (0.5 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec3[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -139,10 +163,12 @@ class faust2chLpf2p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -150,23 +176,23 @@ class faust2chLpf2p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (0.0010000000000000009 * fSlow4);
-		double fSlow6 = (0.0010000000000000009 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow7 = (0.0010000000000000009 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow8 = (0.00050000000000000044 * fSlow4);
+		double fSlow5 = (fConst2 * fSlow4);
+		double fSlow6 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
+		double fSlow7 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
+		double fSlow8 = (fConst4 * fSlow4);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow5 + (0.999 * fRec0[1]));
-			fRec2[0] = (fSlow6 + (0.999 * fRec2[1]));
-			fRec3[0] = (fSlow7 + (0.999 * fRec3[1]));
+			fRec0[0] = (fSlow5 + (fConst1 * fRec0[1]));
+			fRec2[0] = (fSlow6 + (fConst1 * fRec2[1]));
+			fRec3[0] = (fSlow7 + (fConst1 * fRec3[1]));
 			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
-			fRec4[0] = (fSlow8 + (0.999 * fRec4[1]));
+			fRec4[0] = (fSlow8 + (fConst1 * fRec4[1]));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec4[0] * (fRec1[0] + fRec1[2]))));
 			fRec5[0] = (fTemp1 - ((fRec2[0] * fRec5[1]) + (fRec3[0] * fRec5[2])));
 			output1[i] = FAUSTFLOAT(((fRec0[0] * fRec5[1]) + (fRec4[0] * (fRec5[0] + fRec5[2]))));
@@ -178,7 +204,9 @@ class faust2chLpf2p : public sfzFilterDsp {
 			fRec4[1] = fRec4[0];
 			fRec5[2] = fRec5[1];
 			fRec5[1] = fRec5[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chLpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chLpf2pSv_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chLpf2pSv
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec3[2];
 	FAUSTFLOAT fQ;
@@ -50,13 +52,15 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -69,12 +73,14 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -87,53 +93,70 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (3.1415926535897931 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec3[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec2[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec7[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
 			fRec8[l6] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -143,10 +166,12 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -154,16 +179,16 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (0.0010000000000000009 * std::tan((fConst0 * double(fCutoff))));
+		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
 		double fSlow1 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec3[0] = (fSlow0 + (0.999 * fRec3[1]));
+			fRec3[0] = (fSlow0 + (fConst1 * fRec3[1]));
 			double fTemp2 = (fSlow1 + fRec3[0]);
-			fRec4[0] = ((0.999 * fRec4[1]) + (0.0010000000000000009 / ((fRec3[0] * fTemp2) + 1.0)));
+			fRec4[0] = ((fConst2 / ((fRec3[0] * fTemp2) + 1.0)) + (fConst1 * fRec4[1]));
 			double fTemp3 = (fRec3[0] * fRec4[0]);
-			fRec5[0] = ((0.999 * fRec5[1]) + (0.0010000000000000009 * fTemp2));
+			fRec5[0] = ((fConst1 * fRec5[1]) + (fConst2 * fTemp2));
 			double fTemp4 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fTemp5 = (fTemp3 * fTemp4);
 			double fTemp6 = (fRec2[1] + (2.0 * fTemp5));
@@ -187,7 +212,9 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 			fRec2[1] = fRec2[0];
 			fRec7[1] = fRec7[0];
 			fRec8[1] = fRec8[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chLpf4p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf4p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chLpf4p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chLpf4p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,14 +30,18 @@ class faust2chLpf4p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec3[2];
 	double fRec4[2];
 	double fRec2[3];
+	double fConst4;
 	double fRec5[2];
 	double fRec1[3];
 	double fRec7[3];
@@ -51,13 +54,15 @@ class faust2chLpf4p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -70,12 +75,14 @@ class faust2chLpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -88,56 +95,75 @@ class faust2chLpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (0.5 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec4[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec5[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec1[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec7[l6] = 0.0;
+			
 		}
 		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
 			fRec6[l7] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -147,10 +173,12 @@ class faust2chLpf4p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -158,23 +186,23 @@ class faust2chLpf4p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (0.0010000000000000009 * fSlow4);
-		double fSlow6 = (0.0010000000000000009 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow7 = (0.0010000000000000009 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow8 = (0.00050000000000000044 * fSlow4);
+		double fSlow5 = (fConst2 * fSlow4);
+		double fSlow6 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
+		double fSlow7 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
+		double fSlow8 = (fConst4 * fSlow4);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow5 + (0.999 * fRec0[1]));
-			fRec3[0] = (fSlow6 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow7 + (0.999 * fRec4[1]));
+			fRec0[0] = (fSlow5 + (fConst1 * fRec0[1]));
+			fRec3[0] = (fSlow6 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fSlow7 + (fConst1 * fRec4[1]));
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = (fSlow8 + (0.999 * fRec5[1]));
+			fRec5[0] = (fSlow8 + (fConst1 * fRec5[1]));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec5[0] * (fRec1[0] + fRec1[2]))));
 			fRec7[0] = (fTemp1 - ((fRec3[0] * fRec7[1]) + (fRec4[0] * fRec7[2])));
@@ -192,7 +220,9 @@ class faust2chLpf4p : public sfzFilterDsp {
 			fRec7[1] = fRec7[0];
 			fRec6[2] = fRec6[1];
 			fRec6[1] = fRec6[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chLpf6p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf6p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chLpf6p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chLpf6p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,14 +30,18 @@ class faust2chLpf6p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec4[2];
 	double fRec5[2];
 	double fRec3[3];
+	double fConst4;
 	double fRec6[2];
 	double fRec2[3];
 	double fRec1[3];
@@ -53,13 +56,15 @@ class faust2chLpf6p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -72,12 +77,14 @@ class faust2chLpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -90,62 +97,83 @@ class faust2chLpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (0.5 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec6[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec2[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec1[l6] = 0.0;
+			
 		}
 		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
 			fRec9[l7] = 0.0;
+			
 		}
 		for (int l8 = 0; (l8 < 3); l8 = (l8 + 1)) {
 			fRec8[l8] = 0.0;
+			
 		}
 		for (int l9 = 0; (l9 < 3); l9 = (l9 + 1)) {
 			fRec7[l9] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -155,10 +183,12 @@ class faust2chLpf6p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -166,23 +196,23 @@ class faust2chLpf6p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (0.0010000000000000009 * fSlow4);
-		double fSlow6 = (0.0010000000000000009 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow7 = (0.0010000000000000009 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow8 = (0.00050000000000000044 * fSlow4);
+		double fSlow5 = (fConst2 * fSlow4);
+		double fSlow6 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
+		double fSlow7 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
+		double fSlow8 = (fConst4 * fSlow4);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow5 + (0.999 * fRec0[1]));
-			fRec4[0] = (fSlow6 + (0.999 * fRec4[1]));
-			fRec5[0] = (fSlow7 + (0.999 * fRec5[1]));
+			fRec0[0] = (fSlow5 + (fConst1 * fRec0[1]));
+			fRec4[0] = (fSlow6 + (fConst1 * fRec4[1]));
+			fRec5[0] = (fSlow7 + (fConst1 * fRec5[1]));
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (fSlow8 + (0.999 * fRec6[1]));
+			fRec6[0] = (fSlow8 + (fConst1 * fRec6[1]));
 			fRec2[0] = (((fRec0[0] * fRec3[1]) + (fRec6[0] * (fRec3[0] + fRec3[2]))) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec6[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec6[0] * (fRec1[0] + fRec1[2]))));
@@ -206,7 +236,9 @@ class faust2chLpf6p : public sfzFilterDsp {
 			fRec8[1] = fRec8[0];
 			fRec7[2] = fRec7[1];
 			fRec7[1] = fRec7[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chLsh.cxx
+++ b/src/sfizz/gen/filters/sfz2chLsh.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chLsh_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chLsh
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,15 +30,19 @@ class faust2chLsh : public sfzFilterDsp {
 	
  public:
 	
-	FAUSTFLOAT fPkShGain;
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	FAUSTFLOAT fPkShGain;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec1[2];
 	double fRec2[2];
 	double fRec0[3];
 	double fRec3[2];
+	double fConst4;
 	double fRec4[2];
 	double fRec5[2];
 	double fRec6[3];
@@ -51,13 +54,15 @@ class faust2chLsh : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -70,12 +75,14 @@ class faust2chLsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -88,54 +95,72 @@ class faust2chLsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (2.0 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fPkShGain = FAUSTFLOAT(0.0);
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec6[l6] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -145,10 +170,12 @@ class faust2chLsh : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -157,27 +184,27 @@ class faust2chLsh : public sfzFilterDsp {
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
 		double fSlow0 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
-		double fSlow1 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow1 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::cos(fSlow1);
-		double fSlow3 = (fSlow2 * (fSlow0 + 1.0));
-		double fSlow4 = ((std::sqrt(fSlow0) * std::sin(fSlow1)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
-		double fSlow5 = (fSlow2 * (fSlow0 + -1.0));
-		double fSlow6 = (fSlow0 + fSlow5);
-		double fSlow7 = ((fSlow4 + fSlow6) + 1.0);
-		double fSlow8 = (0.0010000000000000009 * ((0.0 - (2.0 * ((fSlow0 + fSlow3) + -1.0))) / fSlow7));
-		double fSlow9 = (0.0010000000000000009 * ((fSlow6 + (1.0 - fSlow4)) / fSlow7));
-		double fSlow10 = (0.0010000000000000009 * ((fSlow0 * ((fSlow0 + fSlow4) + (1.0 - fSlow5))) / fSlow7));
-		double fSlow11 = (0.0020000000000000018 * ((fSlow0 * (fSlow0 + (-1.0 - fSlow3))) / fSlow7));
-		double fSlow12 = (0.0010000000000000009 * ((fSlow0 * (fSlow0 + (1.0 - (fSlow4 + fSlow5)))) / fSlow7));
+		double fSlow3 = ((fSlow0 + 1.0) * fSlow2);
+		double fSlow4 = ((fSlow0 + -1.0) * fSlow2);
+		double fSlow5 = (fSlow4 + fSlow0);
+		double fSlow6 = ((std::sqrt(fSlow0) * std::sin(fSlow1)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
+		double fSlow7 = ((fSlow5 + fSlow6) + 1.0);
+		double fSlow8 = (fConst2 * ((0.0 - (2.0 * ((fSlow3 + fSlow0) + -1.0))) / fSlow7));
+		double fSlow9 = (fConst2 * ((fSlow5 + (1.0 - fSlow6)) / fSlow7));
+		double fSlow10 = (fConst2 * ((((fSlow0 + fSlow6) + (1.0 - fSlow4)) * fSlow0) / fSlow7));
+		double fSlow11 = (fConst4 * (((fSlow0 + (-1.0 - fSlow3)) * fSlow0) / fSlow7));
+		double fSlow12 = (fConst2 * (((fSlow0 + (1.0 - (fSlow4 + fSlow6))) * fSlow0) / fSlow7));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow8 + (0.999 * fRec1[1]));
-			fRec2[0] = (fSlow9 + (0.999 * fRec2[1]));
+			fRec1[0] = (fSlow8 + (fConst1 * fRec1[1]));
+			fRec2[0] = (fSlow9 + (fConst1 * fRec2[1]));
 			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow10 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow11 + (0.999 * fRec4[1]));
-			fRec5[0] = (fSlow12 + (0.999 * fRec5[1]));
+			fRec3[0] = (fSlow10 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fSlow11 + (fConst1 * fRec4[1]));
+			fRec5[0] = (fSlow12 + (fConst1 * fRec5[1]));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec6[0] = (fTemp1 - ((fRec1[0] * fRec6[1]) + (fRec2[0] * fRec6[2])));
 			output1[i] = FAUSTFLOAT((((fRec3[0] * fRec6[0]) + (fRec4[0] * fRec6[1])) + (fRec5[0] * fRec6[2])));
@@ -190,7 +217,9 @@ class faust2chLsh : public sfzFilterDsp {
 			fRec5[1] = fRec5[0];
 			fRec6[2] = fRec6[1];
 			fRec6[1] = fRec6[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chPeq.cxx
+++ b/src/sfizz/gen/filters/sfz2chPeq.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chPeq_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chPeq
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,14 +30,17 @@ class faust2chPeq : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	FAUSTFLOAT fPkShGain;
-	double fRec1[2];
+	double fRec0[2];
 	double fRec2[2];
-	double fRec0[3];
+	double fRec1[3];
 	double fRec3[2];
 	double fRec4[2];
 	double fRec5[3];
@@ -50,13 +52,15 @@ class faust2chPeq : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -69,12 +73,14 @@ class faust2chPeq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -87,51 +93,67 @@ class faust2chPeq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 		fPkShGain = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+			fRec1[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -141,10 +163,12 @@ class faust2chPeq : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -152,39 +176,41 @@ class faust2chPeq : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::sin(fSlow0);
 		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow3 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
 		double fSlow4 = (0.5 * (fSlow1 / (fSlow2 * fSlow3)));
 		double fSlow5 = (fSlow4 + 1.0);
-		double fSlow6 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow5));
-		double fSlow7 = (0.0010000000000000009 * ((1.0 - fSlow4) / fSlow5));
+		double fSlow6 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow5));
+		double fSlow7 = (fConst2 * ((1.0 - fSlow4) / fSlow5));
 		double fSlow8 = (0.5 * ((fSlow1 * fSlow3) / fSlow2));
-		double fSlow9 = (0.0010000000000000009 * ((fSlow8 + 1.0) / fSlow5));
-		double fSlow10 = (0.0010000000000000009 * ((1.0 - fSlow8) / fSlow5));
+		double fSlow9 = (fConst2 * ((fSlow8 + 1.0) / fSlow5));
+		double fSlow10 = (fConst2 * ((1.0 - fSlow8) / fSlow5));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow6 + (0.999 * fRec1[1]));
-			double fTemp2 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = (fSlow7 + (0.999 * fRec2[1]));
-			fRec0[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow9 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow10 + (0.999 * fRec4[1]));
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp2) + (fRec4[0] * fRec0[2])));
-			double fTemp3 = (fRec1[0] * fRec5[1]);
+			fRec0[0] = (fSlow6 + (fConst1 * fRec0[1]));
+			double fTemp2 = (fRec0[0] * fRec1[1]);
+			fRec2[0] = (fSlow7 + (fConst1 * fRec2[1]));
+			fRec1[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec1[2])));
+			fRec3[0] = (fSlow9 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fSlow10 + (fConst1 * fRec4[1]));
+			output0[i] = FAUSTFLOAT((fTemp2 + ((fRec1[0] * fRec3[0]) + (fRec4[0] * fRec1[2]))));
+			double fTemp3 = (fRec0[0] * fRec5[1]);
 			fRec5[0] = (fTemp1 - (fTemp3 + (fRec2[0] * fRec5[2])));
 			output1[i] = FAUSTFLOAT(((fTemp3 + (fRec3[0] * fRec5[0])) + (fRec4[0] * fRec5[2])));
-			fRec1[1] = fRec1[0];
-			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
 			fRec0[1] = fRec0[0];
+			fRec2[1] = fRec2[0];
+			fRec1[2] = fRec1[1];
+			fRec1[1] = fRec1[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
 			fRec5[2] = fRec5[1];
 			fRec5[1] = fRec5[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chPink.cxx
+++ b/src/sfizz/gen/filters/sfz2chPink.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chPink_H__
@@ -20,7 +20,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chPink
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -32,7 +31,7 @@ class faust2chPink : public sfzFilterDsp {
 	
 	double fRec0[4];
 	double fRec1[4];
-	int fSampleRate;
+	int fSamplingFreq;
 	
  public:
 	
@@ -41,13 +40,15 @@ class faust2chPink : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
+		
 	}
 	virtual int getNumOutputs() {
 		return 2;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -60,12 +61,14 @@ class faust2chPink : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -78,35 +81,44 @@ class faust2chPink : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 4); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 4); l1 = (l1 + 1)) {
 			fRec1[l1] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -116,10 +128,12 @@ class faust2chPink : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -130,17 +144,21 @@ class faust2chPink : public sfzFilterDsp {
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = ((fTemp0 + ((2.4949560019999999 * fRec0[1]) + (0.52218940000000003 * fRec0[3]))) - (2.0172658750000001 * fRec0[2]));
+			fRec0[0] = ((((2.4949560019999999 * fRec0[1]) + (0.52218940000000003 * fRec0[3])) + fTemp0) - (2.0172658750000001 * fRec0[2]));
 			output0[i] = FAUSTFLOAT((((0.049922034999999997 * fRec0[0]) + (0.050612698999999997 * fRec0[2])) - ((0.095993537000000004 * fRec0[1]) + (0.0044087859999999996 * fRec0[3]))));
-			fRec1[0] = ((fTemp1 + ((2.4949560019999999 * fRec1[1]) + (0.52218940000000003 * fRec1[3]))) - (2.0172658750000001 * fRec1[2]));
+			fRec1[0] = ((((2.4949560019999999 * fRec1[1]) + (0.52218940000000003 * fRec1[3])) + fTemp1) - (2.0172658750000001 * fRec1[2]));
 			output1[i] = FAUSTFLOAT((((0.049922034999999997 * fRec1[0]) + (0.050612698999999997 * fRec1[2])) - ((0.095993537000000004 * fRec1[1]) + (0.0044087859999999996 * fRec1[3]))));
 			for (int j0 = 3; (j0 > 0); j0 = (j0 - 1)) {
 				fRec0[j0] = fRec0[(j0 - 1)];
+				
 			}
 			for (int j1 = 3; (j1 > 0); j1 = (j1 - 1)) {
 				fRec1[j1] = fRec1[(j1 - 1)];
+				
 			}
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzApf1p.cxx
+++ b/src/sfizz/gen/filters/sfzApf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustApf1p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustApf1p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faustApf1p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec1[2];
 	double fRec0[2];
@@ -44,13 +46,15 @@ class faustApf1p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -59,12 +63,14 @@ class faustApf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -73,37 +79,49 @@ class faustApf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec0[l1] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -113,24 +131,28 @@ class faustApf1p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (0.0010000000000000009 * ((fConst0 * double(fCutoff)) + -1.0));
+		double fSlow0 = (fConst2 * ((fConst3 * double(fCutoff)) + -1.0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow0 + (0.999 * fRec1[1]));
+			fRec1[0] = (fSlow0 + (fConst1 * fRec1[1]));
 			fRec0[0] = (fTemp0 - (fRec1[0] * fRec0[1]));
 			output0[i] = FAUSTFLOAT((fRec0[1] + (fRec1[0] * fRec0[0])));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBpf1p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBpf1p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustBpf1p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faustBpf1p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec2[2];
 	double fRec1[2];
@@ -45,13 +47,15 @@ class faustBpf1p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -60,12 +64,14 @@ class faustBpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -74,40 +80,53 @@ class faustBpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (1.0 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (1.0 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec2[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec1[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -117,27 +136,31 @@ class faustBpf1p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (0.0010000000000000009 * std::exp((fConst0 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
+		double fSlow0 = (fConst2 * std::exp((fConst3 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec2[0] = (fSlow0 + (0.999 * fRec2[1]));
-			fRec1[0] = (fTemp0 + (fRec2[0] * fRec1[1]));
+			fRec2[0] = (fSlow0 + (fConst1 * fRec2[1]));
+			fRec1[0] = ((fRec2[0] * fRec1[1]) + fTemp0);
 			fRec0[0] = ((fRec1[0] * (1.0 - fRec2[0])) + (fRec2[0] * fRec0[1]));
 			double fTemp1 = (fRec2[0] + 1.0);
 			output0[i] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp1)) + (fRec0[1] * (0.0 - (0.5 * fTemp1)))));
 			fRec2[1] = fRec2[0];
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBpf2p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBpf2p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustBpf2p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,13 +30,17 @@ class faustBpf2p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec1[2];
 	double fRec2[2];
 	double fRec0[3];
+	double fConst4;
 	double fRec3[2];
 	double fRec4[2];
 	double fRec5[2];
@@ -49,13 +52,15 @@ class faustBpf2p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -64,12 +69,14 @@ class faustBpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -78,50 +85,67 @@ class faustBpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (0.5 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -131,33 +155,35 @@ class faustBpf2p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::sin(fSlow0);
 		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow3 = (0.5 * (fSlow1 / fSlow2));
 		double fSlow4 = (fSlow3 + 1.0);
-		double fSlow5 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
-		double fSlow6 = (0.0010000000000000009 * ((1.0 - fSlow3) / fSlow4));
-		double fSlow7 = (fSlow1 / (fSlow2 * fSlow4));
-		double fSlow8 = (0.00050000000000000044 * fSlow7);
-		double fSlow9 = (0.0010000000000000009 * (0.0 - (0.5 * fSlow7)));
+		double fSlow5 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
+		double fSlow6 = (fConst2 * ((1.0 - fSlow3) / fSlow4));
+		double fSlow7 = (fSlow1 / (fSlow4 * fSlow2));
+		double fSlow8 = (fConst4 * fSlow7);
+		double fSlow9 = (fConst2 * (0.0 - (0.5 * fSlow7)));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow5 + (0.999 * fRec1[1]));
-			fRec2[0] = (fSlow6 + (0.999 * fRec2[1]));
+			fRec1[0] = (fSlow5 + (fConst1 * fRec1[1]));
+			fRec2[0] = (fSlow6 + (fConst1 * fRec2[1]));
 			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow8 + (0.999 * fRec3[1]));
-			fRec4[0] = (0.999 * fRec4[1]);
-			fRec5[0] = (fSlow9 + (0.999 * fRec5[1]));
+			fRec3[0] = (fSlow8 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fConst1 * fRec4[1]);
+			fRec5[0] = (fSlow9 + (fConst1 * fRec5[1]));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
@@ -166,7 +192,9 @@ class faustBpf2p : public sfzFilterDsp {
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
 			fRec5[1] = fRec5[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzBpf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBpf2pSv_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustBpf2pSv
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faustBpf2pSv : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec3[2];
 	FAUSTFLOAT fQ;
@@ -49,13 +51,15 @@ class faustBpf2pSv : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -64,12 +68,14 @@ class faustBpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -78,50 +84,66 @@ class faustBpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (3.1415926535897931 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec3[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec2[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec6[l5] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -131,25 +153,27 @@ class faustBpf2pSv : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (0.0010000000000000009 * std::tan((fConst0 * double(fCutoff))));
+		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
 		double fSlow1 = std::pow(10.0, (0.050000000000000003 * double(fQ)));
 		double fSlow2 = (1.0 / fSlow1);
-		double fSlow3 = (0.0010000000000000009 / fSlow1);
+		double fSlow3 = (fConst2 / fSlow1);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec3[0] = (fSlow0 + (0.999 * fRec3[1]));
+			fRec3[0] = (fSlow0 + (fConst1 * fRec3[1]));
 			double fTemp1 = (fSlow2 + fRec3[0]);
-			fRec4[0] = ((0.999 * fRec4[1]) + (0.0010000000000000009 / ((fRec3[0] * fTemp1) + 1.0)));
-			fRec5[0] = ((0.999 * fRec5[1]) + (0.0010000000000000009 * fTemp1));
+			fRec4[0] = ((fConst1 * fRec4[1]) + (fConst2 / ((fRec3[0] * fTemp1) + 1.0)));
+			fRec5[0] = ((fConst1 * fRec5[1]) + (fConst2 * fTemp1));
 			double fTemp2 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fTemp3 = ((fRec3[0] * fRec4[0]) * fTemp2);
 			double fTemp4 = (fRec2[1] + fTemp3);
@@ -157,7 +181,7 @@ class faustBpf2pSv : public sfzFilterDsp {
 			fRec1[0] = (fRec1[1] + (2.0 * (fRec3[0] * fTemp4)));
 			double fTemp5 = (fRec2[1] + (2.0 * fTemp3));
 			fRec2[0] = fTemp5;
-			fRec6[0] = (fSlow3 + (0.999 * fRec6[1]));
+			fRec6[0] = (fSlow3 + (fConst1 * fRec6[1]));
 			output0[i] = FAUSTFLOAT((fRec0 * fRec6[0]));
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
@@ -165,7 +189,9 @@ class faustBpf2pSv : public sfzFilterDsp {
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
 			fRec6[1] = fRec6[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBpf4p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf4p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBpf4p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustBpf4p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,12 @@ class faustBpf4p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
+	double fConst4;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
@@ -50,13 +53,15 @@ class faustBpf4p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -65,12 +70,14 @@ class faustBpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -79,53 +86,71 @@ class faustBpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (0.5 * fConst2);
+		fConst4 = (6.2831853071795862 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec4[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec5[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec6[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec1[l6] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -135,33 +160,35 @@ class faustBpf4p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst4 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::sin(fSlow0);
 		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow3 = (0.5 * (fSlow1 / fSlow2));
 		double fSlow4 = (fSlow3 + 1.0);
-		double fSlow5 = (fSlow1 / (fSlow2 * fSlow4));
-		double fSlow6 = (0.00050000000000000044 * fSlow5);
-		double fSlow7 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
-		double fSlow8 = (0.0010000000000000009 * ((1.0 - fSlow3) / fSlow4));
-		double fSlow9 = (0.0010000000000000009 * (0.0 - (0.5 * fSlow5)));
+		double fSlow5 = (fSlow1 / (fSlow4 * fSlow2));
+		double fSlow6 = (fConst3 * fSlow5);
+		double fSlow7 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
+		double fSlow8 = (fConst2 * ((1.0 - fSlow3) / fSlow4));
+		double fSlow9 = (fConst2 * (0.0 - (0.5 * fSlow5)));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow6 + (0.999 * fRec0[1]));
-			fRec3[0] = (fSlow7 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow8 + (0.999 * fRec4[1]));
+			fRec0[0] = (fSlow6 + (fConst1 * fRec0[1]));
+			fRec3[0] = (fSlow7 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fSlow8 + (fConst1 * fRec4[1]));
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = (0.999 * fRec5[1]);
-			fRec6[0] = (fSlow9 + (0.999 * fRec6[1]));
+			fRec5[0] = (fConst1 * fRec5[1]);
+			fRec6[0] = (fSlow9 + (fConst1 * fRec6[1]));
 			fRec1[0] = ((((fRec2[0] * fRec0[0]) + (fRec5[0] * fRec2[1])) + (fRec6[0] * fRec2[2])) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec5[0] * fRec1[1])) + (fRec6[0] * fRec1[2])));
 			fRec0[1] = fRec0[0];
@@ -173,7 +200,9 @@ class faustBpf4p : public sfzFilterDsp {
 			fRec6[1] = fRec6[0];
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBpf6p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf6p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBpf6p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustBpf6p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,12 @@ class faustBpf6p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
+	double fConst4;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
@@ -51,13 +54,15 @@ class faustBpf6p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -66,12 +71,14 @@ class faustBpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -80,56 +87,75 @@ class faustBpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (0.5 * fConst2);
+		fConst4 = (6.2831853071795862 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec6[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec7[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec2[l6] = 0.0;
+			
 		}
 		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
 			fRec1[l7] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -139,33 +165,35 @@ class faustBpf6p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst4 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::sin(fSlow0);
 		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow3 = (0.5 * (fSlow1 / fSlow2));
 		double fSlow4 = (fSlow3 + 1.0);
-		double fSlow5 = (fSlow1 / (fSlow2 * fSlow4));
-		double fSlow6 = (0.00050000000000000044 * fSlow5);
-		double fSlow7 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
-		double fSlow8 = (0.0010000000000000009 * ((1.0 - fSlow3) / fSlow4));
-		double fSlow9 = (0.0010000000000000009 * (0.0 - (0.5 * fSlow5)));
+		double fSlow5 = (fSlow1 / (fSlow4 * fSlow2));
+		double fSlow6 = (fConst3 * fSlow5);
+		double fSlow7 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
+		double fSlow8 = (fConst2 * ((1.0 - fSlow3) / fSlow4));
+		double fSlow9 = (fConst2 * (0.0 - (0.5 * fSlow5)));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow6 + (0.999 * fRec0[1]));
-			fRec4[0] = (fSlow7 + (0.999 * fRec4[1]));
-			fRec5[0] = (fSlow8 + (0.999 * fRec5[1]));
+			fRec0[0] = (fSlow6 + (fConst1 * fRec0[1]));
+			fRec4[0] = (fSlow7 + (fConst1 * fRec4[1]));
+			fRec5[0] = (fSlow8 + (fConst1 * fRec5[1]));
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (0.999 * fRec6[1]);
-			fRec7[0] = (fSlow9 + (0.999 * fRec7[1]));
+			fRec6[0] = (fConst1 * fRec6[1]);
+			fRec7[0] = (fSlow9 + (fConst1 * fRec7[1]));
 			fRec2[0] = ((((fRec3[0] * fRec0[0]) + (fRec6[0] * fRec3[1])) + (fRec7[0] * fRec3[2])) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = ((((fRec0[0] * fRec2[0]) + (fRec6[0] * fRec2[1])) + (fRec7[0] * fRec2[2])) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec6[0] * fRec1[1])) + (fRec7[0] * fRec1[2])));
@@ -180,7 +208,9 @@ class faustBpf6p : public sfzFilterDsp {
 			fRec2[1] = fRec2[0];
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBrf1p.cxx
+++ b/src/sfizz/gen/filters/sfzBrf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBrf1p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustBrf1p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faustBrf1p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec2[2];
 	double fRec1[2];
@@ -45,13 +47,15 @@ class faustBrf1p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -60,12 +64,14 @@ class faustBrf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -74,40 +80,53 @@ class faustBrf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec2[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec1[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -117,26 +136,30 @@ class faustBrf1p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (0.0010000000000000009 * ((fConst0 * double(fCutoff)) + -1.0));
+		double fSlow0 = (fConst2 * ((fConst3 * double(fCutoff)) + -1.0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec2[0] = (fSlow0 + (0.999 * fRec2[1]));
+			fRec2[0] = (fSlow0 + (fConst1 * fRec2[1]));
 			fRec1[0] = (fTemp0 - (fRec2[0] * fRec1[1]));
 			fRec0[0] = (fRec1[1] + (fRec2[0] * (fRec1[0] - fRec0[1])));
-			output0[i] = FAUSTFLOAT((fTemp0 + (fRec0[1] + (fRec2[0] * fRec0[0]))));
+			output0[i] = FAUSTFLOAT(((fRec0[1] + (fRec2[0] * fRec0[0])) + fTemp0));
 			fRec2[1] = fRec2[0];
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBrf2p.cxx
+++ b/src/sfizz/gen/filters/sfzBrf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBrf2p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustBrf2p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faustBrf2p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
@@ -47,13 +49,15 @@ class faustBrf2p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -62,12 +66,14 @@ class faustBrf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -76,44 +82,58 @@ class faustBrf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec1[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -123,35 +143,39 @@ class faustBrf2p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow2 = (fSlow1 + 1.0);
-		double fSlow3 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow2));
-		double fSlow4 = (0.0010000000000000009 * ((1.0 - fSlow1) / fSlow2));
-		double fSlow5 = (0.0010000000000000009 / fSlow2);
+		double fSlow3 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow2));
+		double fSlow4 = (fConst2 * ((1.0 - fSlow1) / fSlow2));
+		double fSlow5 = (fConst2 / fSlow2);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow3 + (0.999 * fRec0[1]));
+			fRec0[0] = (fSlow3 + (fConst1 * fRec0[1]));
 			double fTemp1 = (fRec0[0] * fRec1[1]);
-			fRec2[0] = (fSlow4 + (0.999 * fRec2[1]));
+			fRec2[0] = (fSlow4 + (fConst1 * fRec2[1]));
 			fRec1[0] = (fTemp0 - (fTemp1 + (fRec2[0] * fRec1[2])));
-			fRec3[0] = (fSlow5 + (0.999 * fRec3[1]));
+			fRec3[0] = (fSlow5 + (fConst1 * fRec3[1]));
 			output0[i] = FAUSTFLOAT((fTemp1 + (fRec3[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
 			fRec3[1] = fRec3[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBrf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzBrf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBrf2pSv_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustBrf2pSv
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faustBrf2pSv : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec5[2];
 	FAUSTFLOAT fQ;
@@ -48,13 +50,15 @@ class faustBrf2pSv : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -63,12 +67,14 @@ class faustBrf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -77,47 +83,62 @@ class faustBrf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (3.1415926535897931 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec5[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec6[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec3[l4] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -127,23 +148,25 @@ class faustBrf2pSv : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (0.0010000000000000009 * std::tan((fConst0 * double(fCutoff))));
+		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
 		double fSlow1 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec5[0] = (fSlow0 + (0.999 * fRec5[1]));
+			fRec5[0] = (fSlow0 + (fConst1 * fRec5[1]));
 			double fTemp1 = (fSlow1 + fRec5[0]);
-			fRec4[0] = ((0.999 * fRec4[1]) + (0.0010000000000000009 / ((fRec5[0] * fTemp1) + 1.0)));
-			fRec6[0] = ((0.999 * fRec6[1]) + (0.0010000000000000009 * fTemp1));
+			fRec4[0] = ((fConst1 * fRec4[1]) + (fConst2 / ((fRec5[0] * fTemp1) + 1.0)));
+			fRec6[0] = ((fConst1 * fRec6[1]) + (fConst2 * fTemp1));
 			double fTemp2 = (fTemp0 - (fRec2[1] + (fRec6[0] * fRec3[1])));
 			double fRec0 = (fRec4[0] * fTemp2);
 			double fTemp3 = ((fRec5[0] * fRec4[0]) * fTemp2);
@@ -158,7 +181,9 @@ class faustBrf2pSv : public sfzFilterDsp {
 			fRec6[1] = fRec6[0];
 			fRec2[1] = fRec2[0];
 			fRec3[1] = fRec3[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzEq.cxx
+++ b/src/sfizz/gen/filters/sfzEq.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustEq_H__
@@ -22,7 +22,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustEq
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -32,11 +31,13 @@ class faustEq : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
 	double fConst1;
-	FAUSTFLOAT fCutoff;
 	double fConst2;
+	double fConst3;
+	FAUSTFLOAT fCutoff;
+	double fConst4;
 	FAUSTFLOAT fBandwidth;
 	FAUSTFLOAT fPkShGain;
 	double fRec1[2];
@@ -52,13 +53,15 @@ class faustEq : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -67,12 +70,14 @@ class faustEq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -81,50 +86,64 @@ class faustEq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
-		fConst1 = (6.2831853071795862 / fConst0);
-		fConst2 = (2.1775860903036022 / fConst0);
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (2.1775860903036022 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fBandwidth = FAUSTFLOAT(1.0);
 		fPkShGain = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -134,35 +153,37 @@ class faustEq : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = std::max<double>(0.0, double(fCutoff));
-		double fSlow1 = (fConst1 * fSlow0);
+		double fSlow1 = (fConst3 * fSlow0);
 		double fSlow2 = std::sin(fSlow1);
-		double fSlow3 = std::max<double>(0.001, (0.5 / double(sinh(double((fConst2 * ((fSlow0 * double(fBandwidth)) / fSlow2)))))));
+		double fSlow3 = std::max<double>(0.001, (0.5 / double(sinh(double((fConst4 * ((fSlow0 * double(fBandwidth)) / fSlow2)))))));
 		double fSlow4 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
 		double fSlow5 = (0.5 * (fSlow2 / (fSlow3 * fSlow4)));
 		double fSlow6 = (fSlow5 + 1.0);
-		double fSlow7 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow1))) / fSlow6));
-		double fSlow8 = (0.0010000000000000009 * ((1.0 - fSlow5) / fSlow6));
+		double fSlow7 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow1))) / fSlow6));
+		double fSlow8 = (fConst2 * ((1.0 - fSlow5) / fSlow6));
 		double fSlow9 = (0.5 * ((fSlow2 * fSlow4) / fSlow3));
-		double fSlow10 = (0.0010000000000000009 * ((fSlow9 + 1.0) / fSlow6));
-		double fSlow11 = (0.0010000000000000009 * ((1.0 - fSlow9) / fSlow6));
+		double fSlow10 = (fConst2 * ((fSlow9 + 1.0) / fSlow6));
+		double fSlow11 = (fConst2 * ((1.0 - fSlow9) / fSlow6));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow7 + (0.999 * fRec1[1]));
+			fRec1[0] = (fSlow7 + (fConst1 * fRec1[1]));
 			double fTemp1 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = (fSlow8 + (0.999 * fRec2[1]));
+			fRec2[0] = (fSlow8 + (fConst1 * fRec2[1]));
 			fRec0[0] = (fTemp0 - (fTemp1 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow10 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow11 + (0.999 * fRec4[1]));
+			fRec3[0] = (fSlow10 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fSlow11 + (fConst1 * fRec4[1]));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp1) + (fRec4[0] * fRec0[2])));
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
@@ -170,7 +191,9 @@ class faustEq : public sfzFilterDsp {
 			fRec0[1] = fRec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzHpf1p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustHpf1p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustHpf1p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faustHpf1p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec1[2];
 	double fRec0[2];
@@ -44,13 +46,15 @@ class faustHpf1p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -59,12 +63,14 @@ class faustHpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -73,37 +79,49 @@ class faustHpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (1.0 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (1.0 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec0[l1] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -113,25 +131,29 @@ class faustHpf1p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (0.0010000000000000009 * std::exp((fConst0 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
+		double fSlow0 = (fConst2 * std::exp((fConst3 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow0 + (0.999 * fRec1[1]));
-			fRec0[0] = (fTemp0 + (fRec1[0] * fRec0[1]));
+			fRec1[0] = (fSlow0 + (fConst1 * fRec1[1]));
+			fRec0[0] = ((fRec1[0] * fRec0[1]) + fTemp0);
 			double fTemp1 = (fRec1[0] + 1.0);
 			output0[i] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp1)) + (fRec0[1] * (0.0 - (0.5 * fTemp1)))));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzHpf2p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustHpf2p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustHpf2p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,14 +30,18 @@ class faustHpf2p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec2[2];
 	double fRec3[2];
 	double fRec1[3];
+	double fConst4;
 	double fRec4[2];
 	
  public:
@@ -48,13 +51,15 @@ class faustHpf2p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -63,12 +68,14 @@ class faustHpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -77,47 +84,63 @@ class faustHpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (0.5 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec3[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -127,30 +150,32 @@ class faustHpf2p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
-		double fSlow4 = (0.0010000000000000009 * ((-1.0 - fSlow1) / fSlow3));
-		double fSlow5 = (0.0010000000000000009 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow6 = (0.0010000000000000009 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow7 = (0.00050000000000000044 * ((fSlow1 + 1.0) / fSlow3));
+		double fSlow4 = (fConst2 * ((-1.0 - fSlow1) / fSlow3));
+		double fSlow5 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
+		double fSlow6 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
+		double fSlow7 = (fConst4 * ((fSlow1 + 1.0) / fSlow3));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow4 + (0.999 * fRec0[1]));
-			fRec2[0] = (fSlow5 + (0.999 * fRec2[1]));
-			fRec3[0] = (fSlow6 + (0.999 * fRec3[1]));
+			fRec0[0] = (fSlow4 + (fConst1 * fRec0[1]));
+			fRec2[0] = (fSlow5 + (fConst1 * fRec2[1]));
+			fRec3[0] = (fSlow6 + (fConst1 * fRec3[1]));
 			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
-			fRec4[0] = (fSlow7 + (0.999 * fRec4[1]));
+			fRec4[0] = (fSlow7 + (fConst1 * fRec4[1]));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec4[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];
@@ -158,7 +183,9 @@ class faustHpf2p : public sfzFilterDsp {
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
 			fRec4[1] = fRec4[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzHpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzHpf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustHpf2pSv_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustHpf2pSv
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faustHpf2pSv : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec4[2];
 	FAUSTFLOAT fQ;
@@ -48,13 +50,15 @@ class faustHpf2pSv : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -63,12 +67,14 @@ class faustHpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -77,47 +83,62 @@ class faustHpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (3.1415926535897931 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec4[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec2[l4] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -127,23 +148,25 @@ class faustHpf2pSv : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (0.0010000000000000009 * std::tan((fConst0 * double(fCutoff))));
+		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
 		double fSlow1 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec4[0] = (fSlow0 + (0.999 * fRec4[1]));
+			fRec4[0] = (fSlow0 + (fConst1 * fRec4[1]));
 			double fTemp1 = (fSlow1 + fRec4[0]);
-			fRec3[0] = ((0.999 * fRec3[1]) + (0.0010000000000000009 / ((fRec4[0] * fTemp1) + 1.0)));
-			fRec5[0] = ((0.999 * fRec5[1]) + (0.0010000000000000009 * fTemp1));
+			fRec3[0] = ((fConst1 * fRec3[1]) + (fConst2 / ((fRec4[0] * fTemp1) + 1.0)));
+			fRec5[0] = ((fConst1 * fRec5[1]) + (fConst2 * fTemp1));
 			double fTemp2 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fRec0 = (fRec3[0] * fTemp2);
 			double fTemp3 = ((fRec4[0] * fRec3[0]) * fTemp2);
@@ -157,7 +180,9 @@ class faustHpf2pSv : public sfzFilterDsp {
 			fRec5[1] = fRec5[0];
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzHpf4p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf4p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustHpf4p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustHpf4p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,14 +30,18 @@ class faustHpf4p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec3[2];
 	double fRec4[2];
 	double fRec2[3];
+	double fConst4;
 	double fRec5[2];
 	double fRec1[3];
 	
@@ -49,13 +52,15 @@ class faustHpf4p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -64,12 +69,14 @@ class faustHpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -78,50 +85,67 @@ class faustHpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (0.5 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec4[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec5[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec1[l5] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -131,30 +155,32 @@ class faustHpf4p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
-		double fSlow4 = (0.0010000000000000009 * ((-1.0 - fSlow1) / fSlow3));
-		double fSlow5 = (0.0010000000000000009 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow6 = (0.0010000000000000009 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow7 = (0.00050000000000000044 * ((fSlow1 + 1.0) / fSlow3));
+		double fSlow4 = (fConst2 * ((-1.0 - fSlow1) / fSlow3));
+		double fSlow5 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
+		double fSlow6 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
+		double fSlow7 = (fConst4 * ((fSlow1 + 1.0) / fSlow3));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow4 + (0.999 * fRec0[1]));
-			fRec3[0] = (fSlow5 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow6 + (0.999 * fRec4[1]));
+			fRec0[0] = (fSlow4 + (fConst1 * fRec0[1]));
+			fRec3[0] = (fSlow5 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fSlow6 + (fConst1 * fRec4[1]));
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = (fSlow7 + (0.999 * fRec5[1]));
+			fRec5[0] = (fSlow7 + (fConst1 * fRec5[1]));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec5[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];
@@ -165,7 +191,9 @@ class faustHpf4p : public sfzFilterDsp {
 			fRec5[1] = fRec5[0];
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzHpf6p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf6p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustHpf6p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustHpf6p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,14 +30,18 @@ class faustHpf6p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec4[2];
 	double fRec5[2];
 	double fRec3[3];
+	double fConst4;
 	double fRec6[2];
 	double fRec2[3];
 	double fRec1[3];
@@ -50,13 +53,15 @@ class faustHpf6p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -65,12 +70,14 @@ class faustHpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -79,53 +86,71 @@ class faustHpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (0.5 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec6[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec2[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec1[l6] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -135,30 +160,32 @@ class faustHpf6p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
-		double fSlow4 = (0.0010000000000000009 * ((-1.0 - fSlow1) / fSlow3));
-		double fSlow5 = (0.0010000000000000009 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow6 = (0.0010000000000000009 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow7 = (0.00050000000000000044 * ((fSlow1 + 1.0) / fSlow3));
+		double fSlow4 = (fConst2 * ((-1.0 - fSlow1) / fSlow3));
+		double fSlow5 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
+		double fSlow6 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
+		double fSlow7 = (fConst4 * ((fSlow1 + 1.0) / fSlow3));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow4 + (0.999 * fRec0[1]));
-			fRec4[0] = (fSlow5 + (0.999 * fRec4[1]));
-			fRec5[0] = (fSlow6 + (0.999 * fRec5[1]));
+			fRec0[0] = (fSlow4 + (fConst1 * fRec0[1]));
+			fRec4[0] = (fSlow5 + (fConst1 * fRec4[1]));
+			fRec5[0] = (fSlow6 + (fConst1 * fRec5[1]));
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (fSlow7 + (0.999 * fRec6[1]));
+			fRec6[0] = (fSlow7 + (fConst1 * fRec6[1]));
 			fRec2[0] = (((fRec0[0] * fRec3[1]) + (fRec6[0] * (fRec3[0] + fRec3[2]))) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec6[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec6[0] * (fRec1[0] + fRec1[2]))));
@@ -172,7 +199,9 @@ class faustHpf6p : public sfzFilterDsp {
 			fRec2[1] = fRec2[0];
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzHsh.cxx
+++ b/src/sfizz/gen/filters/sfzHsh.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustHsh_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustHsh
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,12 +30,16 @@ class faustHsh : public sfzFilterDsp {
 	
  public:
 	
-	FAUSTFLOAT fPkShGain;
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	FAUSTFLOAT fPkShGain;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec1[2];
+	double fConst4;
 	double fRec2[2];
 	double fRec0[3];
 	double fRec3[2];
@@ -50,13 +53,15 @@ class faustHsh : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -65,12 +70,14 @@ class faustHsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -79,51 +86,68 @@ class faustHsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (2.0 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fPkShGain = FAUSTFLOAT(0.0);
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -133,36 +157,38 @@ class faustHsh : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
-		double fSlow1 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow1 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::cos(fSlow1);
-		double fSlow3 = (fSlow2 * (fSlow0 + 1.0));
+		double fSlow3 = ((fSlow0 + -1.0) * fSlow2);
 		double fSlow4 = ((std::sqrt(fSlow0) * std::sin(fSlow1)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
-		double fSlow5 = (fSlow2 * (fSlow0 + -1.0));
-		double fSlow6 = ((fSlow0 + fSlow4) + (1.0 - fSlow5));
-		double fSlow7 = (0.0020000000000000018 * ((fSlow0 + (-1.0 - fSlow3)) / fSlow6));
-		double fSlow8 = (0.0010000000000000009 * ((fSlow0 + (1.0 - (fSlow4 + fSlow5))) / fSlow6));
-		double fSlow9 = (fSlow0 + fSlow5);
-		double fSlow10 = (0.0010000000000000009 * ((fSlow0 * ((fSlow4 + fSlow9) + 1.0)) / fSlow6));
-		double fSlow11 = (0.0010000000000000009 * (((0.0 - (2.0 * fSlow0)) * ((fSlow0 + fSlow3) + -1.0)) / fSlow6));
-		double fSlow12 = (0.0010000000000000009 * ((fSlow0 * (fSlow9 + (1.0 - fSlow4))) / fSlow6));
+		double fSlow5 = ((fSlow0 + fSlow4) + (1.0 - fSlow3));
+		double fSlow6 = (fConst2 * ((fSlow0 + (1.0 - (fSlow3 + fSlow4))) / fSlow5));
+		double fSlow7 = ((fSlow0 + 1.0) * fSlow2);
+		double fSlow8 = (fConst4 * ((fSlow0 + (-1.0 - fSlow7)) / fSlow5));
+		double fSlow9 = (fSlow3 + fSlow0);
+		double fSlow10 = (fConst2 * ((((fSlow9 + fSlow4) + 1.0) * fSlow0) / fSlow5));
+		double fSlow11 = (fConst2 * (((0.0 - (2.0 * fSlow0)) * ((fSlow7 + fSlow0) + -1.0)) / fSlow5));
+		double fSlow12 = (fConst2 * (((fSlow9 + (1.0 - fSlow4)) * fSlow0) / fSlow5));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow7 + (0.999 * fRec1[1]));
-			fRec2[0] = (fSlow8 + (0.999 * fRec2[1]));
-			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow10 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow11 + (0.999 * fRec4[1]));
-			fRec5[0] = (fSlow12 + (0.999 * fRec5[1]));
+			fRec1[0] = (fSlow6 + (fConst1 * fRec1[1]));
+			fRec2[0] = (fSlow8 + (fConst1 * fRec2[1]));
+			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[2]) + (fRec2[0] * fRec0[1])));
+			fRec3[0] = (fSlow10 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fSlow11 + (fConst1 * fRec4[1]));
+			fRec5[0] = (fSlow12 + (fConst1 * fRec5[1]));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
@@ -171,7 +197,9 @@ class faustHsh : public sfzFilterDsp {
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
 			fRec5[1] = fRec5[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzLpf1p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustLpf1p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustLpf1p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faustLpf1p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec1[2];
 	double fRec0[2];
@@ -44,13 +46,15 @@ class faustLpf1p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -59,12 +63,14 @@ class faustLpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -73,37 +79,49 @@ class faustLpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (1.0 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (1.0 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec0[l1] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -113,24 +131,28 @@ class faustLpf1p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (0.0010000000000000009 * std::exp((fConst0 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
+		double fSlow0 = (fConst2 * std::exp((fConst3 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow0 + (0.999 * fRec1[1]));
-			fRec0[0] = (fTemp0 + (fRec1[0] * fRec0[1]));
+			fRec1[0] = (fSlow0 + (fConst1 * fRec1[1]));
+			fRec0[0] = ((fRec1[0] * fRec0[1]) + fTemp0);
 			output0[i] = FAUSTFLOAT((fRec0[0] * (1.0 - fRec1[0])));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzLpf2p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustLpf2p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustLpf2p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,14 +30,18 @@ class faustLpf2p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec2[2];
 	double fRec3[2];
 	double fRec1[3];
+	double fConst4;
 	double fRec4[2];
 	
  public:
@@ -48,13 +51,15 @@ class faustLpf2p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -63,12 +68,14 @@ class faustLpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -77,47 +84,63 @@ class faustLpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (0.5 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec3[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -127,31 +150,33 @@ class faustLpf2p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (0.0010000000000000009 * fSlow4);
-		double fSlow6 = (0.0010000000000000009 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow7 = (0.0010000000000000009 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow8 = (0.00050000000000000044 * fSlow4);
+		double fSlow5 = (fConst2 * fSlow4);
+		double fSlow6 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
+		double fSlow7 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
+		double fSlow8 = (fConst4 * fSlow4);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow5 + (0.999 * fRec0[1]));
-			fRec2[0] = (fSlow6 + (0.999 * fRec2[1]));
-			fRec3[0] = (fSlow7 + (0.999 * fRec3[1]));
+			fRec0[0] = (fSlow5 + (fConst1 * fRec0[1]));
+			fRec2[0] = (fSlow6 + (fConst1 * fRec2[1]));
+			fRec3[0] = (fSlow7 + (fConst1 * fRec3[1]));
 			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
-			fRec4[0] = (fSlow8 + (0.999 * fRec4[1]));
+			fRec4[0] = (fSlow8 + (fConst1 * fRec4[1]));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec4[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];
@@ -159,7 +184,9 @@ class faustLpf2p : public sfzFilterDsp {
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
 			fRec4[1] = fRec4[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzLpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzLpf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustLpf2pSv_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustLpf2pSv
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faustLpf2pSv : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec3[2];
 	FAUSTFLOAT fQ;
@@ -48,13 +50,15 @@ class faustLpf2pSv : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -63,12 +67,14 @@ class faustLpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -77,47 +83,62 @@ class faustLpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (3.1415926535897931 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (3.1415926535897931 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec3[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec2[l4] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -127,23 +148,25 @@ class faustLpf2pSv : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (0.0010000000000000009 * std::tan((fConst0 * double(fCutoff))));
+		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
 		double fSlow1 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec3[0] = (fSlow0 + (0.999 * fRec3[1]));
+			fRec3[0] = (fSlow0 + (fConst1 * fRec3[1]));
 			double fTemp1 = (fSlow1 + fRec3[0]);
-			fRec4[0] = ((0.999 * fRec4[1]) + (0.0010000000000000009 / ((fRec3[0] * fTemp1) + 1.0)));
-			fRec5[0] = ((0.999 * fRec5[1]) + (0.0010000000000000009 * fTemp1));
+			fRec4[0] = ((fConst1 * fRec4[1]) + (fConst2 / ((fRec3[0] * fTemp1) + 1.0)));
+			fRec5[0] = ((fConst1 * fRec5[1]) + (fConst2 * fTemp1));
 			double fTemp2 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fTemp3 = ((fRec3[0] * fRec4[0]) * fTemp2);
 			double fTemp4 = (fRec2[1] + (2.0 * fTemp3));
@@ -157,7 +180,9 @@ class faustLpf2pSv : public sfzFilterDsp {
 			fRec5[1] = fRec5[0];
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzLpf4p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf4p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustLpf4p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustLpf4p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,14 +30,18 @@ class faustLpf4p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec3[2];
 	double fRec4[2];
 	double fRec2[3];
+	double fConst4;
 	double fRec5[2];
 	double fRec1[3];
 	
@@ -49,13 +52,15 @@ class faustLpf4p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -64,12 +69,14 @@ class faustLpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -78,50 +85,67 @@ class faustLpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (0.5 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec4[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec5[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec1[l5] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -131,32 +155,34 @@ class faustLpf4p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (0.0010000000000000009 * fSlow4);
-		double fSlow6 = (0.0010000000000000009 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow7 = (0.0010000000000000009 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow8 = (0.00050000000000000044 * fSlow4);
+		double fSlow5 = (fConst2 * fSlow4);
+		double fSlow6 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
+		double fSlow7 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
+		double fSlow8 = (fConst4 * fSlow4);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow5 + (0.999 * fRec0[1]));
-			fRec3[0] = (fSlow6 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow7 + (0.999 * fRec4[1]));
+			fRec0[0] = (fSlow5 + (fConst1 * fRec0[1]));
+			fRec3[0] = (fSlow6 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fSlow7 + (fConst1 * fRec4[1]));
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = (fSlow8 + (0.999 * fRec5[1]));
-			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
+			fRec5[0] = (fSlow8 + (fConst1 * fRec5[1]));
+			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[2]) + (fRec3[0] * fRec1[1])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec5[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];
 			fRec3[1] = fRec3[0];
@@ -166,7 +192,9 @@ class faustLpf4p : public sfzFilterDsp {
 			fRec5[1] = fRec5[0];
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzLpf6p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf6p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustLpf6p_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustLpf6p
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,14 +30,18 @@ class faustLpf6p : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec4[2];
 	double fRec5[2];
 	double fRec3[3];
+	double fConst4;
 	double fRec6[2];
 	double fRec2[3];
 	double fRec1[3];
@@ -50,13 +53,15 @@ class faustLpf6p : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -65,12 +70,14 @@ class faustLpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -79,53 +86,71 @@ class faustLpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (0.5 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec6[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec2[l5] = 0.0;
+			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec1[l6] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -135,31 +160,33 @@ class faustLpf6p : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (0.0010000000000000009 * fSlow4);
-		double fSlow6 = (0.0010000000000000009 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow7 = (0.0010000000000000009 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow8 = (0.00050000000000000044 * fSlow4);
+		double fSlow5 = (fConst2 * fSlow4);
+		double fSlow6 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
+		double fSlow7 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
+		double fSlow8 = (fConst4 * fSlow4);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow5 + (0.999 * fRec0[1]));
-			fRec4[0] = (fSlow6 + (0.999 * fRec4[1]));
-			fRec5[0] = (fSlow7 + (0.999 * fRec5[1]));
+			fRec0[0] = (fSlow5 + (fConst1 * fRec0[1]));
+			fRec4[0] = (fSlow6 + (fConst1 * fRec4[1]));
+			fRec5[0] = (fSlow7 + (fConst1 * fRec5[1]));
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (fSlow8 + (0.999 * fRec6[1]));
+			fRec6[0] = (fSlow8 + (fConst1 * fRec6[1]));
 			fRec2[0] = (((fRec0[0] * fRec3[1]) + (fRec6[0] * (fRec3[0] + fRec3[2]))) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec6[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec6[0] * (fRec1[0] + fRec1[2]))));
@@ -173,7 +200,9 @@ class faustLpf6p : public sfzFilterDsp {
 			fRec2[1] = fRec2[0];
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzLsh.cxx
+++ b/src/sfizz/gen/filters/sfzLsh.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustLsh_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustLsh
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,15 +30,19 @@ class faustLsh : public sfzFilterDsp {
 	
  public:
 	
-	FAUSTFLOAT fPkShGain;
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	FAUSTFLOAT fPkShGain;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec1[2];
 	double fRec2[2];
 	double fRec0[3];
 	double fRec3[2];
+	double fConst4;
 	double fRec4[2];
 	double fRec5[2];
 	
@@ -50,13 +53,15 @@ class faustLsh : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -65,12 +70,14 @@ class faustLsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -79,51 +86,68 @@ class faustLsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		fConst4 = (2.0 * fConst2);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fPkShGain = FAUSTFLOAT(0.0);
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -133,36 +157,38 @@ class faustLsh : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
-		double fSlow1 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow1 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::cos(fSlow1);
-		double fSlow3 = (fSlow2 * (fSlow0 + 1.0));
-		double fSlow4 = ((std::sqrt(fSlow0) * std::sin(fSlow1)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
-		double fSlow5 = (fSlow2 * (fSlow0 + -1.0));
-		double fSlow6 = (fSlow0 + fSlow5);
-		double fSlow7 = ((fSlow4 + fSlow6) + 1.0);
-		double fSlow8 = (0.0010000000000000009 * ((0.0 - (2.0 * ((fSlow0 + fSlow3) + -1.0))) / fSlow7));
-		double fSlow9 = (0.0010000000000000009 * ((fSlow6 + (1.0 - fSlow4)) / fSlow7));
-		double fSlow10 = (0.0010000000000000009 * ((fSlow0 * ((fSlow0 + fSlow4) + (1.0 - fSlow5))) / fSlow7));
-		double fSlow11 = (0.0020000000000000018 * ((fSlow0 * (fSlow0 + (-1.0 - fSlow3))) / fSlow7));
-		double fSlow12 = (0.0010000000000000009 * ((fSlow0 * (fSlow0 + (1.0 - (fSlow4 + fSlow5)))) / fSlow7));
+		double fSlow3 = ((fSlow0 + 1.0) * fSlow2);
+		double fSlow4 = ((fSlow0 + -1.0) * fSlow2);
+		double fSlow5 = (fSlow4 + fSlow0);
+		double fSlow6 = ((std::sqrt(fSlow0) * std::sin(fSlow1)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
+		double fSlow7 = ((fSlow5 + fSlow6) + 1.0);
+		double fSlow8 = (fConst2 * ((0.0 - (2.0 * ((fSlow3 + fSlow0) + -1.0))) / fSlow7));
+		double fSlow9 = (fConst2 * ((fSlow5 + (1.0 - fSlow6)) / fSlow7));
+		double fSlow10 = (fConst2 * ((((fSlow0 + fSlow6) + (1.0 - fSlow4)) * fSlow0) / fSlow7));
+		double fSlow11 = (fConst4 * (((fSlow0 + (-1.0 - fSlow3)) * fSlow0) / fSlow7));
+		double fSlow12 = (fConst2 * (((fSlow0 + (1.0 - (fSlow4 + fSlow6))) * fSlow0) / fSlow7));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow8 + (0.999 * fRec1[1]));
-			fRec2[0] = (fSlow9 + (0.999 * fRec2[1]));
+			fRec1[0] = (fSlow8 + (fConst1 * fRec1[1]));
+			fRec2[0] = (fSlow9 + (fConst1 * fRec2[1]));
 			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow10 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow11 + (0.999 * fRec4[1]));
-			fRec5[0] = (fSlow12 + (0.999 * fRec5[1]));
+			fRec3[0] = (fSlow10 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fSlow11 + (fConst1 * fRec4[1]));
+			fRec5[0] = (fSlow12 + (fConst1 * fRec5[1]));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
@@ -171,7 +197,9 @@ class faustLsh : public sfzFilterDsp {
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
 			fRec5[1] = fRec5[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzPeq.cxx
+++ b/src/sfizz/gen/filters/sfzPeq.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustPeq_H__
@@ -21,7 +21,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustPeq
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,8 +30,11 @@ class faustPeq : public sfzFilterDsp {
 	
  public:
 	
-	int fSampleRate;
+	int fSamplingFreq;
 	double fConst0;
+	double fConst1;
+	double fConst2;
+	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	FAUSTFLOAT fPkShGain;
@@ -49,13 +51,15 @@ class faustPeq : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -64,12 +68,14 @@ class faustPeq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -78,48 +84,63 @@ class faustPeq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
-		fConst0 = (6.2831853071795862 / std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate))));
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
+		fConst2 = (1.0 - fConst1);
+		fConst3 = (6.2831853071795862 / fConst0);
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 		fPkShGain = FAUSTFLOAT(0.0);
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
+			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
+			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
+			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
+			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -129,34 +150,36 @@ class faustPeq : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst0 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::sin(fSlow0);
 		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow3 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
 		double fSlow4 = (0.5 * (fSlow1 / (fSlow2 * fSlow3)));
 		double fSlow5 = (fSlow4 + 1.0);
-		double fSlow6 = (0.0010000000000000009 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow5));
-		double fSlow7 = (0.0010000000000000009 * ((1.0 - fSlow4) / fSlow5));
+		double fSlow6 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow5));
+		double fSlow7 = (fConst2 * ((1.0 - fSlow4) / fSlow5));
 		double fSlow8 = (0.5 * ((fSlow1 * fSlow3) / fSlow2));
-		double fSlow9 = (0.0010000000000000009 * ((fSlow8 + 1.0) / fSlow5));
-		double fSlow10 = (0.0010000000000000009 * ((1.0 - fSlow8) / fSlow5));
+		double fSlow9 = (fConst2 * ((fSlow8 + 1.0) / fSlow5));
+		double fSlow10 = (fConst2 * ((1.0 - fSlow8) / fSlow5));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow6 + (0.999 * fRec1[1]));
+			fRec1[0] = (fSlow6 + (fConst1 * fRec1[1]));
 			double fTemp1 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = (fSlow7 + (0.999 * fRec2[1]));
+			fRec2[0] = (fSlow7 + (fConst1 * fRec2[1]));
 			fRec0[0] = (fTemp0 - (fTemp1 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow9 + (0.999 * fRec3[1]));
-			fRec4[0] = (fSlow10 + (0.999 * fRec4[1]));
+			fRec3[0] = (fSlow9 + (fConst1 * fRec3[1]));
+			fRec4[0] = (fSlow10 + (fConst1 * fRec4[1]));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp1) + (fRec4[0] * fRec0[2])));
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
@@ -164,7 +187,9 @@ class faustPeq : public sfzFilterDsp {
 			fRec0[1] = fRec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
+			
 		}
+		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzPink.cxx
+++ b/src/sfizz/gen/filters/sfzPink.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.20.2 (https://faust.grame.fr)
-Compilation options: -lang cpp -inpl -double -ftz 0
+Code generated with Faust 2.15.11 (https://faust.grame.fr)
+Compilation options: -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustPink_H__
@@ -20,7 +20,6 @@ Compilation options: -lang cpp -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustPink
 #endif
-
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,7 +30,7 @@ class faustPink : public sfzFilterDsp {
  public:
 	
 	double fRec0[4];
-	int fSampleRate;
+	int fSamplingFreq;
 	
  public:
 	
@@ -40,13 +39,15 @@ class faustPink : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
+		
 	}
 	virtual int getNumOutputs() {
 		return 1;
+		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -55,12 +56,14 @@ class faustPink : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch ((channel)) {
+		switch (channel) {
 			case 0: {
 				rate = 1;
 				break;
@@ -69,32 +72,40 @@ class faustPink : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
+			
 		}
 		return rate;
+		
 	}
 	
-	static void classInit(int sample_rate) {
+	static void classInit(int samplingFreq) {
+		
 	}
 	
-	virtual void instanceConstants(int sample_rate) {
-		fSampleRate = sample_rate;
+	virtual void instanceConstants(int samplingFreq) {
+		fSamplingFreq = samplingFreq;
+		
 	}
 	
 	virtual void instanceResetUserInterface() {
+		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 4); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
+			
 		}
+		
 	}
 	
-	virtual void init(int sample_rate) {
-		classInit(sample_rate);
-		instanceInit(sample_rate);
+	virtual void init(int samplingFreq) {
+		classInit(samplingFreq);
+		instanceInit(samplingFreq);
 	}
-	virtual void instanceInit(int sample_rate) {
-		instanceConstants(sample_rate);
+	
+	virtual void instanceInit(int samplingFreq) {
+		instanceConstants(samplingFreq);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -104,10 +115,12 @@ class faustPink : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSampleRate;
+		return fSamplingFreq;
+		
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
+		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -115,12 +128,15 @@ class faustPink : public sfzFilterDsp {
 		FAUSTFLOAT* output0 = outputs[0];
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = ((fTemp0 + ((2.4949560019999999 * fRec0[1]) + (0.52218940000000003 * fRec0[3]))) - (2.0172658750000001 * fRec0[2]));
+			fRec0[0] = ((((2.4949560019999999 * fRec0[1]) + (0.52218940000000003 * fRec0[3])) + fTemp0) - (2.0172658750000001 * fRec0[2]));
 			output0[i] = FAUSTFLOAT((((0.049922034999999997 * fRec0[0]) + (0.050612698999999997 * fRec0[2])) - ((0.095993537000000004 * fRec0[1]) + (0.0044087859999999996 * fRec0[3]))));
 			for (int j0 = 3; (j0 > 0); j0 = (j0 - 1)) {
 				fRec0[j0] = fRec0[(j0 - 1)];
+				
 			}
+			
 		}
+		
 	}
 
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ sfizz_enable_lto_if_needed(sfizz_tests)
 
 find_package(PkgConfig)
 if(PKGCONFIG_FOUND)
-    pkg_check_modules(JACK "jack")
+pkg_check_modules(JACK "jack")
 endif()
 find_package(Qt5 COMPONENTS Widgets)
 
@@ -49,5 +49,12 @@ if(JACK_FOUND AND TARGET Qt5::Widgets)
     target_link_libraries(sfizz_demo_stereo PRIVATE sfizz::sfizz Qt5::Widgets ${JACK_LIBRARIES})
     set_target_properties(sfizz_demo_stereo PROPERTIES AUTOUIC ON)
 endif()
+
+add_executable(eq_apply EQ.cpp)
+target_link_libraries(eq_apply PRIVATE sfizz::sfizz)
+
+add_executable(filter_apply Filter.cpp)
+target_link_libraries(filter_apply PRIVATE sfizz::sfizz)
+
 
 file(COPY "." DESTINATION ${CMAKE_BINARY_DIR}/tests)

--- a/tests/DemoFilters.cpp
+++ b/tests/DemoFilters.cpp
@@ -5,6 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "sfizz/SfzFilter.h"
+#include "sfizz/MathHelpers.h"
 #include "ui_DemoFilters.h"
 #include <QApplication>
 #include <QMainWindow>
@@ -294,7 +295,10 @@ int DemoApp::processAudio(jack_nframes_t nframes, void *cbdata)
 
     for (jack_nframes_t i = 0; i < nframes; ++i) {
         float lfo = cutoffMod * triangleLfo(cutoffLfoPhase);
-        tempCutoff[i] *= std::exp2(lfo * (1.0f / 12.0f));
+        float modCutoff = tempCutoff[i];
+        modCutoff *= std::exp2(lfo * (1.0f / 12.0f));
+        modCutoff = clamp(modCutoff, 0.0f, 20000.0f);
+        tempCutoff[i] = modCutoff;
         cutoffLfoPhase += cutoffRate * sampleTime;
         cutoffLfoPhase -= (int)cutoffLfoPhase;
     }

--- a/tests/DemoFilters.ui
+++ b/tests/DemoFilters.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>415</width>
-    <height>216</height>
+    <height>304</height>
    </rect>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QGridLayout" name="gridLayout_2">
+   <layout class="QGridLayout" name="gridLayout_4">
     <item row="0" column="0">
      <widget class="QDial" name="dialCutoff"/>
     </item>
@@ -227,6 +227,83 @@
           </size>
          </property>
         </spacer>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item row="4" column="0" colspan="3">
+     <widget class="QGroupBox" name="groupBox">
+      <property name="title">
+       <string>Cutoff modulation</string>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>Speed</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QSlider" name="valCutoffModSpeed">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLabel" name="lblCutoffModSpeed">
+         <property name="minimumSize">
+          <size>
+           <width>60</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QLabel" name="label_8">
+         <property name="text">
+          <string>Hz</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>Range</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QSlider" name="valCutoffModRange">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QLabel" name="lblCutoffModRange">
+         <property name="minimumSize">
+          <size>
+           <width>60</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="QLabel" name="label_9">
+         <property name="text">
+          <string>semitones</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/tests/EQ.cpp
+++ b/tests/EQ.cpp
@@ -1,0 +1,96 @@
+#include "sfizz/SfzFilter.h"
+#include "sfizz/Buffer.h"
+#include "sfizz/SIMDHelpers.h"
+#include "ghc/filesystem.hpp"
+#include "cxxopts.hpp"
+#include "sfizz/StringViewHelpers.h"
+#include <sndfile.hh>
+#include <string>
+#include <iostream>
+
+namespace fs = ghc::filesystem;
+
+int main(int argc, char** argv)
+{
+    (void)argc;
+
+    cxxopts::Options options("test", "A brief description");
+
+    float gain { 0.0f };
+    float frequency { 50.0f };
+    float bandwidth { 1.0f };
+
+    options.add_options()
+        ("g,gain", "Gain", cxxopts::value(gain))
+        ("f,frequency", "Frequency", cxxopts::value(frequency))
+        ("b,bandwidth", "Bandwidth", cxxopts::value(bandwidth))
+        ("h,help", "Print usage")
+    ;
+
+    auto result = options.parse(argc, argv);
+    // options.parse_positional({ "filename" });
+
+    if (result.count("help"))
+    {
+        std::cout << options.help() << std::endl;
+        return 0;
+    }
+
+    if (argc == 1) {
+        std::cout << "Need a file name" << '\n';
+        return -1;
+    }
+
+    std::cout << "File: " << argv[1]  << '\n';
+    std::cout << "Gain: " << gain << '\n';
+    std::cout << "Frequency: " << frequency << '\n';
+    std::cout << "Bandwidth: " << bandwidth << '\n';
+
+    auto path = fs::current_path() / argv[1];
+    if (!fs::exists(path)) {
+        std::cout << "Can't find " << argv[1] << '\n';
+        return -1;
+    }
+
+    std::cout << "Opening " << path.native() << '\n';
+    SndfileHandle sndfile { path.native() };
+    if (sndfile.error()) {
+        std::cout << "Input file error" << '\n';
+        std::cout << sndfile.strError() << '\n';
+        return -1;
+    }
+
+    auto numFrames = static_cast<size_t>(sndfile.frames());
+
+    sfz::Buffer<float> left { numFrames };
+
+    if (sndfile.channels() == 2) {
+        sfz::Buffer<float> buffer { numFrames * 2 };
+        sfz::Buffer<float> right { numFrames };
+        sndfile.readf(buffer.data(), numFrames * 2 );
+        sfz::readInterleaved<float>(buffer, absl::MakeSpan(left), absl::MakeSpan(right));
+    } else if (sndfile.channels() == 1) {
+        sndfile.readf(left.data(), numFrames);
+    } else {
+        std::cout << "Unhandled number of channels:" << sndfile.channels() << '\n';
+    }
+
+    sfz::Buffer<float> output { numFrames };
+    sfz::FilterEq eq;
+    eq.init(sndfile.samplerate());
+    float* in [1] = { left.data() };
+    float* out [1] = { output.data() };
+    eq.process(in, out, frequency, bandwidth, gain, numFrames);
+
+    auto outputFile = fs::current_path() / path.stem().concat("_processed").concat(path.extension());
+    SndfileHandle outSndfile { outputFile.native(), SFM_WRITE, sndfile.format(), 1, sndfile.samplerate() };
+    if (outSndfile.error() != 0 && outSndfile.error() != 2) {
+        std::cout << "Output file error: " << outSndfile.error() << '\n';
+        std::cout << outSndfile.strError() << '\n';
+        return -1;
+    }
+    std::cout << "Writing to " << outputFile.native() << '\n';
+    outSndfile.writef(output.data(), output.size());
+
+    return 0;
+}

--- a/tests/Filter.cpp
+++ b/tests/Filter.cpp
@@ -1,0 +1,129 @@
+#include "sfizz/SfzFilter.h"
+#include "sfizz/Buffer.h"
+#include "sfizz/SIMDHelpers.h"
+#include "ghc/filesystem.hpp"
+#include "cxxopts.hpp"
+#include "sfizz/StringViewHelpers.h"
+#include <sndfile.hh>
+#include <string>
+#include <iostream>
+
+namespace fs = ghc::filesystem;
+
+int main(int argc, char** argv)
+{
+    (void)argc;
+
+    cxxopts::Options options("test", "A brief description");
+
+    float gain { 0.0f };
+    float cutoff { 50.0f };
+    float resonance { 1.0f };
+    std::string filterType { };
+
+    options.add_options()
+        ("g,gain", "Gain", cxxopts::value(gain))
+        ("c,cutoff", "Cutoff", cxxopts::value(cutoff))
+        ("r,resonance", "Resonance", cxxopts::value(resonance))
+        ("q", "Q factor", cxxopts::value(resonance))
+        ("h,help", "Print usage")
+    ;
+
+    auto result = options.parse(argc, argv);
+    // options.parse_positional({ "filename" });
+
+    if (result.count("help"))
+    {
+        std::cout << options.help() << std::endl;
+        return 0;
+    }
+
+    if (argc == 1) {
+        std::cout << "Need a file name" << '\n';
+        return -1;
+    }
+
+    std::cout << "File: " << argv[1]  << '\n';
+    std::cout << "Gain: " << gain << '\n';
+    std::cout << "Cutoff: " << cutoff << '\n';
+    std::cout << "Filter type: " << filterType << '\n';
+    std::cout << "Resonance: " << resonance << '\n';
+
+    auto path = fs::current_path() / argv[1];
+    if (!fs::exists(path)) {
+        std::cout << "Can't find " << argv[1] << '\n';
+        return -1;
+    }
+
+    std::cout << "Opening " << path.native() << '\n';
+    SndfileHandle sndfile { path.native() };
+    if (sndfile.error()) {
+        std::cout << "Input file error" << '\n';
+        std::cout << sndfile.strError() << '\n';
+        return -1;
+    }
+
+    auto numFrames = static_cast<size_t>(sndfile.frames());
+
+    sfz::Buffer<float> left { numFrames };
+
+    if (sndfile.channels() == 2) {
+        sfz::Buffer<float> buffer { numFrames * 2 };
+        sfz::Buffer<float> right { numFrames };
+        sndfile.readf(buffer.data(), numFrames * 2 );
+        sfz::readInterleaved<float>(buffer, absl::MakeSpan(left), absl::MakeSpan(right));
+    } else if (sndfile.channels() == 1) {
+        sndfile.readf(left.data(), numFrames);
+    } else {
+        std::cout << "Unhandled number of channels:" << sndfile.channels() << '\n';
+    }
+
+    sfz::Buffer<float> output { numFrames };
+    sfz::Filter filter;
+    filter.init(sndfile.samplerate());
+
+    switch(hash(filterType)) {
+        case hash("Apf1p"): filter.setType(sfz::FilterType::kFilterApf1p); break;
+        case hash("Bpf1p"): filter.setType(sfz::FilterType::kFilterBpf1p); break;
+        case hash("Bpf2p"): filter.setType(sfz::FilterType::kFilterBpf2p); break;
+        case hash("Bpf4p"): filter.setType(sfz::FilterType::kFilterBpf4p); break;
+        case hash("Bpf6p"): filter.setType(sfz::FilterType::kFilterBpf6p); break;
+        case hash("Brf1p"): filter.setType(sfz::FilterType::kFilterBrf1p); break;
+        case hash("Brf2p"): filter.setType(sfz::FilterType::kFilterBrf2p); break;
+        case hash("Hpf1p"): filter.setType(sfz::FilterType::kFilterHpf1p); break;
+        case hash("Hpf2p"): filter.setType(sfz::FilterType::kFilterHpf2p); break;
+        case hash("Hpf4p"): filter.setType(sfz::FilterType::kFilterHpf4p); break;
+        case hash("Hpf6p"): filter.setType(sfz::FilterType::kFilterHpf6p); break;
+        case hash("Lpf1p"): filter.setType(sfz::FilterType::kFilterLpf1p); break;
+        case hash("Lpf2p"): filter.setType(sfz::FilterType::kFilterLpf2p); break;
+        case hash("Lpf4p"): filter.setType(sfz::FilterType::kFilterLpf4p); break;
+        case hash("Lpf6p"): filter.setType(sfz::FilterType::kFilterLpf6p); break;
+        case hash("Pink"): filter.setType(sfz::FilterType::kFilterPink); break;
+        case hash("Lpf2pSv"): filter.setType(sfz::FilterType::kFilterLpf2pSv); break;
+        case hash("Hpf2pSv"): filter.setType(sfz::FilterType::kFilterHpf2pSv); break;
+        case hash("Bpf2pSv"): filter.setType(sfz::FilterType::kFilterBpf2pSv); break;
+        case hash("Brf2pSv"): filter.setType(sfz::FilterType::kFilterBrf2pSv); break;
+        case hash("Lsh"): filter.setType(sfz::FilterType::kFilterLsh); break;
+        case hash("Hsh"): filter.setType(sfz::FilterType::kFilterHsh); break;
+        case hash("Peq"): filter.setType(sfz::FilterType::kFilterPeq); break;
+        default:
+            std::cout << "Unknown filter type" << '\n';
+            return -1;
+    }
+
+    float* in [1] = { left.data() };
+    float* out [1] = { output.data() };
+    filter.process(in, out, cutoff, resonance, gain, numFrames);
+
+    auto outputFile = fs::current_path() / path.stem().concat("_processed").concat(path.extension());
+    SndfileHandle outSndfile { outputFile.native(), SFM_WRITE, sndfile.format(), 1, sndfile.samplerate() };
+    if (outSndfile.error() != 0 && outSndfile.error() != 2) {
+        std::cout << "Output file error: " << outSndfile.error() << '\n';
+        std::cout << outSndfile.strError() << '\n';
+        return -1;
+    }
+    std::cout << "Writing to " << outputFile.native() << '\n';
+    outSndfile.writef(output.data(), output.size());
+
+    return 0;
+}

--- a/tests/cxxopts.hpp
+++ b/tests/cxxopts.hpp
@@ -1,0 +1,2104 @@
+/*
+
+Copyright (c) 2014, 2015, 2016, 2017 Jarryd Beck
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+#ifndef CXXOPTS_HPP_INCLUDED
+#define CXXOPTS_HPP_INCLUDED
+
+#include <cstring>
+#include <cctype>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <memory>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#ifdef __cpp_lib_optional
+#include <optional>
+#define CXXOPTS_HAS_OPTIONAL
+#endif
+
+#ifndef CXXOPTS_VECTOR_DELIMITER
+#define CXXOPTS_VECTOR_DELIMITER ','
+#endif
+
+#define CXXOPTS__VERSION_MAJOR 2
+#define CXXOPTS__VERSION_MINOR 2
+#define CXXOPTS__VERSION_PATCH 0
+
+namespace cxxopts
+{
+  static constexpr struct {
+    uint8_t major, minor, patch;
+  } version = {
+    CXXOPTS__VERSION_MAJOR,
+    CXXOPTS__VERSION_MINOR,
+    CXXOPTS__VERSION_PATCH
+  };
+}
+
+//when we ask cxxopts to use Unicode, help strings are processed using ICU,
+//which results in the correct lengths being computed for strings when they
+//are formatted for the help output
+//it is necessary to make sure that <unicode/unistr.h> can be found by the
+//compiler, and that icu-uc is linked in to the binary.
+
+#ifdef CXXOPTS_USE_UNICODE
+#include <unicode/unistr.h>
+
+namespace cxxopts
+{
+  typedef icu::UnicodeString String;
+
+  inline
+  String
+  toLocalString(std::string s)
+  {
+    return icu::UnicodeString::fromUTF8(std::move(s));
+  }
+
+  class UnicodeStringIterator : public
+    std::iterator<std::forward_iterator_tag, int32_t>
+  {
+    public:
+
+    UnicodeStringIterator(const icu::UnicodeString* string, int32_t pos)
+    : s(string)
+    , i(pos)
+    {
+    }
+
+    value_type
+    operator*() const
+    {
+      return s->char32At(i);
+    }
+
+    bool
+    operator==(const UnicodeStringIterator& rhs) const
+    {
+      return s == rhs.s && i == rhs.i;
+    }
+
+    bool
+    operator!=(const UnicodeStringIterator& rhs) const
+    {
+      return !(*this == rhs);
+    }
+
+    UnicodeStringIterator&
+    operator++()
+    {
+      ++i;
+      return *this;
+    }
+
+    UnicodeStringIterator
+    operator+(int32_t v)
+    {
+      return UnicodeStringIterator(s, i + v);
+    }
+
+    private:
+    const icu::UnicodeString* s;
+    int32_t i;
+  };
+
+  inline
+  String&
+  stringAppend(String&s, String a)
+  {
+    return s.append(std::move(a));
+  }
+
+  inline
+  String&
+  stringAppend(String& s, int n, UChar32 c)
+  {
+    for (int i = 0; i != n; ++i)
+    {
+      s.append(c);
+    }
+
+    return s;
+  }
+
+  template <typename Iterator>
+  String&
+  stringAppend(String& s, Iterator begin, Iterator end)
+  {
+    while (begin != end)
+    {
+      s.append(*begin);
+      ++begin;
+    }
+
+    return s;
+  }
+
+  inline
+  size_t
+  stringLength(const String& s)
+  {
+    return s.length();
+  }
+
+  inline
+  std::string
+  toUTF8String(const String& s)
+  {
+    std::string result;
+    s.toUTF8String(result);
+
+    return result;
+  }
+
+  inline
+  bool
+  empty(const String& s)
+  {
+    return s.isEmpty();
+  }
+}
+
+namespace std
+{
+  inline
+  cxxopts::UnicodeStringIterator
+  begin(const icu::UnicodeString& s)
+  {
+    return cxxopts::UnicodeStringIterator(&s, 0);
+  }
+
+  inline
+  cxxopts::UnicodeStringIterator
+  end(const icu::UnicodeString& s)
+  {
+    return cxxopts::UnicodeStringIterator(&s, s.length());
+  }
+}
+
+//ifdef CXXOPTS_USE_UNICODE
+#else
+
+namespace cxxopts
+{
+  typedef std::string String;
+
+  template <typename T>
+  T
+  toLocalString(T&& t)
+  {
+    return std::forward<T>(t);
+  }
+
+  inline
+  size_t
+  stringLength(const String& s)
+  {
+    return s.length();
+  }
+
+  inline
+  String&
+  stringAppend(String&s, String a)
+  {
+    return s.append(std::move(a));
+  }
+
+  inline
+  String&
+  stringAppend(String& s, size_t n, char c)
+  {
+    return s.append(n, c);
+  }
+
+  template <typename Iterator>
+  String&
+  stringAppend(String& s, Iterator begin, Iterator end)
+  {
+    return s.append(begin, end);
+  }
+
+  template <typename T>
+  std::string
+  toUTF8String(T&& t)
+  {
+    return std::forward<T>(t);
+  }
+
+  inline
+  bool
+  empty(const std::string& s)
+  {
+    return s.empty();
+  }
+}
+
+//ifdef CXXOPTS_USE_UNICODE
+#endif
+
+namespace cxxopts
+{
+  namespace
+  {
+#ifdef _WIN32
+    const std::string LQUOTE("\'");
+    const std::string RQUOTE("\'");
+#else
+    const std::string LQUOTE("‘");
+    const std::string RQUOTE("’");
+#endif
+  }
+
+  class Value : public std::enable_shared_from_this<Value>
+  {
+    public:
+
+    virtual ~Value() = default;
+
+    virtual
+    std::shared_ptr<Value>
+    clone() const = 0;
+
+    virtual void
+    parse(const std::string& text) const = 0;
+
+    virtual void
+    parse() const = 0;
+
+    virtual bool
+    has_default() const = 0;
+
+    virtual bool
+    is_container() const = 0;
+
+    virtual bool
+    has_implicit() const = 0;
+
+    virtual std::string
+    get_default_value() const = 0;
+
+    virtual std::string
+    get_implicit_value() const = 0;
+
+    virtual std::shared_ptr<Value>
+    default_value(const std::string& value) = 0;
+
+    virtual std::shared_ptr<Value>
+    implicit_value(const std::string& value) = 0;
+
+    virtual std::shared_ptr<Value>
+    no_implicit_value() = 0;
+
+    virtual bool
+    is_boolean() const = 0;
+  };
+
+  class OptionException : public std::exception
+  {
+    public:
+    OptionException(const std::string& message)
+    : m_message(message)
+    {
+    }
+
+    virtual const char*
+    what() const noexcept
+    {
+      return m_message.c_str();
+    }
+
+    private:
+    std::string m_message;
+  };
+
+  class OptionSpecException : public OptionException
+  {
+    public:
+
+    OptionSpecException(const std::string& message)
+    : OptionException(message)
+    {
+    }
+  };
+
+  class OptionParseException : public OptionException
+  {
+    public:
+    OptionParseException(const std::string& message)
+    : OptionException(message)
+    {
+    }
+  };
+
+  class option_exists_error : public OptionSpecException
+  {
+    public:
+    option_exists_error(const std::string& option)
+    : OptionSpecException("Option " + LQUOTE + option + RQUOTE + " already exists")
+    {
+    }
+  };
+
+  class invalid_option_format_error : public OptionSpecException
+  {
+    public:
+    invalid_option_format_error(const std::string& format)
+    : OptionSpecException("Invalid option format " + LQUOTE + format + RQUOTE)
+    {
+    }
+  };
+
+  class option_syntax_exception : public OptionParseException {
+    public:
+    option_syntax_exception(const std::string& text)
+    : OptionParseException("Argument " + LQUOTE + text + RQUOTE +
+        " starts with a - but has incorrect syntax")
+    {
+    }
+  };
+
+  class option_not_exists_exception : public OptionParseException
+  {
+    public:
+    option_not_exists_exception(const std::string& option)
+    : OptionParseException("Option " + LQUOTE + option + RQUOTE + " does not exist")
+    {
+    }
+  };
+
+  class missing_argument_exception : public OptionParseException
+  {
+    public:
+    missing_argument_exception(const std::string& option)
+    : OptionParseException(
+        "Option " + LQUOTE + option + RQUOTE + " is missing an argument"
+      )
+    {
+    }
+  };
+
+  class option_requires_argument_exception : public OptionParseException
+  {
+    public:
+    option_requires_argument_exception(const std::string& option)
+    : OptionParseException(
+        "Option " + LQUOTE + option + RQUOTE + " requires an argument"
+      )
+    {
+    }
+  };
+
+  class option_not_has_argument_exception : public OptionParseException
+  {
+    public:
+    option_not_has_argument_exception
+    (
+      const std::string& option,
+      const std::string& arg
+    )
+    : OptionParseException(
+        "Option " + LQUOTE + option + RQUOTE +
+        " does not take an argument, but argument " +
+        LQUOTE + arg + RQUOTE + " given"
+      )
+    {
+    }
+  };
+
+  class option_not_present_exception : public OptionParseException
+  {
+    public:
+    option_not_present_exception(const std::string& option)
+    : OptionParseException("Option " + LQUOTE + option + RQUOTE + " not present")
+    {
+    }
+  };
+
+  class argument_incorrect_type : public OptionParseException
+  {
+    public:
+    argument_incorrect_type
+    (
+      const std::string& arg
+    )
+    : OptionParseException(
+        "Argument " + LQUOTE + arg + RQUOTE + " failed to parse"
+      )
+    {
+    }
+  };
+
+  class option_required_exception : public OptionParseException
+  {
+    public:
+    option_required_exception(const std::string& option)
+    : OptionParseException(
+        "Option " + LQUOTE + option + RQUOTE + " is required but not present"
+      )
+    {
+    }
+  };
+
+  namespace values
+  {
+    namespace
+    {
+      std::basic_regex<char> integer_pattern
+        ("(-)?(0x)?([0-9a-zA-Z]+)|((0x)?0)");
+      std::basic_regex<char> truthy_pattern
+        ("(t|T)(rue)?|1");
+      std::basic_regex<char> falsy_pattern
+        ("(f|F)(alse)?|0");
+    }
+
+    namespace detail
+    {
+      template <typename T, bool B>
+      struct SignedCheck;
+
+      template <typename T>
+      struct SignedCheck<T, true>
+      {
+        template <typename U>
+        void
+        operator()(bool negative, U u, const std::string& text)
+        {
+          if (negative)
+          {
+            if (u > static_cast<U>((std::numeric_limits<T>::min)()))
+            {
+              throw argument_incorrect_type(text);
+            }
+          }
+          else
+          {
+            if (u > static_cast<U>((std::numeric_limits<T>::max)()))
+            {
+              throw argument_incorrect_type(text);
+            }
+          }
+        }
+      };
+
+      template <typename T>
+      struct SignedCheck<T, false>
+      {
+        template <typename U>
+        void
+        operator()(bool, U, const std::string&) {}
+      };
+
+      template <typename T, typename U>
+      void
+      check_signed_range(bool negative, U value, const std::string& text)
+      {
+        SignedCheck<T, std::numeric_limits<T>::is_signed>()(negative, value, text);
+      }
+    }
+
+    template <typename R, typename T>
+    R
+    checked_negate(T&& t, const std::string&, std::true_type)
+    {
+      // if we got to here, then `t` is a positive number that fits into
+      // `R`. So to avoid MSVC C4146, we first cast it to `R`.
+      // See https://github.com/jarro2783/cxxopts/issues/62 for more details.
+      return -static_cast<R>(t-1)-1;
+    }
+
+    template <typename R, typename T>
+    T
+    checked_negate(T&&, const std::string& text, std::false_type)
+    {
+      throw argument_incorrect_type(text);
+    }
+
+    template <typename T>
+    void
+    integer_parser(const std::string& text, T& value)
+    {
+      std::smatch match;
+      std::regex_match(text, match, integer_pattern);
+
+      if (match.length() == 0)
+      {
+        throw argument_incorrect_type(text);
+      }
+
+      if (match.length(4) > 0)
+      {
+        value = 0;
+        return;
+      }
+
+      using US = typename std::make_unsigned<T>::type;
+
+      constexpr bool is_signed = std::numeric_limits<T>::is_signed;
+      const bool negative = match.length(1) > 0;
+      const uint8_t base = match.length(2) > 0 ? 16 : 10;
+
+      auto value_match = match[3];
+
+      US result = 0;
+
+      for (auto iter = value_match.first; iter != value_match.second; ++iter)
+      {
+        US digit = 0;
+
+        if (*iter >= '0' && *iter <= '9')
+        {
+          digit = static_cast<US>(*iter - '0');
+        }
+        else if (base == 16 && *iter >= 'a' && *iter <= 'f')
+        {
+          digit = static_cast<US>(*iter - 'a' + 10);
+        }
+        else if (base == 16 && *iter >= 'A' && *iter <= 'F')
+        {
+          digit = static_cast<US>(*iter - 'A' + 10);
+        }
+        else
+        {
+          throw argument_incorrect_type(text);
+        }
+
+        US next = result * base + digit;
+        if (result > next)
+        {
+          throw argument_incorrect_type(text);
+        }
+
+        result = next;
+      }
+
+      detail::check_signed_range<T>(negative, result, text);
+
+      if (negative)
+      {
+        value = checked_negate<T>(result,
+          text,
+          std::integral_constant<bool, is_signed>());
+      }
+      else
+      {
+        value = static_cast<T>(result);
+      }
+    }
+
+    template <typename T>
+    void stringstream_parser(const std::string& text, T& value)
+    {
+      std::stringstream in(text);
+      in >> value;
+      if (!in) {
+        throw argument_incorrect_type(text);
+      }
+    }
+
+    inline
+    void
+    parse_value(const std::string& text, uint8_t& value)
+    {
+      integer_parser(text, value);
+    }
+
+    inline
+    void
+    parse_value(const std::string& text, int8_t& value)
+    {
+      integer_parser(text, value);
+    }
+
+    inline
+    void
+    parse_value(const std::string& text, uint16_t& value)
+    {
+      integer_parser(text, value);
+    }
+
+    inline
+    void
+    parse_value(const std::string& text, int16_t& value)
+    {
+      integer_parser(text, value);
+    }
+
+    inline
+    void
+    parse_value(const std::string& text, uint32_t& value)
+    {
+      integer_parser(text, value);
+    }
+
+    inline
+    void
+    parse_value(const std::string& text, int32_t& value)
+    {
+      integer_parser(text, value);
+    }
+
+    inline
+    void
+    parse_value(const std::string& text, uint64_t& value)
+    {
+      integer_parser(text, value);
+    }
+
+    inline
+    void
+    parse_value(const std::string& text, int64_t& value)
+    {
+      integer_parser(text, value);
+    }
+
+    inline
+    void
+    parse_value(const std::string& text, bool& value)
+    {
+      std::smatch result;
+      std::regex_match(text, result, truthy_pattern);
+
+      if (!result.empty())
+      {
+        value = true;
+        return;
+      }
+
+      std::regex_match(text, result, falsy_pattern);
+      if (!result.empty())
+      {
+        value = false;
+        return;
+      }
+
+      throw argument_incorrect_type(text);
+    }
+
+    inline
+    void
+    parse_value(const std::string& text, std::string& value)
+    {
+      value = text;
+    }
+
+    // The fallback parser. It uses the stringstream parser to parse all types
+    // that have not been overloaded explicitly.  It has to be placed in the
+    // source code before all other more specialized templates.
+    template <typename T>
+    void
+    parse_value(const std::string& text, T& value) {
+      stringstream_parser(text, value);
+    }
+
+    template <typename T>
+    void
+    parse_value(const std::string& text, std::vector<T>& value)
+    {
+      std::stringstream in(text);
+      std::string token;
+      while(in.eof() == false && std::getline(in, token, CXXOPTS_VECTOR_DELIMITER)) {
+        T v;
+        parse_value(token, v);
+        value.emplace_back(std::move(v));
+      }
+    }
+
+#ifdef CXXOPTS_HAS_OPTIONAL
+    template <typename T>
+    void
+    parse_value(const std::string& text, std::optional<T>& value)
+    {
+      T result;
+      parse_value(text, result);
+      value = std::move(result);
+    }
+#endif
+
+    template <typename T>
+    struct type_is_container
+    {
+      static constexpr bool value = false;
+    };
+
+    template <typename T>
+    struct type_is_container<std::vector<T>>
+    {
+      static constexpr bool value = true;
+    };
+
+    template <typename T>
+    class abstract_value : public Value
+    {
+      using Self = abstract_value<T>;
+
+      public:
+      abstract_value()
+      : m_result(std::make_shared<T>())
+      , m_store(m_result.get())
+      {
+      }
+
+      abstract_value(T* t)
+      : m_store(t)
+      {
+      }
+
+      virtual ~abstract_value() = default;
+
+      abstract_value(const abstract_value& rhs)
+      {
+        if (rhs.m_result)
+        {
+          m_result = std::make_shared<T>();
+          m_store = m_result.get();
+        }
+        else
+        {
+          m_store = rhs.m_store;
+        }
+
+        m_default = rhs.m_default;
+        m_implicit = rhs.m_implicit;
+        m_default_value = rhs.m_default_value;
+        m_implicit_value = rhs.m_implicit_value;
+      }
+
+      void
+      parse(const std::string& text) const
+      {
+        parse_value(text, *m_store);
+      }
+
+      bool
+      is_container() const
+      {
+        return type_is_container<T>::value;
+      }
+
+      void
+      parse() const
+      {
+        parse_value(m_default_value, *m_store);
+      }
+
+      bool
+      has_default() const
+      {
+        return m_default;
+      }
+
+      bool
+      has_implicit() const
+      {
+        return m_implicit;
+      }
+
+      std::shared_ptr<Value>
+      default_value(const std::string& value)
+      {
+        m_default = true;
+        m_default_value = value;
+        return shared_from_this();
+      }
+
+      std::shared_ptr<Value>
+      implicit_value(const std::string& value)
+      {
+        m_implicit = true;
+        m_implicit_value = value;
+        return shared_from_this();
+      }
+
+      std::shared_ptr<Value>
+      no_implicit_value()
+      {
+        m_implicit = false;
+        return shared_from_this();
+      }
+
+      std::string
+      get_default_value() const
+      {
+        return m_default_value;
+      }
+
+      std::string
+      get_implicit_value() const
+      {
+        return m_implicit_value;
+      }
+
+      bool
+      is_boolean() const
+      {
+        return std::is_same<T, bool>::value;
+      }
+
+      const T&
+      get() const
+      {
+        if (m_store == nullptr)
+        {
+          return *m_result;
+        }
+        else
+        {
+          return *m_store;
+        }
+      }
+
+      protected:
+      std::shared_ptr<T> m_result;
+      T* m_store;
+
+      bool m_default = false;
+      bool m_implicit = false;
+
+      std::string m_default_value;
+      std::string m_implicit_value;
+    };
+
+    template <typename T>
+    class standard_value : public abstract_value<T>
+    {
+      public:
+      using abstract_value<T>::abstract_value;
+
+      std::shared_ptr<Value>
+      clone() const
+      {
+        return std::make_shared<standard_value<T>>(*this);
+      }
+    };
+
+    template <>
+    class standard_value<bool> : public abstract_value<bool>
+    {
+      public:
+      ~standard_value() = default;
+
+      standard_value()
+      {
+        set_default_and_implicit();
+      }
+
+      standard_value(bool* b)
+      : abstract_value(b)
+      {
+        set_default_and_implicit();
+      }
+
+      std::shared_ptr<Value>
+      clone() const
+      {
+        return std::make_shared<standard_value<bool>>(*this);
+      }
+
+      private:
+
+      void
+      set_default_and_implicit()
+      {
+        m_default = true;
+        m_default_value = "false";
+        m_implicit = true;
+        m_implicit_value = "true";
+      }
+    };
+  }
+
+  template <typename T>
+  std::shared_ptr<Value>
+  value()
+  {
+    return std::make_shared<values::standard_value<T>>();
+  }
+
+  template <typename T>
+  std::shared_ptr<Value>
+  value(T& t)
+  {
+    return std::make_shared<values::standard_value<T>>(&t);
+  }
+
+  class OptionAdder;
+
+  class OptionDetails
+  {
+    public:
+    OptionDetails
+    (
+      const std::string& short_,
+      const std::string& long_,
+      const String& desc,
+      std::shared_ptr<const Value> val
+    )
+    : m_short(short_)
+    , m_long(long_)
+    , m_desc(desc)
+    , m_value(val)
+    , m_count(0)
+    {
+    }
+
+    OptionDetails(const OptionDetails& rhs)
+    : m_desc(rhs.m_desc)
+    , m_count(rhs.m_count)
+    {
+      m_value = rhs.m_value->clone();
+    }
+
+    OptionDetails(OptionDetails&& rhs) = default;
+
+    const String&
+    description() const
+    {
+      return m_desc;
+    }
+
+    const Value& value() const {
+        return *m_value;
+    }
+
+    std::shared_ptr<Value>
+    make_storage() const
+    {
+      return m_value->clone();
+    }
+
+    const std::string&
+    short_name() const
+    {
+      return m_short;
+    }
+
+    const std::string&
+    long_name() const
+    {
+      return m_long;
+    }
+
+    private:
+    std::string m_short;
+    std::string m_long;
+    String m_desc;
+    std::shared_ptr<const Value> m_value;
+    int m_count;
+  };
+
+  struct HelpOptionDetails
+  {
+    std::string s;
+    std::string l;
+    String desc;
+    bool has_default;
+    std::string default_value;
+    bool has_implicit;
+    std::string implicit_value;
+    std::string arg_help;
+    bool is_container;
+    bool is_boolean;
+  };
+
+  struct HelpGroupDetails
+  {
+    std::string name;
+    std::string description;
+    std::vector<HelpOptionDetails> options;
+  };
+
+  class OptionValue
+  {
+    public:
+    void
+    parse
+    (
+      std::shared_ptr<const OptionDetails> details,
+      const std::string& text
+    )
+    {
+      ensure_value(details);
+      ++m_count;
+      m_value->parse(text);
+    }
+
+    void
+    parse_default(std::shared_ptr<const OptionDetails> details)
+    {
+      ensure_value(details);
+      m_value->parse();
+    }
+
+    size_t
+    count() const
+    {
+      return m_count;
+    }
+
+    template <typename T>
+    const T&
+    as() const
+    {
+      if (m_value == nullptr) {
+        throw std::domain_error("No value");
+      }
+
+#ifdef CXXOPTS_NO_RTTI
+      return static_cast<const values::standard_value<T>&>(*m_value).get();
+#else
+      return dynamic_cast<const values::standard_value<T>&>(*m_value).get();
+#endif
+    }
+
+    private:
+    void
+    ensure_value(std::shared_ptr<const OptionDetails> details)
+    {
+      if (m_value == nullptr)
+      {
+        m_value = details->make_storage();
+      }
+    }
+
+    std::shared_ptr<Value> m_value;
+    size_t m_count = 0;
+  };
+
+  class KeyValue
+  {
+    public:
+    KeyValue(std::string key_, std::string value_)
+    : m_key(std::move(key_))
+    , m_value(std::move(value_))
+    {
+    }
+
+    const
+    std::string&
+    key() const
+    {
+      return m_key;
+    }
+
+    const
+    std::string&
+    value() const
+    {
+      return m_value;
+    }
+
+    template <typename T>
+    T
+    as() const
+    {
+      T result;
+      values::parse_value(m_value, result);
+      return result;
+    }
+
+    private:
+    std::string m_key;
+    std::string m_value;
+  };
+
+  class ParseResult
+  {
+    public:
+
+    ParseResult(
+      const std::shared_ptr<
+        std::unordered_map<std::string, std::shared_ptr<OptionDetails>>
+      >,
+      std::vector<std::string>,
+      bool allow_unrecognised,
+      int&, char**&);
+
+    size_t
+    count(const std::string& o) const
+    {
+      auto iter = m_options->find(o);
+      if (iter == m_options->end())
+      {
+        return 0;
+      }
+
+      auto riter = m_results.find(iter->second);
+
+      return riter->second.count();
+    }
+
+    const OptionValue&
+    operator[](const std::string& option) const
+    {
+      auto iter = m_options->find(option);
+
+      if (iter == m_options->end())
+      {
+        throw option_not_present_exception(option);
+      }
+
+      auto riter = m_results.find(iter->second);
+
+      return riter->second;
+    }
+
+    const std::vector<KeyValue>&
+    arguments() const
+    {
+      return m_sequential;
+    }
+
+    private:
+
+    void
+    parse(int& argc, char**& argv);
+
+    void
+    add_to_option(const std::string& option, const std::string& arg);
+
+    bool
+    consume_positional(std::string a);
+
+    void
+    parse_option
+    (
+      std::shared_ptr<OptionDetails> value,
+      const std::string& name,
+      const std::string& arg = ""
+    );
+
+    void
+    parse_default(std::shared_ptr<OptionDetails> details);
+
+    void
+    checked_parse_arg
+    (
+      int argc,
+      char* argv[],
+      int& current,
+      std::shared_ptr<OptionDetails> value,
+      const std::string& name
+    );
+
+    const std::shared_ptr<
+      std::unordered_map<std::string, std::shared_ptr<OptionDetails>>
+    > m_options;
+    std::vector<std::string> m_positional;
+    std::vector<std::string>::iterator m_next_positional;
+    std::unordered_set<std::string> m_positional_set;
+    std::unordered_map<std::shared_ptr<OptionDetails>, OptionValue> m_results;
+
+    bool m_allow_unrecognised;
+
+    std::vector<KeyValue> m_sequential;
+  };
+
+  class Options
+  {
+    typedef std::unordered_map<std::string, std::shared_ptr<OptionDetails>>
+      OptionMap;
+    public:
+
+    Options(std::string program, std::string help_string = "")
+    : m_program(std::move(program))
+    , m_help_string(toLocalString(std::move(help_string)))
+    , m_custom_help("[OPTION...]")
+    , m_positional_help("positional parameters")
+    , m_show_positional(false)
+    , m_allow_unrecognised(false)
+    , m_options(std::make_shared<OptionMap>())
+    , m_next_positional(m_positional.end())
+    {
+    }
+
+    Options&
+    positional_help(std::string help_text)
+    {
+      m_positional_help = std::move(help_text);
+      return *this;
+    }
+
+    Options&
+    custom_help(std::string help_text)
+    {
+      m_custom_help = std::move(help_text);
+      return *this;
+    }
+
+    Options&
+    show_positional_help()
+    {
+      m_show_positional = true;
+      return *this;
+    }
+
+    Options&
+    allow_unrecognised_options()
+    {
+      m_allow_unrecognised = true;
+      return *this;
+    }
+
+    ParseResult
+    parse(int& argc, char**& argv);
+
+    OptionAdder
+    add_options(std::string group = "");
+
+    void
+    add_option
+    (
+      const std::string& group,
+      const std::string& s,
+      const std::string& l,
+      std::string desc,
+      std::shared_ptr<const Value> value,
+      std::string arg_help
+    );
+
+    //parse positional arguments into the given option
+    void
+    parse_positional(std::string option);
+
+    void
+    parse_positional(std::vector<std::string> options);
+
+    void
+    parse_positional(std::initializer_list<std::string> options);
+
+    template <typename Iterator>
+    void
+    parse_positional(Iterator begin, Iterator end) {
+      parse_positional(std::vector<std::string>{begin, end});
+    }
+
+    std::string
+    help(const std::vector<std::string>& groups = {}) const;
+
+    const std::vector<std::string>
+    groups() const;
+
+    const HelpGroupDetails&
+    group_help(const std::string& group) const;
+
+    private:
+
+    void
+    add_one_option
+    (
+      const std::string& option,
+      std::shared_ptr<OptionDetails> details
+    );
+
+    String
+    help_one_group(const std::string& group) const;
+
+    void
+    generate_group_help
+    (
+      String& result,
+      const std::vector<std::string>& groups
+    ) const;
+
+    void
+    generate_all_groups_help(String& result) const;
+
+    std::string m_program;
+    String m_help_string;
+    std::string m_custom_help;
+    std::string m_positional_help;
+    bool m_show_positional;
+    bool m_allow_unrecognised;
+
+    std::shared_ptr<OptionMap> m_options;
+    std::vector<std::string> m_positional;
+    std::vector<std::string>::iterator m_next_positional;
+    std::unordered_set<std::string> m_positional_set;
+
+    //mapping from groups to help options
+    std::map<std::string, HelpGroupDetails> m_help;
+  };
+
+  class OptionAdder
+  {
+    public:
+
+    OptionAdder(Options& options, std::string group)
+    : m_options(options), m_group(std::move(group))
+    {
+    }
+
+    OptionAdder&
+    operator()
+    (
+      const std::string& opts,
+      const std::string& desc,
+      std::shared_ptr<const Value> value
+        = ::cxxopts::value<bool>(),
+      std::string arg_help = ""
+    );
+
+    private:
+    Options& m_options;
+    std::string m_group;
+  };
+
+  namespace
+  {
+    constexpr int OPTION_LONGEST = 30;
+    constexpr int OPTION_DESC_GAP = 2;
+
+    std::basic_regex<char> option_matcher
+      ("--([[:alnum:]][-_[:alnum:]]+)(=(.*))?|-([[:alnum:]]+)");
+
+    std::basic_regex<char> option_specifier
+      ("(([[:alnum:]]),)?[ ]*([[:alnum:]][-_[:alnum:]]*)?");
+
+    String
+    format_option
+    (
+      const HelpOptionDetails& o
+    )
+    {
+      auto& s = o.s;
+      auto& l = o.l;
+
+      String result = "  ";
+
+      if (s.size() > 0)
+      {
+        result += "-" + toLocalString(s) + ",";
+      }
+      else
+      {
+        result += "   ";
+      }
+
+      if (l.size() > 0)
+      {
+        result += " --" + toLocalString(l);
+      }
+
+      auto arg = o.arg_help.size() > 0 ? toLocalString(o.arg_help) : "arg";
+
+      if (!o.is_boolean)
+      {
+        if (o.has_implicit)
+        {
+          result += " [=" + arg + "(=" + toLocalString(o.implicit_value) + ")]";
+        }
+        else
+        {
+          result += " " + arg;
+        }
+      }
+
+      return result;
+    }
+
+    String
+    format_description
+    (
+      const HelpOptionDetails& o,
+      size_t start,
+      size_t width
+    )
+    {
+      auto desc = o.desc;
+
+      if (o.has_default && (!o.is_boolean || o.default_value != "false"))
+      {
+        desc += toLocalString(" (default: " + o.default_value + ")");
+      }
+
+      String result;
+
+      auto current = std::begin(desc);
+      auto startLine = current;
+      auto lastSpace = current;
+
+      auto size = size_t{};
+
+      while (current != std::end(desc))
+      {
+        if (*current == ' ')
+        {
+          lastSpace = current;
+        }
+
+        if (*current == '\n')
+        {
+          startLine = current + 1;
+          lastSpace = startLine;
+        }
+        else if (size > width)
+        {
+          if (lastSpace == startLine)
+          {
+            stringAppend(result, startLine, current + 1);
+            stringAppend(result, "\n");
+            stringAppend(result, start, ' ');
+            startLine = current + 1;
+            lastSpace = startLine;
+          }
+          else
+          {
+            stringAppend(result, startLine, lastSpace);
+            stringAppend(result, "\n");
+            stringAppend(result, start, ' ');
+            startLine = lastSpace + 1;
+          }
+          size = 0;
+        }
+        else
+        {
+          ++size;
+        }
+
+        ++current;
+      }
+
+      //append whatever is left
+      stringAppend(result, startLine, current);
+
+      return result;
+    }
+  }
+
+inline
+ParseResult::ParseResult
+(
+  const std::shared_ptr<
+    std::unordered_map<std::string, std::shared_ptr<OptionDetails>>
+  > options,
+  std::vector<std::string> positional,
+  bool allow_unrecognised,
+  int& argc, char**& argv
+)
+: m_options(options)
+, m_positional(std::move(positional))
+, m_next_positional(m_positional.begin())
+, m_allow_unrecognised(allow_unrecognised)
+{
+  parse(argc, argv);
+}
+
+inline
+OptionAdder
+Options::add_options(std::string group)
+{
+  return OptionAdder(*this, std::move(group));
+}
+
+inline
+OptionAdder&
+OptionAdder::operator()
+(
+  const std::string& opts,
+  const std::string& desc,
+  std::shared_ptr<const Value> value,
+  std::string arg_help
+)
+{
+  std::match_results<const char*> result;
+  std::regex_match(opts.c_str(), result, option_specifier);
+
+  if (result.empty())
+  {
+    throw invalid_option_format_error(opts);
+  }
+
+  const auto& short_match = result[2];
+  const auto& long_match = result[3];
+
+  if (!short_match.length() && !long_match.length())
+  {
+    throw invalid_option_format_error(opts);
+  } else if (long_match.length() == 1 && short_match.length())
+  {
+    throw invalid_option_format_error(opts);
+  }
+
+  auto option_names = []
+  (
+    const std::sub_match<const char*>& short_,
+    const std::sub_match<const char*>& long_
+  )
+  {
+    if (long_.length() == 1)
+    {
+      return std::make_tuple(long_.str(), short_.str());
+    }
+    else
+    {
+      return std::make_tuple(short_.str(), long_.str());
+    }
+  }(short_match, long_match);
+
+  m_options.add_option
+  (
+    m_group,
+    std::get<0>(option_names),
+    std::get<1>(option_names),
+    desc,
+    value,
+    std::move(arg_help)
+  );
+
+  return *this;
+}
+
+inline
+void
+ParseResult::parse_default(std::shared_ptr<OptionDetails> details)
+{
+  m_results[details].parse_default(details);
+}
+
+inline
+void
+ParseResult::parse_option
+(
+  std::shared_ptr<OptionDetails> value,
+  const std::string& /*name*/,
+  const std::string& arg
+)
+{
+  auto& result = m_results[value];
+  result.parse(value, arg);
+
+  m_sequential.emplace_back(value->long_name(), arg);
+}
+
+inline
+void
+ParseResult::checked_parse_arg
+(
+  int argc,
+  char* argv[],
+  int& current,
+  std::shared_ptr<OptionDetails> value,
+  const std::string& name
+)
+{
+  if (current + 1 >= argc)
+  {
+    if (value->value().has_implicit())
+    {
+      parse_option(value, name, value->value().get_implicit_value());
+    }
+    else
+    {
+      throw missing_argument_exception(name);
+    }
+  }
+  else
+  {
+    if (value->value().has_implicit())
+    {
+      parse_option(value, name, value->value().get_implicit_value());
+    }
+    else
+    {
+      parse_option(value, name, argv[current + 1]);
+      ++current;
+    }
+  }
+}
+
+inline
+void
+ParseResult::add_to_option(const std::string& option, const std::string& arg)
+{
+  auto iter = m_options->find(option);
+
+  if (iter == m_options->end())
+  {
+    throw option_not_exists_exception(option);
+  }
+
+  parse_option(iter->second, option, arg);
+}
+
+inline
+bool
+ParseResult::consume_positional(std::string a)
+{
+  while (m_next_positional != m_positional.end())
+  {
+    auto iter = m_options->find(*m_next_positional);
+    if (iter != m_options->end())
+    {
+      auto& result = m_results[iter->second];
+      if (!iter->second->value().is_container())
+      {
+        if (result.count() == 0)
+        {
+          add_to_option(*m_next_positional, a);
+          ++m_next_positional;
+          return true;
+        }
+        else
+        {
+          ++m_next_positional;
+          continue;
+        }
+      }
+      else
+      {
+        add_to_option(*m_next_positional, a);
+        return true;
+      }
+    }
+    else
+    {
+      throw option_not_exists_exception(*m_next_positional);
+    }
+  }
+
+  return false;
+}
+
+inline
+void
+Options::parse_positional(std::string option)
+{
+  parse_positional(std::vector<std::string>{std::move(option)});
+}
+
+inline
+void
+Options::parse_positional(std::vector<std::string> options)
+{
+  m_positional = std::move(options);
+  m_next_positional = m_positional.begin();
+
+  m_positional_set.insert(m_positional.begin(), m_positional.end());
+}
+
+inline
+void
+Options::parse_positional(std::initializer_list<std::string> options)
+{
+  parse_positional(std::vector<std::string>(std::move(options)));
+}
+
+inline
+ParseResult
+Options::parse(int& argc, char**& argv)
+{
+  ParseResult result(m_options, m_positional, m_allow_unrecognised, argc, argv);
+  return result;
+}
+
+inline
+void
+ParseResult::parse(int& argc, char**& argv)
+{
+  int current = 1;
+
+  int nextKeep = 1;
+
+  bool consume_remaining = false;
+
+  while (current != argc)
+  {
+    if (strcmp(argv[current], "--") == 0)
+    {
+      consume_remaining = true;
+      ++current;
+      break;
+    }
+
+    std::match_results<const char*> result;
+    std::regex_match(argv[current], result, option_matcher);
+
+    if (result.empty())
+    {
+      //not a flag
+
+      // but if it starts with a `-`, then it's an error
+      if (argv[current][0] == '-' && argv[current][1] != '\0') {
+        if (!m_allow_unrecognised) {
+          throw option_syntax_exception(argv[current]);
+        }
+      }
+
+      //if true is returned here then it was consumed, otherwise it is
+      //ignored
+      if (consume_positional(argv[current]))
+      {
+      }
+      else
+      {
+        argv[nextKeep] = argv[current];
+        ++nextKeep;
+      }
+      //if we return from here then it was parsed successfully, so continue
+    }
+    else
+    {
+      //short or long option?
+      if (result[4].length() != 0)
+      {
+        const std::string& s = result[4];
+
+        for (std::size_t i = 0; i != s.size(); ++i)
+        {
+          std::string name(1, s[i]);
+          auto iter = m_options->find(name);
+
+          if (iter == m_options->end())
+          {
+            if (m_allow_unrecognised)
+            {
+              continue;
+            }
+            else
+            {
+              //error
+              throw option_not_exists_exception(name);
+            }
+          }
+
+          auto value = iter->second;
+
+          if (i + 1 == s.size())
+          {
+            //it must be the last argument
+            checked_parse_arg(argc, argv, current, value, name);
+          }
+          else if (value->value().has_implicit())
+          {
+            parse_option(value, name, value->value().get_implicit_value());
+          }
+          else
+          {
+            //error
+            throw option_requires_argument_exception(name);
+          }
+        }
+      }
+      else if (result[1].length() != 0)
+      {
+        const std::string& name = result[1];
+
+        auto iter = m_options->find(name);
+
+        if (iter == m_options->end())
+        {
+          if (m_allow_unrecognised)
+          {
+            // keep unrecognised options in argument list, skip to next argument
+            argv[nextKeep] = argv[current];
+            ++nextKeep;
+            ++current;
+            continue;
+          }
+          else
+          {
+            //error
+            throw option_not_exists_exception(name);
+          }
+        }
+
+        auto opt = iter->second;
+
+        //equals provided for long option?
+        if (result[2].length() != 0)
+        {
+          //parse the option given
+
+          parse_option(opt, name, result[3]);
+        }
+        else
+        {
+          //parse the next argument
+          checked_parse_arg(argc, argv, current, opt, name);
+        }
+      }
+
+    }
+
+    ++current;
+  }
+
+  for (auto& opt : *m_options)
+  {
+    auto& detail = opt.second;
+    auto& value = detail->value();
+
+    auto& store = m_results[detail];
+
+    if(!store.count() && value.has_default()){
+      parse_default(detail);
+    }
+  }
+
+  if (consume_remaining)
+  {
+    while (current < argc)
+    {
+      if (!consume_positional(argv[current])) {
+        break;
+      }
+      ++current;
+    }
+
+    //adjust argv for any that couldn't be swallowed
+    while (current != argc) {
+      argv[nextKeep] = argv[current];
+      ++nextKeep;
+      ++current;
+    }
+  }
+
+  argc = nextKeep;
+
+}
+
+inline
+void
+Options::add_option
+(
+  const std::string& group,
+  const std::string& s,
+  const std::string& l,
+  std::string desc,
+  std::shared_ptr<const Value> value,
+  std::string arg_help
+)
+{
+  auto stringDesc = toLocalString(std::move(desc));
+  auto option = std::make_shared<OptionDetails>(s, l, stringDesc, value);
+
+  if (s.size() > 0)
+  {
+    add_one_option(s, option);
+  }
+
+  if (l.size() > 0)
+  {
+    add_one_option(l, option);
+  }
+
+  //add the help details
+  auto& options = m_help[group];
+
+  options.options.emplace_back(HelpOptionDetails{s, l, stringDesc,
+      value->has_default(), value->get_default_value(),
+      value->has_implicit(), value->get_implicit_value(),
+      std::move(arg_help),
+      value->is_container(),
+      value->is_boolean()});
+}
+
+inline
+void
+Options::add_one_option
+(
+  const std::string& option,
+  std::shared_ptr<OptionDetails> details
+)
+{
+  auto in = m_options->emplace(option, details);
+
+  if (!in.second)
+  {
+    throw option_exists_error(option);
+  }
+}
+
+inline
+String
+Options::help_one_group(const std::string& g) const
+{
+  typedef std::vector<std::pair<String, String>> OptionHelp;
+
+  auto group = m_help.find(g);
+  if (group == m_help.end())
+  {
+    return "";
+  }
+
+  OptionHelp format;
+
+  size_t longest = 0;
+
+  String result;
+
+  if (!g.empty())
+  {
+    result += toLocalString(" " + g + " options:\n");
+  }
+
+  for (const auto& o : group->second.options)
+  {
+    if (m_positional_set.find(o.l) != m_positional_set.end() &&
+        !m_show_positional)
+    {
+      continue;
+    }
+
+    auto s = format_option(o);
+    longest = (std::max)(longest, stringLength(s));
+    format.push_back(std::make_pair(s, String()));
+  }
+
+  longest = (std::min)(longest, static_cast<size_t>(OPTION_LONGEST));
+
+  //widest allowed description
+  auto allowed = size_t{76} - longest - OPTION_DESC_GAP;
+
+  auto fiter = format.begin();
+  for (const auto& o : group->second.options)
+  {
+    if (m_positional_set.find(o.l) != m_positional_set.end() &&
+        !m_show_positional)
+    {
+      continue;
+    }
+
+    auto d = format_description(o, longest + OPTION_DESC_GAP, allowed);
+
+    result += fiter->first;
+    if (stringLength(fiter->first) > longest)
+    {
+      result += '\n';
+      result += toLocalString(std::string(longest + OPTION_DESC_GAP, ' '));
+    }
+    else
+    {
+      result += toLocalString(std::string(longest + OPTION_DESC_GAP -
+        stringLength(fiter->first),
+        ' '));
+    }
+    result += d;
+    result += '\n';
+
+    ++fiter;
+  }
+
+  return result;
+}
+
+inline
+void
+Options::generate_group_help
+(
+  String& result,
+  const std::vector<std::string>& print_groups
+) const
+{
+  for (size_t i = 0; i != print_groups.size(); ++i)
+  {
+    const String& group_help_text = help_one_group(print_groups[i]);
+    if (empty(group_help_text))
+    {
+      continue;
+    }
+    result += group_help_text;
+    if (i < print_groups.size() - 1)
+    {
+      result += '\n';
+    }
+  }
+}
+
+inline
+void
+Options::generate_all_groups_help(String& result) const
+{
+  std::vector<std::string> all_groups;
+  all_groups.reserve(m_help.size());
+
+  for (auto& group : m_help)
+  {
+    all_groups.push_back(group.first);
+  }
+
+  generate_group_help(result, all_groups);
+}
+
+inline
+std::string
+Options::help(const std::vector<std::string>& help_groups) const
+{
+  String result = m_help_string + "\nUsage:\n  " +
+    toLocalString(m_program) + " " + toLocalString(m_custom_help);
+
+  if (m_positional.size() > 0 && m_positional_help.size() > 0) {
+    result += " " + toLocalString(m_positional_help);
+  }
+
+  result += "\n\n";
+
+  if (help_groups.size() == 0)
+  {
+    generate_all_groups_help(result);
+  }
+  else
+  {
+    generate_group_help(result, help_groups);
+  }
+
+  return toUTF8String(result);
+}
+
+inline
+const std::vector<std::string>
+Options::groups() const
+{
+  std::vector<std::string> g;
+
+  std::transform(
+    m_help.begin(),
+    m_help.end(),
+    std::back_inserter(g),
+    [] (const std::map<std::string, HelpGroupDetails>::value_type& pair)
+    {
+      return pair.first;
+    }
+  );
+
+  return g;
+}
+
+inline
+const HelpGroupDetails&
+Options::group_help(const std::string& group) const
+{
+  return m_help.at(group);
+}
+
+}
+
+#endif //CXXOPTS_HPP_INCLUDED


### PR DESCRIPTION
It appears that the spaceship sounds comes from the initial smoothing from 0 to whatever parameters the filter starts on. This is a transient thing, there's no issue once the smoothing stops which is also why you can only really see it on spectrograms/envelopes.

There are I guess different ways to handle the problem:

- In this PR, I went with a smaller transition period, which implies going in Faust from `si.smoo` for smoothing to `si.smooth(ba.tau2pole(desired value for tau in seconds))`. The parameters appear to take between 5 and 10 `tau` to stabilize, the theoretical value being around 7 (@jpcima feel free to correct).
- The "best" solution would be to only smooth after the first initialization of the parameters, but apparently it is complicated right now for Faust-generated code at least. We could do this by dry-running the filters for about `5 * tau` on initialization but there's a substantial cost.
- Another possibility would be to not smooth within Faust at all and smooth the parameter changes within sfizz. We'll have to do this in a couple other places anyway, but it might be better for filter stability to smooth the biquad's parameters rather than the input parameters of the filters.

As said, this PR takes the first approach which might be the best compromise in the short term.