### PR TITLE
Add method to set up initial filter coeffs

### DIFF
--- a/src/sfizz/MidiState.h
+++ b/src/sfizz/MidiState.h
@@ -8,6 +8,8 @@
 #include <chrono>
 #include <array>
 #include "SfzHelpers.h"
+#include "CCMap.h"
+#include "Range.h"
 
 namespace sfz
 {
@@ -102,6 +104,26 @@ public:
      * @brief Reset all the controllers
      */
     void resetAllControllers() noexcept;
+
+    /**
+     * @brief Modulate a value using the last entered CCs in the midiState
+     *
+     * @tparam T
+     * @tparam U
+     * @param value the base value
+     * @param modifiers the list of CC modifiers
+     * @param validRange a range to clamp the output
+     * @param lambda the function to apply for each modifier
+     * @return T
+     */
+    template<class T, class U>
+    T modulate(T value, const CCMap<U>& modifiers, const Range<T>& validRange, const modFunction<T, U>& lambda = addToBase<T>) const noexcept
+    {
+        for (auto& mod: modifiers) {
+            lambda(value, getCCValue(mod.first) * mod.second);
+        }
+        return validRange.clamp(value);
+    }
 
 private:
     template<class T>

--- a/src/sfizz/SfzFilter.cpp
+++ b/src/sfizz/SfzFilter.cpp
@@ -105,6 +105,29 @@ void Filter::clear()
         dsp->instanceClear();
 }
 
+void Filter::prepare(float cutoff, float q, float pksh)
+{
+    sfzFilterDsp *dsp = P->getDsp(P->fChannels, P->fType);
+
+    if (!dsp)
+        return;
+
+    // compute a dummy 1-frame cycle with smoothing off
+
+    float buffer[Impl::maxChannels] = {0};
+    float *inout[Impl::maxChannels];
+    bool en = dsp->isSmoothingEnabled();
+
+    for (unsigned i = 0; i < Impl::maxChannels; ++i)
+        inout[i] = &buffer[i];
+
+    dsp->instanceClear();
+    dsp->configureStandard(cutoff, q, pksh);
+    dsp->setSmoothingEnabled(false);
+    dsp->compute(1, inout, inout);
+    dsp->setSmoothingEnabled(en);
+}
+
 void Filter::process(const float *const in[], float *const out[], float cutoff, float q, float pksh, unsigned nframes)
 {
     unsigned channels = P->fChannels;
@@ -272,6 +295,29 @@ void FilterEq::clear()
 
     if (dsp)
         dsp->instanceClear();
+}
+
+void FilterEq::prepare(float cutoff, float bw, float pksh)
+{
+    sfzFilterDsp *dsp = P->getDsp(P->fChannels);
+
+    if (!dsp)
+        return;
+
+    // compute a dummy 1-frame cycle with smoothing off
+
+    float buffer[Impl::maxChannels] = {0};
+    float *inout[Impl::maxChannels];
+    bool en = dsp->isSmoothingEnabled();
+
+    for (unsigned i = 0; i < Impl::maxChannels; ++i)
+        inout[i] = &buffer[i];
+
+    dsp->instanceClear();
+    dsp->configureEq(cutoff, bw, pksh);
+    dsp->setSmoothingEnabled(false);
+    dsp->compute(1, inout, inout);
+    dsp->setSmoothingEnabled(en);
 }
 
 void FilterEq::process(const float *const in[], float *const out[], float cutoff, float bw, float pksh, unsigned nframes)

--- a/src/sfizz/SfzFilter.h
+++ b/src/sfizz/SfzFilter.h
@@ -37,6 +37,14 @@ public:
     void clear();
 
     /**
+       Clear the filter memory, and compute the initial coefficients unaffected
+       by any smoothing.
+
+       Make sure to set the filter type and channel count first.
+     */
+    void prepare(float cutoff, float q, float pksh);
+
+    /**
        Process one cycle of the filter without modulating cutoff or Q.
        `cutoff` is a frequency expressed in Hz.
        `q` is a resonance expressed in dB.
@@ -130,6 +138,14 @@ public:
        Reinitialize the filter memory to zeros.
      */
     void clear();
+
+    /**
+       Clear the filter memory, and compute the initial coefficients unaffected
+       by any smoothing.
+
+       Make sure to set the channel count first.
+     */
+    void prepare(float cutoff, float bw, float pksh);
 
     /**
        Process one cycle of the filter without modulating cutoff or bandwidth.

--- a/src/sfizz/SfzFilterImpls.cxx
+++ b/src/sfizz/SfzFilterImpls.cxx
@@ -20,6 +20,19 @@ public:
 
     virtual void configureStandard(float, float, float) {}
     virtual void configureEq(float, float, float) {}
+
+    bool isSmoothingEnabled() const
+    {
+        return fSmoothEnable;
+    }
+
+    void setSmoothingEnabled(bool smooth)
+    {
+        fSmoothEnable = smooth;
+    }
+
+protected:
+    bool fSmoothEnable = true; // external variable used from faust code
 };
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/src/sfizz/SfzHelpers.h
+++ b/src/sfizz/SfzHelpers.h
@@ -172,5 +172,37 @@ bool findDefine(absl::string_view line, absl::string_view& variable, absl::strin
  */
 bool findInclude(absl::string_view line, std::string& path);
 
+/**
+ * @brief Defines a function that modulates a base value with another one
+ *
+ * @tparam T
+ */
+template<class T, class U>
+using modFunction = std::function<void(T&, U)>;
+
+/**
+ * @brief Modulation helper that adds the modifier to the base value
+ *
+ * @tparam T
+ * @param base the base value
+ * @param modifier the modifier value
+ */
+template<class T>
+constexpr void addToBase(T& base, T modifier)
+{
+    base += modifier;
+}
+
+/**
+ * @brief multiply a value by a factor, in cents. To be used for pitch variations.
+ *
+ * @param base
+ * @param modifier
+ */
+constexpr void multiplyByCents(float& base, int modifier)
+{
+    base *= centsFactor(modifier);
+}
+
 } // namespace sfz
 

--- a/src/sfizz/dsp/filters/sfz_filters.dsp
+++ b/src/sfizz/dsp/filters/sfz_filters.dsp
@@ -146,4 +146,8 @@ bandwidth = vslider("[04] Bandwidth [unit:octave]", 1.0, 0.1, 10.0, 0.01);
 // smoothCoefs = _ ; // No smoothing applied at all
 
 // This applies a quicker smoothing but which may render the filter unstable
-smoothCoefs = si.smooth(ba.tau2pole(0.001)) ; // time constant = 1ms
+smoothCoefs = si.smooth(ba.if(smoothEnable, pole, 0.0)) with {
+  timeConstant = 1e-3; // time constant = 1ms
+  pole = ba.tau2pole(timeConstant);
+  smoothEnable = fvariable(int fSmoothEnable, <math.h>);
+};

--- a/src/sfizz/gen/filters/sfz2chApf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chApf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chApf1p_H__
@@ -11,50 +11,49 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chApf1p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chApf1p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
-	double fConst2;
 	FAUSTFLOAT fCutoff;
+	double fConst2;
 	double fRec1[2];
 	double fRec0[2];
 	double fRec2[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -67,14 +66,12 @@ class faust2chApf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -87,80 +84,68 @@ class faust2chApf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (6.2831853071795862 / fConst0);
-		
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
+		fConst1 = (6.2831853071795862 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec0[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec2[l2] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chApf1p* clone() {
 		return new faust2chApf1p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
-		double fSlow1 = (((fConst2 * double(fCutoff)) + -1.0) * (1.0 - fSlow0));
+		double fSlow0 = (fSmoothEnable ? fConst2 : 0.0);
+		double fSlow1 = (((fConst1 * double(fCutoff)) + -1.0) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow1);
+			fRec1[0] = (fSlow1 + (fSlow0 * fRec1[1]));
 			fRec0[0] = (fTemp0 - (fRec1[0] * fRec0[1]));
 			output0[i] = FAUSTFLOAT((fRec0[1] + (fRec1[0] * fRec0[0])));
 			fRec2[0] = (fTemp1 - (fRec1[0] * fRec2[1]));
@@ -168,9 +153,7 @@ class faust2chApf1p : public sfzFilterDsp {
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chApf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chApf1p.cxx
@@ -34,7 +34,6 @@ class faust2chApf1p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec1[2];
 	double fRec0[2];
@@ -102,8 +101,7 @@ class faust2chApf1p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -157,11 +155,12 @@ class faust2chApf1p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst2 * ((fConst3 * double(fCutoff)) + -1.0));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (((fConst2 * double(fCutoff)) + -1.0) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow0 + (fConst1 * fRec1[1]));
+			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow1);
 			fRec0[0] = (fTemp0 - (fRec1[0] * fRec0[1]));
 			output0[i] = FAUSTFLOAT((fRec0[1] + (fRec1[0] * fRec0[0])));
 			fRec2[0] = (fTemp1 - (fRec1[0] * fRec2[1]));

--- a/src/sfizz/gen/filters/sfz2chBpf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf1p.cxx
@@ -34,7 +34,6 @@ class faust2chBpf1p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec2[2];
 	double fRec1[2];
@@ -104,8 +103,7 @@ class faust2chBpf1p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (1.0 / fConst0);
+		fConst2 = (1.0 / fConst0);
 		
 	}
 	
@@ -167,11 +165,12 @@ class faust2chBpf1p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst2 * std::exp((fConst3 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec2[0] = (fSlow0 + (fConst1 * fRec2[1]));
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow1);
 			fRec1[0] = ((fRec2[0] * fRec1[1]) + fTemp0);
 			double fTemp2 = (1.0 - fRec2[0]);
 			fRec0[0] = ((fRec1[0] * fTemp2) + (fRec2[0] * fRec0[1]));

--- a/src/sfizz/gen/filters/sfz2chBpf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBpf1p_H__
@@ -11,52 +11,51 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chBpf1p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chBpf1p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
-	double fConst2;
 	FAUSTFLOAT fCutoff;
+	double fConst2;
 	double fRec2[2];
 	double fRec1[2];
 	double fRec0[2];
 	double fRec4[2];
 	double fRec3[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -69,14 +68,12 @@ class faust2chBpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -89,95 +86,81 @@ class faust2chBpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 / fConst0);
-		
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
+		fConst1 = (1.0 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec2[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec1[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec4[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec3[l4] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chBpf1p* clone() {
 		return new faust2chBpf1p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
-		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
+		double fSlow0 = (fSmoothEnable ? fConst2 : 0.0);
+		double fSlow1 = (std::exp((fConst1 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow1);
-			fRec1[0] = ((fRec2[0] * fRec1[1]) + fTemp0);
+			fRec2[0] = (fSlow1 + (fSlow0 * fRec2[1]));
+			fRec1[0] = (fTemp0 + (fRec2[0] * fRec1[1]));
 			double fTemp2 = (1.0 - fRec2[0]);
 			fRec0[0] = ((fRec1[0] * fTemp2) + (fRec2[0] * fRec0[1]));
 			double fTemp3 = (fRec2[0] + 1.0);
 			double fTemp4 = (0.0 - (0.5 * fTemp3));
 			output0[i] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp3)) + (fRec0[1] * fTemp4)));
-			fRec4[0] = ((fRec2[0] * fRec4[1]) + fTemp1);
+			fRec4[0] = (fTemp1 + (fRec2[0] * fRec4[1]));
 			fRec3[0] = ((fRec4[0] * fTemp2) + (fRec2[0] * fRec3[1]));
 			output1[i] = FAUSTFLOAT(((0.5 * (fRec3[0] * fTemp3)) + (fTemp4 * fRec3[1])));
 			fRec2[1] = fRec2[0];
@@ -185,9 +168,7 @@ class faust2chBpf1p : public sfzFilterDsp {
 			fRec0[1] = fRec0[0];
 			fRec4[1] = fRec4[0];
 			fRec3[1] = fRec3[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBpf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBpf2p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chBpf2p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chBpf2p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -43,23 +44,21 @@ class faust2chBpf2p : public sfzFilterDsp {
 	double fRec4[2];
 	double fRec5[2];
 	double fRec6[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -72,14 +71,12 @@ class faust2chBpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -92,92 +89,76 @@ class faust2chBpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec6[l6] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chBpf2p* clone() {
 		return new faust2chBpf2p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::sin(fSlow1);
 		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
@@ -186,18 +167,18 @@ class faust2chBpf2p : public sfzFilterDsp {
 		double fSlow6 = (1.0 - fSlow0);
 		double fSlow7 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow6);
 		double fSlow8 = (((1.0 - fSlow4) / fSlow5) * fSlow6);
-		double fSlow9 = (0.5 * (fSlow2 / (fSlow5 * fSlow3)));
+		double fSlow9 = (0.5 * (fSlow2 / (fSlow3 * fSlow5)));
 		double fSlow10 = (fSlow9 * fSlow6);
 		double fSlow11 = ((0.0 - fSlow9) * fSlow6);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow7);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow8);
+			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow7);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
 			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow10);
-			fRec4[0] = (fRec4[1] * fSlow0);
-			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow11);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow10);
+			fRec4[0] = (fSlow0 * fRec4[1]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow11);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec6[0] = (fTemp1 - ((fRec1[0] * fRec6[1]) + (fRec2[0] * fRec6[2])));
 			output1[i] = FAUSTFLOAT((((fRec3[0] * fRec6[0]) + (fRec4[0] * fRec6[1])) + (fRec5[0] * fRec6[2])));
@@ -210,9 +191,7 @@ class faust2chBpf2p : public sfzFilterDsp {
 			fRec5[1] = fRec5[0];
 			fRec6[2] = fRec6[1];
 			fRec6[1] = fRec6[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBpf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf2p.cxx
@@ -34,13 +34,11 @@ class faust2chBpf2p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec1[2];
 	double fRec2[2];
 	double fRec0[3];
-	double fConst4;
 	double fRec3[2];
 	double fRec4[2];
 	double fRec5[2];
@@ -108,9 +106,7 @@ class faust2chBpf2p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (0.5 * fConst2);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -181,25 +177,27 @@ class faust2chBpf2p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = std::sin(fSlow0);
-		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
-		double fSlow3 = (0.5 * (fSlow1 / fSlow2));
-		double fSlow4 = (fSlow3 + 1.0);
-		double fSlow5 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
-		double fSlow6 = (fConst2 * ((1.0 - fSlow3) / fSlow4));
-		double fSlow7 = (fSlow1 / (fSlow4 * fSlow2));
-		double fSlow8 = (fConst4 * fSlow7);
-		double fSlow9 = (fConst2 * (0.0 - (0.5 * fSlow7)));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow2 = std::sin(fSlow1);
+		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
+		double fSlow4 = (0.5 * (fSlow2 / fSlow3));
+		double fSlow5 = (fSlow4 + 1.0);
+		double fSlow6 = (1.0 - fSlow0);
+		double fSlow7 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow6);
+		double fSlow8 = (((1.0 - fSlow4) / fSlow5) * fSlow6);
+		double fSlow9 = (0.5 * (fSlow2 / (fSlow5 * fSlow3)));
+		double fSlow10 = (fSlow9 * fSlow6);
+		double fSlow11 = ((0.0 - fSlow9) * fSlow6);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow5 + (fConst1 * fRec1[1]));
-			fRec2[0] = (fSlow6 + (fConst1 * fRec2[1]));
+			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow7);
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow8);
 			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow8 + (fConst1 * fRec3[1]));
-			fRec4[0] = (fConst1 * fRec4[1]);
-			fRec5[0] = (fSlow9 + (fConst1 * fRec5[1]));
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow10);
+			fRec4[0] = (fRec4[1] * fSlow0);
+			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow11);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec6[0] = (fTemp1 - ((fRec1[0] * fRec6[1]) + (fRec2[0] * fRec6[2])));
 			output1[i] = FAUSTFLOAT((((fRec3[0] * fRec6[0]) + (fRec4[0] * fRec6[1])) + (fRec5[0] * fRec6[2])));

--- a/src/sfizz/gen/filters/sfz2chBpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBpf2pSv_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chBpf2pSv
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chBpf2pSv : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -44,23 +45,21 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 	double fRec6[2];
 	double fRec8[2];
 	double fRec9[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -73,14 +72,12 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -93,96 +90,79 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec3[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec2[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec6[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
 			fRec8[l6] = 0.0;
-			
 		}
 		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
 			fRec9[l7] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chBpf2pSv* clone() {
 		return new faust2chBpf2pSv();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
@@ -190,11 +170,11 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow2);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow2);
 			double fTemp2 = (fSlow3 + fRec3[0]);
-			fRec4[0] = ((fRec4[1] * fSlow0) + (fSlow1 / ((fRec3[0] * fTemp2) + 1.0)));
+			fRec4[0] = ((fSlow0 * fRec4[1]) + (fSlow1 / ((fRec3[0] * fTemp2) + 1.0)));
 			double fTemp3 = (fRec3[0] * fRec4[0]);
-			fRec5[0] = ((fRec5[1] * fSlow0) + (fSlow1 * fTemp2));
+			fRec5[0] = ((fSlow0 * fRec5[1]) + (fSlow1 * fTemp2));
 			double fTemp4 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fTemp5 = (fTemp3 * fTemp4);
 			double fTemp6 = (fRec2[1] + fTemp5);
@@ -202,7 +182,7 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 			fRec1[0] = (fRec1[1] + (2.0 * (fRec3[0] * fTemp6)));
 			double fTemp7 = (fRec2[1] + (2.0 * fTemp5));
 			fRec2[0] = fTemp7;
-			fRec6[0] = ((fRec6[1] * fSlow0) + fSlow4);
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow4);
 			output0[i] = FAUSTFLOAT((fRec0 * fRec6[0]));
 			double fTemp8 = (fTemp1 - (fRec8[1] + (fRec5[0] * fRec9[1])));
 			double fTemp9 = (fTemp3 * fTemp8);
@@ -220,9 +200,7 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 			fRec6[1] = fRec6[0];
 			fRec8[1] = fRec8[0];
 			fRec9[1] = fRec9[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf2pSv.cxx
@@ -34,7 +34,6 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec3[2];
 	FAUSTFLOAT fQ;
@@ -108,8 +107,7 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (3.1415926535897931 / fConst0);
+		fConst2 = (3.1415926535897931 / fConst0);
 		
 	}
 	
@@ -184,18 +182,19 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
-		double fSlow1 = std::pow(10.0, (0.050000000000000003 * double(fQ)));
-		double fSlow2 = (1.0 / fSlow1);
-		double fSlow3 = (fConst2 / fSlow1);
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (1.0 - fSlow0);
+		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
+		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
+		double fSlow4 = (fSlow3 * fSlow1);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec3[0] = (fSlow0 + (fConst1 * fRec3[1]));
-			double fTemp2 = (fSlow2 + fRec3[0]);
-			fRec4[0] = ((fConst1 * fRec4[1]) + (fConst2 / ((fRec3[0] * fTemp2) + 1.0)));
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow2);
+			double fTemp2 = (fSlow3 + fRec3[0]);
+			fRec4[0] = ((fRec4[1] * fSlow0) + (fSlow1 / ((fRec3[0] * fTemp2) + 1.0)));
 			double fTemp3 = (fRec3[0] * fRec4[0]);
-			fRec5[0] = ((fConst1 * fRec5[1]) + (fConst2 * fTemp2));
+			fRec5[0] = ((fRec5[1] * fSlow0) + (fSlow1 * fTemp2));
 			double fTemp4 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fTemp5 = (fTemp3 * fTemp4);
 			double fTemp6 = (fRec2[1] + fTemp5);
@@ -203,7 +202,7 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 			fRec1[0] = (fRec1[1] + (2.0 * (fRec3[0] * fTemp6)));
 			double fTemp7 = (fRec2[1] + (2.0 * fTemp5));
 			fRec2[0] = fTemp7;
-			fRec6[0] = (fSlow3 + (fConst1 * fRec6[1]));
+			fRec6[0] = ((fRec6[1] * fSlow0) + fSlow4);
 			output0[i] = FAUSTFLOAT((fRec0 * fRec6[0]));
 			double fTemp8 = (fTemp1 - (fRec8[1] + (fRec5[0] * fRec9[1])));
 			double fTemp9 = (fTemp3 * fTemp8);

--- a/src/sfizz/gen/filters/sfz2chBpf4p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf4p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBpf4p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chBpf4p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chBpf4p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -45,23 +46,21 @@ class faust2chBpf4p : public sfzFilterDsp {
 	double fRec1[3];
 	double fRec8[3];
 	double fRec7[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -74,14 +73,12 @@ class faust2chBpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -94,106 +91,88 @@ class faust2chBpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec4[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec5[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec6[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec1[l6] = 0.0;
-			
 		}
 		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
 			fRec8[l7] = 0.0;
-			
 		}
 		for (int l8 = 0; (l8 < 3); l8 = (l8 + 1)) {
 			fRec7[l8] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chBpf4p* clone() {
 		return new faust2chBpf4p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::sin(fSlow1);
 		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow4 = (0.5 * (fSlow2 / fSlow3));
 		double fSlow5 = (fSlow4 + 1.0);
-		double fSlow6 = (0.5 * (fSlow2 / (fSlow5 * fSlow3)));
+		double fSlow6 = (0.5 * (fSlow2 / (fSlow3 * fSlow5)));
 		double fSlow7 = (1.0 - fSlow0);
 		double fSlow8 = (fSlow6 * fSlow7);
 		double fSlow9 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
@@ -202,12 +181,12 @@ class faust2chBpf4p : public sfzFilterDsp {
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow8);
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow9);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow10);
+			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow8);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow9);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow10);
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = (fRec5[1] * fSlow0);
-			fRec6[0] = ((fRec6[1] * fSlow0) + fSlow11);
+			fRec5[0] = (fSlow0 * fRec5[1]);
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow11);
 			fRec1[0] = ((((fRec2[0] * fRec0[0]) + (fRec5[0] * fRec2[1])) + (fRec6[0] * fRec2[2])) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec5[0] * fRec1[1])) + (fRec6[0] * fRec1[2])));
 			fRec8[0] = (fTemp1 - ((fRec3[0] * fRec8[1]) + (fRec4[0] * fRec8[2])));
@@ -226,9 +205,7 @@ class faust2chBpf4p : public sfzFilterDsp {
 			fRec8[1] = fRec8[0];
 			fRec7[2] = fRec7[1];
 			fRec7[1] = fRec7[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBpf4p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf4p.cxx
@@ -34,8 +34,6 @@ class faust2chBpf4p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
-	double fConst4;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
@@ -110,9 +108,7 @@ class faust2chBpf4p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (0.5 * fConst2);
-		fConst4 = (6.2831853071795862 / fConst0);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -191,25 +187,27 @@ class faust2chBpf4p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst4 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = std::sin(fSlow0);
-		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
-		double fSlow3 = (0.5 * (fSlow1 / fSlow2));
-		double fSlow4 = (fSlow3 + 1.0);
-		double fSlow5 = (fSlow1 / (fSlow4 * fSlow2));
-		double fSlow6 = (fConst3 * fSlow5);
-		double fSlow7 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
-		double fSlow8 = (fConst2 * ((1.0 - fSlow3) / fSlow4));
-		double fSlow9 = (fConst2 * (0.0 - (0.5 * fSlow5)));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow2 = std::sin(fSlow1);
+		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
+		double fSlow4 = (0.5 * (fSlow2 / fSlow3));
+		double fSlow5 = (fSlow4 + 1.0);
+		double fSlow6 = (0.5 * (fSlow2 / (fSlow5 * fSlow3)));
+		double fSlow7 = (1.0 - fSlow0);
+		double fSlow8 = (fSlow6 * fSlow7);
+		double fSlow9 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
+		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
+		double fSlow11 = ((0.0 - fSlow6) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow6 + (fConst1 * fRec0[1]));
-			fRec3[0] = (fSlow7 + (fConst1 * fRec3[1]));
-			fRec4[0] = (fSlow8 + (fConst1 * fRec4[1]));
+			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow8);
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow9);
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow10);
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = (fConst1 * fRec5[1]);
-			fRec6[0] = (fSlow9 + (fConst1 * fRec6[1]));
+			fRec5[0] = (fRec5[1] * fSlow0);
+			fRec6[0] = ((fRec6[1] * fSlow0) + fSlow11);
 			fRec1[0] = ((((fRec2[0] * fRec0[0]) + (fRec5[0] * fRec2[1])) + (fRec6[0] * fRec2[2])) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec5[0] * fRec1[1])) + (fRec6[0] * fRec1[2])));
 			fRec8[0] = (fTemp1 - ((fRec3[0] * fRec8[1]) + (fRec4[0] * fRec8[2])));

--- a/src/sfizz/gen/filters/sfz2chBpf6p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf6p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBpf6p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chBpf6p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chBpf6p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -47,23 +48,21 @@ class faust2chBpf6p : public sfzFilterDsp {
 	double fRec10[3];
 	double fRec9[3];
 	double fRec8[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -76,14 +75,12 @@ class faust2chBpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -96,114 +93,94 @@ class faust2chBpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec3[l1] = 0.0;
-			
+			fRec4[l1] = 0.0;
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
-			
 		}
-		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec6[l3] = 0.0;
-			
+		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
+			fRec3[l3] = 0.0;
 		}
-		for (int l4 = 0; (l4 < 3); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
-			
+		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
+			fRec6[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec7[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec2[l6] = 0.0;
-			
 		}
 		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
 			fRec1[l7] = 0.0;
-			
 		}
 		for (int l8 = 0; (l8 < 3); l8 = (l8 + 1)) {
 			fRec10[l8] = 0.0;
-			
 		}
 		for (int l9 = 0; (l9 < 3); l9 = (l9 + 1)) {
 			fRec9[l9] = 0.0;
-			
 		}
 		for (int l10 = 0; (l10 < 3); l10 = (l10 + 1)) {
 			fRec8[l10] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chBpf6p* clone() {
 		return new faust2chBpf6p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::sin(fSlow1);
 		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow4 = (0.5 * (fSlow2 / fSlow3));
 		double fSlow5 = (fSlow4 + 1.0);
-		double fSlow6 = (0.5 * (fSlow2 / (fSlow5 * fSlow3)));
+		double fSlow6 = (0.5 * (fSlow2 / (fSlow3 * fSlow5)));
 		double fSlow7 = (1.0 - fSlow0);
 		double fSlow8 = (fSlow6 * fSlow7);
 		double fSlow9 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
@@ -212,19 +189,19 @@ class faust2chBpf6p : public sfzFilterDsp {
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow8);
-			fRec3[0] = (fRec3[1] * fSlow0);
-			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow9);
-			fRec6[0] = ((fRec6[1] * fSlow0) + fSlow10);
-			fRec4[0] = (fTemp0 - ((fRec5[0] * fRec4[1]) + (fRec6[0] * fRec4[2])));
-			fRec7[0] = (fSlow11 + (fRec7[1] * fSlow0));
-			fRec2[0] = (((fRec3[0] * fRec4[1]) + ((fRec4[0] * fRec0[0]) + (fRec7[0] * fRec4[2]))) - ((fRec5[0] * fRec2[1]) + (fRec6[0] * fRec2[2])));
-			fRec1[0] = ((((fRec0[0] * fRec2[0]) + (fRec3[0] * fRec2[1])) + (fRec7[0] * fRec2[2])) - ((fRec5[0] * fRec1[1]) + (fRec6[0] * fRec1[2])));
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec3[0] * fRec1[1])) + (fRec7[0] * fRec1[2])));
-			fRec10[0] = (fTemp1 - ((fRec5[0] * fRec10[1]) + (fRec6[0] * fRec10[2])));
-			fRec9[0] = ((((fRec0[0] * fRec10[0]) + (fRec3[0] * fRec10[1])) + (fRec7[0] * fRec10[2])) - ((fRec5[0] * fRec9[1]) + (fRec6[0] * fRec9[2])));
-			fRec8[0] = ((((fRec0[0] * fRec9[0]) + (fRec3[0] * fRec9[1])) + (fRec7[0] * fRec9[2])) - ((fRec5[0] * fRec8[1]) + (fRec6[0] * fRec8[2])));
-			output1[i] = FAUSTFLOAT((((fRec0[0] * fRec8[0]) + (fRec3[0] * fRec8[1])) + (fRec7[0] * fRec8[2])));
+			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow8);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow9);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow10);
+			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
+			fRec6[0] = (fSlow0 * fRec6[1]);
+			fRec7[0] = ((fSlow0 * fRec7[1]) + fSlow11);
+			fRec2[0] = ((((fRec3[0] * fRec0[0]) + (fRec6[0] * fRec3[1])) + (fRec7[0] * fRec3[2])) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
+			fRec1[0] = ((((fRec0[0] * fRec2[0]) + (fRec6[0] * fRec2[1])) + (fRec7[0] * fRec2[2])) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
+			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec6[0] * fRec1[1])) + (fRec7[0] * fRec1[2])));
+			fRec10[0] = (fTemp1 - ((fRec4[0] * fRec10[1]) + (fRec5[0] * fRec10[2])));
+			fRec9[0] = ((((fRec0[0] * fRec10[0]) + (fRec6[0] * fRec10[1])) + (fRec7[0] * fRec10[2])) - ((fRec4[0] * fRec9[1]) + (fRec5[0] * fRec9[2])));
+			fRec8[0] = ((((fRec0[0] * fRec9[0]) + (fRec6[0] * fRec9[1])) + (fRec7[0] * fRec9[2])) - ((fRec4[0] * fRec8[1]) + (fRec5[0] * fRec8[2])));
+			output1[i] = FAUSTFLOAT((((fRec0[0] * fRec8[0]) + (fRec6[0] * fRec8[1])) + (fRec7[0] * fRec8[2])));
 			fRec0[1] = fRec0[0];
 			fRec3[1] = fRec3[0];
 			fRec5[1] = fRec5[0];
@@ -242,9 +219,7 @@ class faust2chBpf6p : public sfzFilterDsp {
 			fRec9[1] = fRec9[0];
 			fRec8[2] = fRec8[1];
 			fRec8[1] = fRec8[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBpf6p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf6p.cxx
@@ -34,15 +34,13 @@ class faust2chBpf6p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
-	double fConst4;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
-	double fRec4[2];
+	double fRec3[2];
 	double fRec5[2];
-	double fRec3[3];
 	double fRec6[2];
+	double fRec4[3];
 	double fRec7[2];
 	double fRec2[3];
 	double fRec1[3];
@@ -112,9 +110,7 @@ class faust2chBpf6p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (0.5 * fConst2);
-		fConst4 = (6.2831853071795862 / fConst0);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -130,19 +126,19 @@ class faust2chBpf6p : public sfzFilterDsp {
 			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec4[l1] = 0.0;
+			fRec3[l1] = 0.0;
 			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
 			
 		}
-		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
+			fRec6[l3] = 0.0;
 			
 		}
-		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec6[l4] = 0.0;
+		for (int l4 = 0; (l4 < 3); l4 = (l4 + 1)) {
+			fRec4[l4] = 0.0;
 			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
@@ -201,38 +197,40 @@ class faust2chBpf6p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst4 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = std::sin(fSlow0);
-		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
-		double fSlow3 = (0.5 * (fSlow1 / fSlow2));
-		double fSlow4 = (fSlow3 + 1.0);
-		double fSlow5 = (fSlow1 / (fSlow4 * fSlow2));
-		double fSlow6 = (fConst3 * fSlow5);
-		double fSlow7 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
-		double fSlow8 = (fConst2 * ((1.0 - fSlow3) / fSlow4));
-		double fSlow9 = (fConst2 * (0.0 - (0.5 * fSlow5)));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow2 = std::sin(fSlow1);
+		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
+		double fSlow4 = (0.5 * (fSlow2 / fSlow3));
+		double fSlow5 = (fSlow4 + 1.0);
+		double fSlow6 = (0.5 * (fSlow2 / (fSlow5 * fSlow3)));
+		double fSlow7 = (1.0 - fSlow0);
+		double fSlow8 = (fSlow6 * fSlow7);
+		double fSlow9 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
+		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
+		double fSlow11 = ((0.0 - fSlow6) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow6 + (fConst1 * fRec0[1]));
-			fRec4[0] = (fSlow7 + (fConst1 * fRec4[1]));
-			fRec5[0] = (fSlow8 + (fConst1 * fRec5[1]));
-			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (fConst1 * fRec6[1]);
-			fRec7[0] = (fSlow9 + (fConst1 * fRec7[1]));
-			fRec2[0] = ((((fRec3[0] * fRec0[0]) + (fRec6[0] * fRec3[1])) + (fRec7[0] * fRec3[2])) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
-			fRec1[0] = ((((fRec0[0] * fRec2[0]) + (fRec6[0] * fRec2[1])) + (fRec7[0] * fRec2[2])) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec6[0] * fRec1[1])) + (fRec7[0] * fRec1[2])));
-			fRec10[0] = (fTemp1 - ((fRec4[0] * fRec10[1]) + (fRec5[0] * fRec10[2])));
-			fRec9[0] = ((((fRec0[0] * fRec10[0]) + (fRec6[0] * fRec10[1])) + (fRec7[0] * fRec10[2])) - ((fRec4[0] * fRec9[1]) + (fRec5[0] * fRec9[2])));
-			fRec8[0] = ((((fRec0[0] * fRec9[0]) + (fRec6[0] * fRec9[1])) + (fRec7[0] * fRec9[2])) - ((fRec4[0] * fRec8[1]) + (fRec5[0] * fRec8[2])));
-			output1[i] = FAUSTFLOAT((((fRec0[0] * fRec8[0]) + (fRec6[0] * fRec8[1])) + (fRec7[0] * fRec8[2])));
+			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow8);
+			fRec3[0] = (fRec3[1] * fSlow0);
+			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow9);
+			fRec6[0] = ((fRec6[1] * fSlow0) + fSlow10);
+			fRec4[0] = (fTemp0 - ((fRec5[0] * fRec4[1]) + (fRec6[0] * fRec4[2])));
+			fRec7[0] = (fSlow11 + (fRec7[1] * fSlow0));
+			fRec2[0] = (((fRec3[0] * fRec4[1]) + ((fRec4[0] * fRec0[0]) + (fRec7[0] * fRec4[2]))) - ((fRec5[0] * fRec2[1]) + (fRec6[0] * fRec2[2])));
+			fRec1[0] = ((((fRec0[0] * fRec2[0]) + (fRec3[0] * fRec2[1])) + (fRec7[0] * fRec2[2])) - ((fRec5[0] * fRec1[1]) + (fRec6[0] * fRec1[2])));
+			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec3[0] * fRec1[1])) + (fRec7[0] * fRec1[2])));
+			fRec10[0] = (fTemp1 - ((fRec5[0] * fRec10[1]) + (fRec6[0] * fRec10[2])));
+			fRec9[0] = ((((fRec0[0] * fRec10[0]) + (fRec3[0] * fRec10[1])) + (fRec7[0] * fRec10[2])) - ((fRec5[0] * fRec9[1]) + (fRec6[0] * fRec9[2])));
+			fRec8[0] = ((((fRec0[0] * fRec9[0]) + (fRec3[0] * fRec9[1])) + (fRec7[0] * fRec9[2])) - ((fRec5[0] * fRec8[1]) + (fRec6[0] * fRec8[2])));
+			output1[i] = FAUSTFLOAT((((fRec0[0] * fRec8[0]) + (fRec3[0] * fRec8[1])) + (fRec7[0] * fRec8[2])));
 			fRec0[1] = fRec0[0];
-			fRec4[1] = fRec4[0];
-			fRec5[1] = fRec5[0];
-			fRec3[2] = fRec3[1];
 			fRec3[1] = fRec3[0];
+			fRec5[1] = fRec5[0];
 			fRec6[1] = fRec6[0];
+			fRec4[2] = fRec4[1];
+			fRec4[1] = fRec4[0];
 			fRec7[1] = fRec7[0];
 			fRec2[2] = fRec2[1];
 			fRec2[1] = fRec2[0];

--- a/src/sfizz/gen/filters/sfz2chBrf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBrf1p.cxx
@@ -34,7 +34,6 @@ class faust2chBrf1p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec2[2];
 	double fRec1[2];
@@ -104,8 +103,7 @@ class faust2chBrf1p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -167,11 +165,12 @@ class faust2chBrf1p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst2 * ((fConst3 * double(fCutoff)) + -1.0));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (((fConst2 * double(fCutoff)) + -1.0) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec2[0] = (fSlow0 + (fConst1 * fRec2[1]));
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow1);
 			fRec1[0] = (fTemp0 - (fRec2[0] * fRec1[1]));
 			fRec0[0] = (fRec1[1] + (fRec2[0] * (fRec1[0] - fRec0[1])));
 			output0[i] = FAUSTFLOAT(((fRec0[1] + (fRec2[0] * fRec0[0])) + fTemp0));

--- a/src/sfizz/gen/filters/sfz2chBrf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBrf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBrf1p_H__
@@ -11,52 +11,51 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chBrf1p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chBrf1p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
-	double fConst2;
 	FAUSTFLOAT fCutoff;
+	double fConst2;
 	double fRec2[2];
 	double fRec1[2];
 	double fRec0[2];
 	double fRec4[2];
 	double fRec3[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -69,14 +68,12 @@ class faust2chBrf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -89,102 +86,86 @@ class faust2chBrf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (6.2831853071795862 / fConst0);
-		
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
+		fConst1 = (6.2831853071795862 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec2[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec1[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec4[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec3[l4] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chBrf1p* clone() {
 		return new faust2chBrf1p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
-		double fSlow1 = (((fConst2 * double(fCutoff)) + -1.0) * (1.0 - fSlow0));
+		double fSlow0 = (fSmoothEnable ? fConst2 : 0.0);
+		double fSlow1 = (((fConst1 * double(fCutoff)) + -1.0) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow1);
+			fRec2[0] = (fSlow1 + (fSlow0 * fRec2[1]));
 			fRec1[0] = (fTemp0 - (fRec2[0] * fRec1[1]));
 			fRec0[0] = (fRec1[1] + (fRec2[0] * (fRec1[0] - fRec0[1])));
-			output0[i] = FAUSTFLOAT(((fRec0[1] + (fRec2[0] * fRec0[0])) + fTemp0));
+			output0[i] = FAUSTFLOAT((fTemp0 + (fRec0[1] + (fRec2[0] * fRec0[0]))));
 			fRec4[0] = (fTemp1 - (fRec2[0] * fRec4[1]));
 			fRec3[0] = (fRec4[1] + (fRec2[0] * (fRec4[0] - fRec3[1])));
-			output1[i] = FAUSTFLOAT(((fRec3[1] + (fRec2[0] * fRec3[0])) + fTemp1));
+			output1[i] = FAUSTFLOAT((fTemp1 + (fRec3[1] + (fRec2[0] * fRec3[0]))));
 			fRec2[1] = fRec2[0];
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
 			fRec4[1] = fRec4[0];
 			fRec3[1] = fRec3[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBrf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBrf2p.cxx
@@ -34,7 +34,6 @@ class faust2chBrf2p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
@@ -105,8 +104,7 @@ class faust2chBrf2p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -169,20 +167,22 @@ class faust2chBrf2p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
-		double fSlow2 = (fSlow1 + 1.0);
-		double fSlow3 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow2));
-		double fSlow4 = (fConst2 * ((1.0 - fSlow1) / fSlow2));
-		double fSlow5 = (fConst2 / fSlow2);
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow2 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
+		double fSlow3 = (fSlow2 + 1.0);
+		double fSlow4 = (1.0 - fSlow0);
+		double fSlow5 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow3) * fSlow4);
+		double fSlow6 = (((1.0 - fSlow2) / fSlow3) * fSlow4);
+		double fSlow7 = ((1.0 / fSlow3) * fSlow4);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow3 + (fConst1 * fRec0[1]));
+			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow5);
 			double fTemp2 = (fRec0[0] * fRec1[1]);
-			fRec2[0] = (fSlow4 + (fConst1 * fRec2[1]));
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow6);
 			fRec1[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec1[2])));
-			fRec3[0] = (fSlow5 + (fConst1 * fRec3[1]));
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow7);
 			output0[i] = FAUSTFLOAT((fTemp2 + (fRec3[0] * (fRec1[0] + fRec1[2]))));
 			double fTemp3 = (fRec0[0] * fRec4[1]);
 			fRec4[0] = (fTemp1 - (fTemp3 + (fRec2[0] * fRec4[2])));

--- a/src/sfizz/gen/filters/sfz2chBrf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBrf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBrf2p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chBrf2p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chBrf2p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -41,23 +42,21 @@ class faust2chBrf2p : public sfzFilterDsp {
 	double fRec1[3];
 	double fRec3[2];
 	double fRec4[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -70,14 +69,12 @@ class faust2chBrf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -90,84 +87,70 @@ class faust2chBrf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec1[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 3); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chBrf2p* clone() {
 		return new faust2chBrf2p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
@@ -178,11 +161,11 @@ class faust2chBrf2p : public sfzFilterDsp {
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow5);
+			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow5);
 			double fTemp2 = (fRec0[0] * fRec1[1]);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow6);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
 			fRec1[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec1[2])));
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow7);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow7);
 			output0[i] = FAUSTFLOAT((fTemp2 + (fRec3[0] * (fRec1[0] + fRec1[2]))));
 			double fTemp3 = (fRec0[0] * fRec4[1]);
 			fRec4[0] = (fTemp1 - (fTemp3 + (fRec2[0] * fRec4[2])));
@@ -194,9 +177,7 @@ class faust2chBrf2p : public sfzFilterDsp {
 			fRec3[1] = fRec3[0];
 			fRec4[2] = fRec4[1];
 			fRec4[1] = fRec4[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chBrf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chBrf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chBrf2pSv_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chBrf2pSv
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chBrf2pSv : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -43,23 +44,21 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 	double fRec3[2];
 	double fRec9[2];
 	double fRec10[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -72,14 +71,12 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -92,102 +89,86 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec5[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec6[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec3[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec9[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
 			fRec10[l6] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chBrf2pSv* clone() {
 		return new faust2chBrf2pSv();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow2);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow2);
 			double fTemp2 = (fSlow3 + fRec5[0]);
-			fRec4[0] = ((fRec4[1] * fSlow0) + (fSlow1 / ((fRec5[0] * fTemp2) + 1.0)));
-			fRec6[0] = ((fRec6[1] * fSlow0) + (fSlow1 * fTemp2));
+			fRec4[0] = ((fSlow0 * fRec4[1]) + (fSlow1 / ((fRec5[0] * fTemp2) + 1.0)));
+			fRec6[0] = ((fSlow0 * fRec6[1]) + (fSlow1 * fTemp2));
 			double fTemp3 = (fTemp0 - (fRec2[1] + (fRec6[0] * fRec3[1])));
 			double fRec0 = (fRec4[0] * fTemp3);
 			double fTemp4 = (fRec5[0] * fRec4[0]);
@@ -214,9 +195,7 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 			fRec3[1] = fRec3[0];
 			fRec9[1] = fRec9[0];
 			fRec10[1] = fRec10[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chEq.cxx
+++ b/src/sfizz/gen/filters/sfz2chEq.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chEq_H__
@@ -11,7 +11,7 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 /* link with : "" */
 #include <algorithm>
@@ -19,19 +19,20 @@ Compilation options: -inpl -double -ftz 0
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chEq
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chEq : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -45,23 +46,21 @@ class faust2chEq : public sfzFilterDsp {
 	double fRec3[2];
 	double fRec4[2];
 	double fRec5[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -74,14 +73,12 @@ class faust2chEq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -94,90 +91,75 @@ class faust2chEq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		fConst3 = (2.1775860903036022 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fBandwidth = FAUSTFLOAT(1.0);
 		fPkShGain = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chEq* clone() {
 		return new faust2chEq();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = std::max<double>(0.0, double(fCutoff));
 		double fSlow2 = (fConst2 * fSlow1);
 		double fSlow3 = std::sin(fSlow2);
@@ -194,12 +176,12 @@ class faust2chEq : public sfzFilterDsp {
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow9);
+			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow9);
 			double fTemp2 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow10);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow10);
 			fRec0[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow12);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow13);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp2) + (fRec4[0] * fRec0[2])));
 			double fTemp3 = (fRec1[0] * fRec5[1]);
 			fRec5[0] = (fTemp1 - (fTemp3 + (fRec2[0] * fRec5[2])));
@@ -212,9 +194,7 @@ class faust2chEq : public sfzFilterDsp {
 			fRec4[1] = fRec4[0];
 			fRec5[2] = fRec5[1];
 			fRec5[1] = fRec5[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chHpf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf1p.cxx
@@ -34,7 +34,6 @@ class faust2chHpf1p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec1[2];
 	double fRec0[2];
@@ -102,8 +101,7 @@ class faust2chHpf1p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (1.0 / fConst0);
+		fConst2 = (1.0 / fConst0);
 		
 	}
 	
@@ -157,11 +155,12 @@ class faust2chHpf1p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst2 * std::exp((fConst3 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow0 + (fConst1 * fRec1[1]));
+			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow1);
 			fRec0[0] = ((fRec1[0] * fRec0[1]) + fTemp0);
 			double fTemp2 = (fRec1[0] + 1.0);
 			double fTemp3 = (0.0 - (0.5 * fTemp2));

--- a/src/sfizz/gen/filters/sfz2chHpf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chHpf1p_H__
@@ -11,50 +11,49 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chHpf1p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chHpf1p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
-	double fConst2;
 	FAUSTFLOAT fCutoff;
+	double fConst2;
 	double fRec1[2];
 	double fRec0[2];
 	double fRec2[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -67,14 +66,12 @@ class faust2chHpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -87,92 +84,78 @@ class faust2chHpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 / fConst0);
-		
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
+		fConst1 = (1.0 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec0[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec2[l2] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chHpf1p* clone() {
 		return new faust2chHpf1p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
-		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
+		double fSlow0 = (fSmoothEnable ? fConst2 : 0.0);
+		double fSlow1 = (std::exp((fConst1 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow1);
-			fRec0[0] = ((fRec1[0] * fRec0[1]) + fTemp0);
+			fRec1[0] = (fSlow1 + (fSlow0 * fRec1[1]));
+			fRec0[0] = (fTemp0 + (fRec1[0] * fRec0[1]));
 			double fTemp2 = (fRec1[0] + 1.0);
 			double fTemp3 = (0.0 - (0.5 * fTemp2));
 			output0[i] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp2)) + (fRec0[1] * fTemp3)));
-			fRec2[0] = ((fRec1[0] * fRec2[1]) + fTemp1);
+			fRec2[0] = (fTemp1 + (fRec1[0] * fRec2[1]));
 			output1[i] = FAUSTFLOAT(((0.5 * (fRec2[0] * fTemp2)) + (fTemp3 * fRec2[1])));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chHpf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chHpf2p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chHpf2p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chHpf2p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -42,23 +43,21 @@ class faust2chHpf2p : public sfzFilterDsp {
 	double fRec1[3];
 	double fRec4[2];
 	double fRec5[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -71,14 +70,12 @@ class faust2chHpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -91,88 +88,73 @@ class faust2chHpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec3[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chHpf2p* clone() {
 		return new faust2chHpf2p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::cos(fSlow1);
 		double fSlow3 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
@@ -185,11 +167,11 @@ class faust2chHpf2p : public sfzFilterDsp {
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow6);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow7);
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow8);
+			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow6);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow7);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow8);
 			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow9);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow9);
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec4[0] * (fRec1[0] + fRec1[2]))));
 			fRec5[0] = (fTemp1 - ((fRec2[0] * fRec5[1]) + (fRec3[0] * fRec5[2])));
 			output1[i] = FAUSTFLOAT(((fRec0[0] * fRec5[1]) + (fRec4[0] * (fRec5[0] + fRec5[2]))));
@@ -201,9 +183,7 @@ class faust2chHpf2p : public sfzFilterDsp {
 			fRec4[1] = fRec4[0];
 			fRec5[2] = fRec5[1];
 			fRec5[1] = fRec5[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chHpf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf2p.cxx
@@ -34,14 +34,12 @@ class faust2chHpf2p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec2[2];
 	double fRec3[2];
 	double fRec1[3];
-	double fConst4;
 	double fRec4[2];
 	double fRec5[3];
 	
@@ -107,9 +105,7 @@ class faust2chHpf2p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (0.5 * fConst2);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -176,22 +172,24 @@ class faust2chHpf2p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = std::cos(fSlow0);
-		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
-		double fSlow3 = (fSlow2 + 1.0);
-		double fSlow4 = (fConst2 * ((-1.0 - fSlow1) / fSlow3));
-		double fSlow5 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow6 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow7 = (fConst4 * ((fSlow1 + 1.0) / fSlow3));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow2 = std::cos(fSlow1);
+		double fSlow3 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
+		double fSlow4 = (fSlow3 + 1.0);
+		double fSlow5 = (1.0 - fSlow0);
+		double fSlow6 = (((-1.0 - fSlow2) / fSlow4) * fSlow5);
+		double fSlow7 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
+		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
+		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow4 + (fConst1 * fRec0[1]));
-			fRec2[0] = (fSlow5 + (fConst1 * fRec2[1]));
-			fRec3[0] = (fSlow6 + (fConst1 * fRec3[1]));
+			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow6);
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow7);
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow8);
 			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
-			fRec4[0] = (fSlow7 + (fConst1 * fRec4[1]));
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow9);
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec4[0] * (fRec1[0] + fRec1[2]))));
 			fRec5[0] = (fTemp1 - ((fRec2[0] * fRec5[1]) + (fRec3[0] * fRec5[2])));
 			output1[i] = FAUSTFLOAT(((fRec0[0] * fRec5[1]) + (fRec4[0] * (fRec5[0] + fRec5[2]))));

--- a/src/sfizz/gen/filters/sfz2chHpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf2pSv.cxx
@@ -34,7 +34,6 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec4[2];
 	FAUSTFLOAT fQ;
@@ -107,8 +106,7 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (3.1415926535897931 / fConst0);
+		fConst2 = (3.1415926535897931 / fConst0);
 		
 	}
 	
@@ -179,15 +177,17 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
-		double fSlow1 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (1.0 - fSlow0);
+		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
+		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec4[0] = (fSlow0 + (fConst1 * fRec4[1]));
-			double fTemp2 = (fSlow1 + fRec4[0]);
-			fRec3[0] = ((fConst2 / ((fRec4[0] * fTemp2) + 1.0)) + (fConst1 * fRec3[1]));
-			fRec5[0] = ((fConst1 * fRec5[1]) + (fConst2 * fTemp2));
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow2);
+			double fTemp2 = (fSlow3 + fRec4[0]);
+			fRec3[0] = ((fRec3[1] * fSlow0) + (fSlow1 / ((fRec4[0] * fTemp2) + 1.0)));
+			fRec5[0] = ((fRec5[1] * fSlow0) + (fSlow1 * fTemp2));
 			double fTemp3 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fRec0 = (fRec3[0] * fTemp3);
 			double fTemp4 = (fRec4[0] * fRec3[0]);

--- a/src/sfizz/gen/filters/sfz2chHpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chHpf2pSv_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chHpf2pSv
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chHpf2pSv : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -43,23 +44,21 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 	double fRec2[2];
 	double fRec7[2];
 	double fRec8[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -72,14 +71,12 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -92,102 +89,86 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec4[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec2[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec7[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
 			fRec8[l6] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chHpf2pSv* clone() {
 		return new faust2chHpf2pSv();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow2);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow2);
 			double fTemp2 = (fSlow3 + fRec4[0]);
-			fRec3[0] = ((fRec3[1] * fSlow0) + (fSlow1 / ((fRec4[0] * fTemp2) + 1.0)));
-			fRec5[0] = ((fRec5[1] * fSlow0) + (fSlow1 * fTemp2));
+			fRec3[0] = ((fSlow0 * fRec3[1]) + (fSlow1 / ((fRec4[0] * fTemp2) + 1.0)));
+			fRec5[0] = ((fSlow0 * fRec5[1]) + (fSlow1 * fTemp2));
 			double fTemp3 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fRec0 = (fRec3[0] * fTemp3);
 			double fTemp4 = (fRec4[0] * fRec3[0]);
@@ -212,9 +193,7 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 			fRec2[1] = fRec2[0];
 			fRec7[1] = fRec7[0];
 			fRec8[1] = fRec8[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chHpf4p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf4p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chHpf4p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chHpf4p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chHpf4p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -44,23 +45,21 @@ class faust2chHpf4p : public sfzFilterDsp {
 	double fRec1[3];
 	double fRec7[3];
 	double fRec6[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -73,14 +72,12 @@ class faust2chHpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -93,96 +90,79 @@ class faust2chHpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec4[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec5[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec1[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec7[l6] = 0.0;
-			
 		}
 		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
 			fRec6[l7] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chHpf4p* clone() {
 		return new faust2chHpf4p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::cos(fSlow1);
 		double fSlow3 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
@@ -195,11 +175,11 @@ class faust2chHpf4p : public sfzFilterDsp {
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow6);
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow7);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow8);
+			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow6);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow7);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow8);
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow9);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow9);
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec5[0] * (fRec1[0] + fRec1[2]))));
 			fRec7[0] = (fTemp1 - ((fRec3[0] * fRec7[1]) + (fRec4[0] * fRec7[2])));
@@ -217,9 +197,7 @@ class faust2chHpf4p : public sfzFilterDsp {
 			fRec7[1] = fRec7[0];
 			fRec6[2] = fRec6[1];
 			fRec6[1] = fRec6[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chHpf4p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf4p.cxx
@@ -34,14 +34,12 @@ class faust2chHpf4p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec3[2];
 	double fRec4[2];
 	double fRec2[3];
-	double fConst4;
 	double fRec5[2];
 	double fRec1[3];
 	double fRec7[3];
@@ -109,9 +107,7 @@ class faust2chHpf4p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (0.5 * fConst2);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -186,22 +182,24 @@ class faust2chHpf4p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = std::cos(fSlow0);
-		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
-		double fSlow3 = (fSlow2 + 1.0);
-		double fSlow4 = (fConst2 * ((-1.0 - fSlow1) / fSlow3));
-		double fSlow5 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow6 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow7 = (fConst4 * ((fSlow1 + 1.0) / fSlow3));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow2 = std::cos(fSlow1);
+		double fSlow3 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
+		double fSlow4 = (fSlow3 + 1.0);
+		double fSlow5 = (1.0 - fSlow0);
+		double fSlow6 = (((-1.0 - fSlow2) / fSlow4) * fSlow5);
+		double fSlow7 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
+		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
+		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow4 + (fConst1 * fRec0[1]));
-			fRec3[0] = (fSlow5 + (fConst1 * fRec3[1]));
-			fRec4[0] = (fSlow6 + (fConst1 * fRec4[1]));
+			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow6);
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow7);
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow8);
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = (fSlow7 + (fConst1 * fRec5[1]));
+			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow9);
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec5[0] * (fRec1[0] + fRec1[2]))));
 			fRec7[0] = (fTemp1 - ((fRec3[0] * fRec7[1]) + (fRec4[0] * fRec7[2])));

--- a/src/sfizz/gen/filters/sfz2chHpf6p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf6p.cxx
@@ -34,14 +34,12 @@ class faust2chHpf6p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec4[2];
 	double fRec5[2];
 	double fRec3[3];
-	double fConst4;
 	double fRec6[2];
 	double fRec2[3];
 	double fRec1[3];
@@ -111,9 +109,7 @@ class faust2chHpf6p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (0.5 * fConst2);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -196,22 +192,24 @@ class faust2chHpf6p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = std::cos(fSlow0);
-		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
-		double fSlow3 = (fSlow2 + 1.0);
-		double fSlow4 = (fConst2 * ((-1.0 - fSlow1) / fSlow3));
-		double fSlow5 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow6 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow7 = (fConst4 * ((fSlow1 + 1.0) / fSlow3));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow2 = std::cos(fSlow1);
+		double fSlow3 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
+		double fSlow4 = (fSlow3 + 1.0);
+		double fSlow5 = (1.0 - fSlow0);
+		double fSlow6 = (((-1.0 - fSlow2) / fSlow4) * fSlow5);
+		double fSlow7 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
+		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
+		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow4 + (fConst1 * fRec0[1]));
-			fRec4[0] = (fSlow5 + (fConst1 * fRec4[1]));
-			fRec5[0] = (fSlow6 + (fConst1 * fRec5[1]));
+			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow6);
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow7);
+			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow8);
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (fSlow7 + (fConst1 * fRec6[1]));
+			fRec6[0] = ((fRec6[1] * fSlow0) + fSlow9);
 			fRec2[0] = (((fRec0[0] * fRec3[1]) + (fRec6[0] * (fRec3[0] + fRec3[2]))) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec6[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec6[0] * (fRec1[0] + fRec1[2]))));

--- a/src/sfizz/gen/filters/sfz2chHpf6p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf6p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chHpf6p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chHpf6p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chHpf6p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -46,23 +47,21 @@ class faust2chHpf6p : public sfzFilterDsp {
 	double fRec9[3];
 	double fRec8[3];
 	double fRec7[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -75,14 +74,12 @@ class faust2chHpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -95,104 +92,85 @@ class faust2chHpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec6[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec2[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec1[l6] = 0.0;
-			
 		}
 		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
 			fRec9[l7] = 0.0;
-			
 		}
 		for (int l8 = 0; (l8 < 3); l8 = (l8 + 1)) {
 			fRec8[l8] = 0.0;
-			
 		}
 		for (int l9 = 0; (l9 < 3); l9 = (l9 + 1)) {
 			fRec7[l9] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chHpf6p* clone() {
 		return new faust2chHpf6p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::cos(fSlow1);
 		double fSlow3 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
@@ -205,11 +183,11 @@ class faust2chHpf6p : public sfzFilterDsp {
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow6);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow7);
-			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow8);
+			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow6);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow7);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow8);
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = ((fRec6[1] * fSlow0) + fSlow9);
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow9);
 			fRec2[0] = (((fRec0[0] * fRec3[1]) + (fRec6[0] * (fRec3[0] + fRec3[2]))) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec6[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec6[0] * (fRec1[0] + fRec1[2]))));
@@ -233,9 +211,7 @@ class faust2chHpf6p : public sfzFilterDsp {
 			fRec8[1] = fRec8[0];
 			fRec7[2] = fRec7[1];
 			fRec7[1] = fRec7[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chHsh.cxx
+++ b/src/sfizz/gen/filters/sfz2chHsh.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chHsh_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chHsh
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chHsh : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fPkShGain;
@@ -44,23 +45,21 @@ class faust2chHsh : public sfzFilterDsp {
 	double fRec4[2];
 	double fRec5[2];
 	double fRec6[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -73,14 +72,12 @@ class faust2chHsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -93,116 +90,100 @@ class faust2chHsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fPkShGain = FAUSTFLOAT(0.0);
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec6[l6] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chHsh* clone() {
 		return new faust2chHsh();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
 		double fSlow2 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow3 = std::cos(fSlow2);
-		double fSlow4 = ((fSlow1 + 1.0) * fSlow3);
+		double fSlow4 = (fSlow3 * (fSlow1 + 1.0));
 		double fSlow5 = ((std::sqrt(fSlow1) * std::sin(fSlow2)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
-		double fSlow6 = ((fSlow1 + -1.0) * fSlow3);
+		double fSlow6 = (fSlow3 * (fSlow1 + -1.0));
 		double fSlow7 = ((fSlow1 + fSlow5) + (1.0 - fSlow6));
 		double fSlow8 = (1.0 - fSlow0);
 		double fSlow9 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow7)) * fSlow8);
-		double fSlow10 = (((fSlow1 + (1.0 - (fSlow6 + fSlow5))) / fSlow7) * fSlow8);
-		double fSlow11 = (fSlow6 + fSlow1);
-		double fSlow12 = (((((fSlow11 + fSlow5) + 1.0) * fSlow1) / fSlow7) * fSlow8);
-		double fSlow13 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow4 + fSlow1) + -1.0)) / fSlow7) * fSlow8);
-		double fSlow14 = ((((fSlow11 + (1.0 - fSlow5)) * fSlow1) / fSlow7) * fSlow8);
+		double fSlow10 = (((fSlow1 + (1.0 - (fSlow5 + fSlow6))) / fSlow7) * fSlow8);
+		double fSlow11 = (fSlow1 + fSlow6);
+		double fSlow12 = (((fSlow1 * ((fSlow5 + fSlow11) + 1.0)) / fSlow7) * fSlow8);
+		double fSlow13 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow1 + fSlow4) + -1.0)) / fSlow7) * fSlow8);
+		double fSlow14 = (((fSlow1 * (fSlow11 + (1.0 - fSlow5))) / fSlow7) * fSlow8);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow9);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow10);
+			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow9);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow10);
 			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow12);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow13);
-			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow14);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow14);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec6[0] = (fTemp1 - ((fRec1[0] * fRec6[1]) + (fRec2[0] * fRec6[2])));
 			output1[i] = FAUSTFLOAT((((fRec3[0] * fRec6[0]) + (fRec4[0] * fRec6[1])) + (fRec5[0] * fRec6[2])));
@@ -215,9 +196,7 @@ class faust2chHsh : public sfzFilterDsp {
 			fRec5[1] = fRec5[0];
 			fRec6[2] = fRec6[1];
 			fRec6[1] = fRec6[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chHsh.cxx
+++ b/src/sfizz/gen/filters/sfz2chHsh.cxx
@@ -33,10 +33,8 @@ class faust2chHsh : public sfzFilterDsp {
 	int fSamplingFreq;
 	double fConst0;
 	double fConst1;
-	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fPkShGain;
-	double fConst4;
+	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec1[2];
@@ -109,9 +107,7 @@ class faust2chHsh : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (2.0 * fConst2);
-		fConst4 = (6.2831853071795862 / fConst0);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -183,28 +179,30 @@ class faust2chHsh : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
-		double fSlow1 = (fConst4 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow2 = std::cos(fSlow1);
-		double fSlow3 = ((fSlow0 + 1.0) * fSlow2);
-		double fSlow4 = ((std::sqrt(fSlow0) * std::sin(fSlow1)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
-		double fSlow5 = ((fSlow0 + -1.0) * fSlow2);
-		double fSlow6 = ((fSlow0 + fSlow4) + (1.0 - fSlow5));
-		double fSlow7 = (fConst3 * ((fSlow0 + (-1.0 - fSlow3)) / fSlow6));
-		double fSlow8 = (fConst2 * ((fSlow0 + (1.0 - (fSlow5 + fSlow4))) / fSlow6));
-		double fSlow9 = (fSlow5 + fSlow0);
-		double fSlow10 = (fConst2 * ((((fSlow9 + fSlow4) + 1.0) * fSlow0) / fSlow6));
-		double fSlow11 = (fConst2 * (((0.0 - (2.0 * fSlow0)) * ((fSlow3 + fSlow0) + -1.0)) / fSlow6));
-		double fSlow12 = (fConst2 * (((fSlow9 + (1.0 - fSlow4)) * fSlow0) / fSlow6));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
+		double fSlow2 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow3 = std::cos(fSlow2);
+		double fSlow4 = ((fSlow1 + 1.0) * fSlow3);
+		double fSlow5 = ((std::sqrt(fSlow1) * std::sin(fSlow2)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
+		double fSlow6 = ((fSlow1 + -1.0) * fSlow3);
+		double fSlow7 = ((fSlow1 + fSlow5) + (1.0 - fSlow6));
+		double fSlow8 = (1.0 - fSlow0);
+		double fSlow9 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow7)) * fSlow8);
+		double fSlow10 = (((fSlow1 + (1.0 - (fSlow6 + fSlow5))) / fSlow7) * fSlow8);
+		double fSlow11 = (fSlow6 + fSlow1);
+		double fSlow12 = (((((fSlow11 + fSlow5) + 1.0) * fSlow1) / fSlow7) * fSlow8);
+		double fSlow13 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow4 + fSlow1) + -1.0)) / fSlow7) * fSlow8);
+		double fSlow14 = ((((fSlow11 + (1.0 - fSlow5)) * fSlow1) / fSlow7) * fSlow8);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow7 + (fConst1 * fRec1[1]));
-			fRec2[0] = (fSlow8 + (fConst1 * fRec2[1]));
+			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow9);
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow10);
 			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow10 + (fConst1 * fRec3[1]));
-			fRec4[0] = (fSlow11 + (fConst1 * fRec4[1]));
-			fRec5[0] = (fSlow12 + (fConst1 * fRec5[1]));
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow12);
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow13);
+			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow14);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec6[0] = (fTemp1 - ((fRec1[0] * fRec6[1]) + (fRec2[0] * fRec6[2])));
 			output1[i] = FAUSTFLOAT((((fRec3[0] * fRec6[0]) + (fRec4[0] * fRec6[1])) + (fRec5[0] * fRec6[2])));

--- a/src/sfizz/gen/filters/sfz2chLpf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chLpf1p_H__
@@ -11,50 +11,49 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chLpf1p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chLpf1p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
-	double fConst2;
 	FAUSTFLOAT fCutoff;
+	double fConst2;
 	double fRec1[2];
 	double fRec0[2];
 	double fRec2[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -67,14 +66,12 @@ class faust2chLpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -87,91 +84,77 @@ class faust2chLpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 / fConst0);
-		
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
+		fConst1 = (1.0 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec0[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec2[l2] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chLpf1p* clone() {
 		return new faust2chLpf1p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
-		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
+		double fSlow0 = (fSmoothEnable ? fConst2 : 0.0);
+		double fSlow1 = (std::exp((fConst1 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow1);
-			fRec0[0] = ((fRec1[0] * fRec0[1]) + fTemp0);
+			fRec1[0] = (fSlow1 + (fSlow0 * fRec1[1]));
+			fRec0[0] = (fTemp0 + (fRec1[0] * fRec0[1]));
 			double fTemp2 = (1.0 - fRec1[0]);
 			output0[i] = FAUSTFLOAT((fRec0[0] * fTemp2));
-			fRec2[0] = ((fRec1[0] * fRec2[1]) + fTemp1);
+			fRec2[0] = (fTemp1 + (fRec1[0] * fRec2[1]));
 			output1[i] = FAUSTFLOAT((fRec2[0] * fTemp2));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chLpf1p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf1p.cxx
@@ -34,7 +34,6 @@ class faust2chLpf1p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec1[2];
 	double fRec0[2];
@@ -102,8 +101,7 @@ class faust2chLpf1p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (1.0 / fConst0);
+		fConst2 = (1.0 / fConst0);
 		
 	}
 	
@@ -157,11 +155,12 @@ class faust2chLpf1p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst2 * std::exp((fConst3 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow0 + (fConst1 * fRec1[1]));
+			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow1);
 			fRec0[0] = ((fRec1[0] * fRec0[1]) + fTemp0);
 			double fTemp2 = (1.0 - fRec1[0]);
 			output0[i] = FAUSTFLOAT((fRec0[0] * fTemp2));

--- a/src/sfizz/gen/filters/sfz2chLpf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf2p.cxx
@@ -33,15 +33,13 @@ class faust2chLpf2p : public sfzFilterDsp {
 	int fSamplingFreq;
 	double fConst0;
 	double fConst1;
-	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
+	double fConst2;
 	double fRec0[2];
 	double fRec2[2];
 	double fRec3[2];
 	double fRec1[3];
-	double fConst4;
 	double fRec4[2];
 	double fRec5[3];
 	
@@ -106,10 +104,8 @@ class faust2chLpf2p : public sfzFilterDsp {
 	virtual void instanceConstants(int samplingFreq) {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (0.5 * fConst2);
+		fConst1 = (6.2831853071795862 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 		
 	}
 	
@@ -176,23 +172,25 @@ class faust2chLpf2p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst1 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (fConst2 * fSlow4);
-		double fSlow6 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow7 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow8 = (fConst4 * fSlow4);
+		double fSlow5 = (fSmoothEnable?fConst2:0.0);
+		double fSlow6 = (1.0 - fSlow5);
+		double fSlow7 = (fSlow4 * fSlow6);
+		double fSlow8 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
+		double fSlow9 = (((1.0 - fSlow2) / fSlow3) * fSlow6);
+		double fSlow10 = ((0.5 * fSlow4) * fSlow6);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow5 + (fConst1 * fRec0[1]));
-			fRec2[0] = (fSlow6 + (fConst1 * fRec2[1]));
-			fRec3[0] = (fSlow7 + (fConst1 * fRec3[1]));
+			fRec0[0] = (fSlow7 + (fRec0[1] * fSlow5));
+			fRec2[0] = ((fRec2[1] * fSlow5) + fSlow8);
+			fRec3[0] = ((fRec3[1] * fSlow5) + fSlow9);
 			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
-			fRec4[0] = (fSlow8 + (fConst1 * fRec4[1]));
+			fRec4[0] = ((fRec4[1] * fSlow5) + fSlow10);
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec4[0] * (fRec1[0] + fRec1[2]))));
 			fRec5[0] = (fTemp1 - ((fRec2[0] * fRec5[1]) + (fRec3[0] * fRec5[2])));
 			output1[i] = FAUSTFLOAT(((fRec0[0] * fRec5[1]) + (fRec4[0] * (fRec5[0] + fRec5[2]))));

--- a/src/sfizz/gen/filters/sfz2chLpf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chLpf2p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chLpf2p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chLpf2p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fCutoff;
@@ -42,23 +43,21 @@ class faust2chLpf2p : public sfzFilterDsp {
 	double fRec1[3];
 	double fRec4[2];
 	double fRec5[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -71,14 +70,12 @@ class faust2chLpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -91,82 +88,67 @@ class faust2chLpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = (6.2831853071795862 / fConst0);
 		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec3[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chLpf2p* clone() {
 		return new faust2chLpf2p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
@@ -177,7 +159,7 @@ class faust2chLpf2p : public sfzFilterDsp {
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (fSmoothEnable?fConst2:0.0);
+		double fSlow5 = (fSmoothEnable ? fConst2 : 0.0);
 		double fSlow6 = (1.0 - fSlow5);
 		double fSlow7 = (fSlow4 * fSlow6);
 		double fSlow8 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
@@ -186,11 +168,11 @@ class faust2chLpf2p : public sfzFilterDsp {
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow7 + (fRec0[1] * fSlow5));
-			fRec2[0] = ((fRec2[1] * fSlow5) + fSlow8);
-			fRec3[0] = ((fRec3[1] * fSlow5) + fSlow9);
+			fRec0[0] = (fSlow7 + (fSlow5 * fRec0[1]));
+			fRec2[0] = ((fSlow5 * fRec2[1]) + fSlow8);
+			fRec3[0] = ((fSlow5 * fRec3[1]) + fSlow9);
 			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
-			fRec4[0] = ((fRec4[1] * fSlow5) + fSlow10);
+			fRec4[0] = ((fSlow5 * fRec4[1]) + fSlow10);
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec4[0] * (fRec1[0] + fRec1[2]))));
 			fRec5[0] = (fTemp1 - ((fRec2[0] * fRec5[1]) + (fRec3[0] * fRec5[2])));
 			output1[i] = FAUSTFLOAT(((fRec0[0] * fRec5[1]) + (fRec4[0] * (fRec5[0] + fRec5[2]))));
@@ -202,9 +184,7 @@ class faust2chLpf2p : public sfzFilterDsp {
 			fRec4[1] = fRec4[0];
 			fRec5[2] = fRec5[1];
 			fRec5[1] = fRec5[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chLpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chLpf2pSv_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chLpf2pSv
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chLpf2pSv : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -43,23 +44,21 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 	double fRec2[2];
 	double fRec7[2];
 	double fRec8[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -72,14 +71,12 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -92,103 +89,87 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec3[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec2[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec7[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
 			fRec8[l6] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chLpf2pSv* clone() {
 		return new faust2chLpf2pSv();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow2);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow2);
 			double fTemp2 = (fSlow3 + fRec3[0]);
-			fRec4[0] = ((fRec4[1] * fSlow0) + (fSlow1 / ((fRec3[0] * fTemp2) + 1.0)));
+			fRec4[0] = ((fSlow0 * fRec4[1]) + (fSlow1 / ((fRec3[0] * fTemp2) + 1.0)));
 			double fTemp3 = (fRec3[0] * fRec4[0]);
-			fRec5[0] = ((fRec5[1] * fSlow0) + (fSlow1 * fTemp2));
+			fRec5[0] = ((fSlow0 * fRec5[1]) + (fSlow1 * fTemp2));
 			double fTemp4 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fTemp5 = (fTemp3 * fTemp4);
 			double fTemp6 = (fRec2[1] + (2.0 * fTemp5));
@@ -212,9 +193,7 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 			fRec2[1] = fRec2[0];
 			fRec7[1] = fRec7[0];
 			fRec8[1] = fRec8[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chLpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf2pSv.cxx
@@ -34,7 +34,6 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec3[2];
 	FAUSTFLOAT fQ;
@@ -107,8 +106,7 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (3.1415926535897931 / fConst0);
+		fConst2 = (3.1415926535897931 / fConst0);
 		
 	}
 	
@@ -179,16 +177,18 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
-		double fSlow1 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (1.0 - fSlow0);
+		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
+		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec3[0] = (fSlow0 + (fConst1 * fRec3[1]));
-			double fTemp2 = (fSlow1 + fRec3[0]);
-			fRec4[0] = ((fConst2 / ((fRec3[0] * fTemp2) + 1.0)) + (fConst1 * fRec4[1]));
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow2);
+			double fTemp2 = (fSlow3 + fRec3[0]);
+			fRec4[0] = ((fRec4[1] * fSlow0) + (fSlow1 / ((fRec3[0] * fTemp2) + 1.0)));
 			double fTemp3 = (fRec3[0] * fRec4[0]);
-			fRec5[0] = ((fConst1 * fRec5[1]) + (fConst2 * fTemp2));
+			fRec5[0] = ((fRec5[1] * fSlow0) + (fSlow1 * fTemp2));
 			double fTemp4 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fTemp5 = (fTemp3 * fTemp4);
 			double fTemp6 = (fRec2[1] + (2.0 * fTemp5));

--- a/src/sfizz/gen/filters/sfz2chLpf4p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf4p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chLpf4p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chLpf4p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chLpf4p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fCutoff;
@@ -44,23 +45,21 @@ class faust2chLpf4p : public sfzFilterDsp {
 	double fRec1[3];
 	double fRec7[3];
 	double fRec6[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -73,14 +72,12 @@ class faust2chLpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -93,90 +90,73 @@ class faust2chLpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = (6.2831853071795862 / fConst0);
 		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec4[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec5[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec1[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec7[l6] = 0.0;
-			
 		}
 		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
 			fRec6[l7] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chLpf4p* clone() {
 		return new faust2chLpf4p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
@@ -187,7 +167,7 @@ class faust2chLpf4p : public sfzFilterDsp {
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (fSmoothEnable?fConst2:0.0);
+		double fSlow5 = (fSmoothEnable ? fConst2 : 0.0);
 		double fSlow6 = (1.0 - fSlow5);
 		double fSlow7 = (fSlow4 * fSlow6);
 		double fSlow8 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
@@ -196,11 +176,11 @@ class faust2chLpf4p : public sfzFilterDsp {
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow7 + (fRec0[1] * fSlow5));
-			fRec3[0] = ((fRec3[1] * fSlow5) + fSlow8);
-			fRec4[0] = ((fRec4[1] * fSlow5) + fSlow9);
+			fRec0[0] = (fSlow7 + (fSlow5 * fRec0[1]));
+			fRec3[0] = ((fSlow5 * fRec3[1]) + fSlow8);
+			fRec4[0] = ((fSlow5 * fRec4[1]) + fSlow9);
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = ((fRec5[1] * fSlow5) + fSlow10);
+			fRec5[0] = ((fSlow5 * fRec5[1]) + fSlow10);
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec5[0] * (fRec1[0] + fRec1[2]))));
 			fRec7[0] = (fTemp1 - ((fRec3[0] * fRec7[1]) + (fRec4[0] * fRec7[2])));
@@ -218,9 +198,7 @@ class faust2chLpf4p : public sfzFilterDsp {
 			fRec7[1] = fRec7[0];
 			fRec6[2] = fRec6[1];
 			fRec6[1] = fRec6[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chLpf4p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf4p.cxx
@@ -33,15 +33,13 @@ class faust2chLpf4p : public sfzFilterDsp {
 	int fSamplingFreq;
 	double fConst0;
 	double fConst1;
-	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
+	double fConst2;
 	double fRec0[2];
 	double fRec3[2];
 	double fRec4[2];
 	double fRec2[3];
-	double fConst4;
 	double fRec5[2];
 	double fRec1[3];
 	double fRec7[3];
@@ -108,10 +106,8 @@ class faust2chLpf4p : public sfzFilterDsp {
 	virtual void instanceConstants(int samplingFreq) {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (0.5 * fConst2);
+		fConst1 = (6.2831853071795862 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 		
 	}
 	
@@ -186,23 +182,25 @@ class faust2chLpf4p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst1 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (fConst2 * fSlow4);
-		double fSlow6 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow7 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow8 = (fConst4 * fSlow4);
+		double fSlow5 = (fSmoothEnable?fConst2:0.0);
+		double fSlow6 = (1.0 - fSlow5);
+		double fSlow7 = (fSlow4 * fSlow6);
+		double fSlow8 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
+		double fSlow9 = (((1.0 - fSlow2) / fSlow3) * fSlow6);
+		double fSlow10 = ((0.5 * fSlow4) * fSlow6);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow5 + (fConst1 * fRec0[1]));
-			fRec3[0] = (fSlow6 + (fConst1 * fRec3[1]));
-			fRec4[0] = (fSlow7 + (fConst1 * fRec4[1]));
+			fRec0[0] = (fSlow7 + (fRec0[1] * fSlow5));
+			fRec3[0] = ((fRec3[1] * fSlow5) + fSlow8);
+			fRec4[0] = ((fRec4[1] * fSlow5) + fSlow9);
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = (fSlow8 + (fConst1 * fRec5[1]));
+			fRec5[0] = ((fRec5[1] * fSlow5) + fSlow10);
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec5[0] * (fRec1[0] + fRec1[2]))));
 			fRec7[0] = (fTemp1 - ((fRec3[0] * fRec7[1]) + (fRec4[0] * fRec7[2])));

--- a/src/sfizz/gen/filters/sfz2chLpf6p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf6p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chLpf6p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chLpf6p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chLpf6p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fCutoff;
@@ -46,23 +47,21 @@ class faust2chLpf6p : public sfzFilterDsp {
 	double fRec9[3];
 	double fRec8[3];
 	double fRec7[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -75,14 +74,12 @@ class faust2chLpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -95,98 +92,79 @@ class faust2chLpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = (6.2831853071795862 / fConst0);
 		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec6[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec2[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec1[l6] = 0.0;
-			
 		}
 		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
 			fRec9[l7] = 0.0;
-			
 		}
 		for (int l8 = 0; (l8 < 3); l8 = (l8 + 1)) {
 			fRec8[l8] = 0.0;
-			
 		}
 		for (int l9 = 0; (l9 < 3); l9 = (l9 + 1)) {
 			fRec7[l9] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chLpf6p* clone() {
 		return new faust2chLpf6p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
@@ -197,7 +175,7 @@ class faust2chLpf6p : public sfzFilterDsp {
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (fSmoothEnable?fConst2:0.0);
+		double fSlow5 = (fSmoothEnable ? fConst2 : 0.0);
 		double fSlow6 = (1.0 - fSlow5);
 		double fSlow7 = (fSlow4 * fSlow6);
 		double fSlow8 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
@@ -206,11 +184,11 @@ class faust2chLpf6p : public sfzFilterDsp {
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow7 + (fRec0[1] * fSlow5));
-			fRec4[0] = ((fRec4[1] * fSlow5) + fSlow8);
-			fRec5[0] = ((fRec5[1] * fSlow5) + fSlow9);
+			fRec0[0] = (fSlow7 + (fSlow5 * fRec0[1]));
+			fRec4[0] = ((fSlow5 * fRec4[1]) + fSlow8);
+			fRec5[0] = ((fSlow5 * fRec5[1]) + fSlow9);
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = ((fRec6[1] * fSlow5) + fSlow10);
+			fRec6[0] = ((fSlow5 * fRec6[1]) + fSlow10);
 			fRec2[0] = (((fRec0[0] * fRec3[1]) + (fRec6[0] * (fRec3[0] + fRec3[2]))) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec6[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec6[0] * (fRec1[0] + fRec1[2]))));
@@ -234,9 +212,7 @@ class faust2chLpf6p : public sfzFilterDsp {
 			fRec8[1] = fRec8[0];
 			fRec7[2] = fRec7[1];
 			fRec7[1] = fRec7[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chLpf6p.cxx
+++ b/src/sfizz/gen/filters/sfz2chLpf6p.cxx
@@ -33,15 +33,13 @@ class faust2chLpf6p : public sfzFilterDsp {
 	int fSamplingFreq;
 	double fConst0;
 	double fConst1;
-	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
+	double fConst2;
 	double fRec0[2];
 	double fRec4[2];
 	double fRec5[2];
 	double fRec3[3];
-	double fConst4;
 	double fRec6[2];
 	double fRec2[3];
 	double fRec1[3];
@@ -110,10 +108,8 @@ class faust2chLpf6p : public sfzFilterDsp {
 	virtual void instanceConstants(int samplingFreq) {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (0.5 * fConst2);
+		fConst1 = (6.2831853071795862 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 		
 	}
 	
@@ -196,23 +192,25 @@ class faust2chLpf6p : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst1 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (fConst2 * fSlow4);
-		double fSlow6 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow7 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow8 = (fConst4 * fSlow4);
+		double fSlow5 = (fSmoothEnable?fConst2:0.0);
+		double fSlow6 = (1.0 - fSlow5);
+		double fSlow7 = (fSlow4 * fSlow6);
+		double fSlow8 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
+		double fSlow9 = (((1.0 - fSlow2) / fSlow3) * fSlow6);
+		double fSlow10 = ((0.5 * fSlow4) * fSlow6);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow5 + (fConst1 * fRec0[1]));
-			fRec4[0] = (fSlow6 + (fConst1 * fRec4[1]));
-			fRec5[0] = (fSlow7 + (fConst1 * fRec5[1]));
+			fRec0[0] = (fSlow7 + (fRec0[1] * fSlow5));
+			fRec4[0] = ((fRec4[1] * fSlow5) + fSlow8);
+			fRec5[0] = ((fRec5[1] * fSlow5) + fSlow9);
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (fSlow8 + (fConst1 * fRec6[1]));
+			fRec6[0] = ((fRec6[1] * fSlow5) + fSlow10);
 			fRec2[0] = (((fRec0[0] * fRec3[1]) + (fRec6[0] * (fRec3[0] + fRec3[2]))) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec6[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec6[0] * (fRec1[0] + fRec1[2]))));

--- a/src/sfizz/gen/filters/sfz2chLsh.cxx
+++ b/src/sfizz/gen/filters/sfz2chLsh.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chLsh_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chLsh
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chLsh : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fPkShGain;
@@ -44,23 +45,21 @@ class faust2chLsh : public sfzFilterDsp {
 	double fRec4[2];
 	double fRec5[2];
 	double fRec6[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -73,14 +72,12 @@ class faust2chLsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -93,116 +90,100 @@ class faust2chLsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fPkShGain = FAUSTFLOAT(0.0);
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec6[l6] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chLsh* clone() {
 		return new faust2chLsh();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
 		double fSlow2 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow3 = std::cos(fSlow2);
-		double fSlow4 = ((fSlow1 + 1.0) * fSlow3);
-		double fSlow5 = ((fSlow1 + -1.0) * fSlow3);
-		double fSlow6 = (fSlow5 + fSlow1);
-		double fSlow7 = ((std::sqrt(fSlow1) * std::sin(fSlow2)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
-		double fSlow8 = ((fSlow6 + fSlow7) + 1.0);
+		double fSlow4 = (fSlow3 * (fSlow1 + 1.0));
+		double fSlow5 = ((std::sqrt(fSlow1) * std::sin(fSlow2)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
+		double fSlow6 = (fSlow3 * (fSlow1 + -1.0));
+		double fSlow7 = (fSlow1 + fSlow6);
+		double fSlow8 = ((fSlow5 + fSlow7) + 1.0);
 		double fSlow9 = (1.0 - fSlow0);
-		double fSlow10 = (((0.0 - (2.0 * ((fSlow4 + fSlow1) + -1.0))) / fSlow8) * fSlow9);
-		double fSlow11 = (((fSlow6 + (1.0 - fSlow7)) / fSlow8) * fSlow9);
-		double fSlow12 = (((((fSlow1 + fSlow7) + (1.0 - fSlow5)) * fSlow1) / fSlow8) * fSlow9);
-		double fSlow13 = ((2.0 * (((fSlow1 + (-1.0 - fSlow4)) * fSlow1) / fSlow8)) * fSlow9);
-		double fSlow14 = ((((fSlow1 + (1.0 - (fSlow5 + fSlow7))) * fSlow1) / fSlow8) * fSlow9);
+		double fSlow10 = (((0.0 - (2.0 * ((fSlow1 + fSlow4) + -1.0))) / fSlow8) * fSlow9);
+		double fSlow11 = (((fSlow7 + (1.0 - fSlow5)) / fSlow8) * fSlow9);
+		double fSlow12 = (((fSlow1 * ((fSlow1 + fSlow5) + (1.0 - fSlow6))) / fSlow8) * fSlow9);
+		double fSlow13 = ((2.0 * ((fSlow1 * (fSlow1 + (-1.0 - fSlow4))) / fSlow8)) * fSlow9);
+		double fSlow14 = (((fSlow1 * (fSlow1 + (1.0 - (fSlow5 + fSlow6)))) / fSlow8) * fSlow9);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow10);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow11);
+			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow10);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow11);
 			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow12);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow13);
-			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow14);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow14);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec6[0] = (fTemp1 - ((fRec1[0] * fRec6[1]) + (fRec2[0] * fRec6[2])));
 			output1[i] = FAUSTFLOAT((((fRec3[0] * fRec6[0]) + (fRec4[0] * fRec6[1])) + (fRec5[0] * fRec6[2])));
@@ -215,9 +196,7 @@ class faust2chLsh : public sfzFilterDsp {
 			fRec5[1] = fRec5[0];
 			fRec6[2] = fRec6[1];
 			fRec6[1] = fRec6[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chLsh.cxx
+++ b/src/sfizz/gen/filters/sfz2chLsh.cxx
@@ -33,16 +33,14 @@ class faust2chLsh : public sfzFilterDsp {
 	int fSamplingFreq;
 	double fConst0;
 	double fConst1;
-	double fConst2;
 	FAUSTFLOAT fPkShGain;
-	double fConst3;
+	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec1[2];
 	double fRec2[2];
 	double fRec0[3];
 	double fRec3[2];
-	double fConst4;
 	double fRec4[2];
 	double fRec5[2];
 	double fRec6[3];
@@ -109,9 +107,7 @@ class faust2chLsh : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (2.0 * fConst2);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -183,28 +179,30 @@ class faust2chLsh : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
-		double fSlow1 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow2 = std::cos(fSlow1);
-		double fSlow3 = ((fSlow0 + 1.0) * fSlow2);
-		double fSlow4 = ((fSlow0 + -1.0) * fSlow2);
-		double fSlow5 = (fSlow4 + fSlow0);
-		double fSlow6 = ((std::sqrt(fSlow0) * std::sin(fSlow1)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
-		double fSlow7 = ((fSlow5 + fSlow6) + 1.0);
-		double fSlow8 = (fConst2 * ((0.0 - (2.0 * ((fSlow3 + fSlow0) + -1.0))) / fSlow7));
-		double fSlow9 = (fConst2 * ((fSlow5 + (1.0 - fSlow6)) / fSlow7));
-		double fSlow10 = (fConst2 * ((((fSlow0 + fSlow6) + (1.0 - fSlow4)) * fSlow0) / fSlow7));
-		double fSlow11 = (fConst4 * (((fSlow0 + (-1.0 - fSlow3)) * fSlow0) / fSlow7));
-		double fSlow12 = (fConst2 * (((fSlow0 + (1.0 - (fSlow4 + fSlow6))) * fSlow0) / fSlow7));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
+		double fSlow2 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow3 = std::cos(fSlow2);
+		double fSlow4 = ((fSlow1 + 1.0) * fSlow3);
+		double fSlow5 = ((fSlow1 + -1.0) * fSlow3);
+		double fSlow6 = (fSlow5 + fSlow1);
+		double fSlow7 = ((std::sqrt(fSlow1) * std::sin(fSlow2)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
+		double fSlow8 = ((fSlow6 + fSlow7) + 1.0);
+		double fSlow9 = (1.0 - fSlow0);
+		double fSlow10 = (((0.0 - (2.0 * ((fSlow4 + fSlow1) + -1.0))) / fSlow8) * fSlow9);
+		double fSlow11 = (((fSlow6 + (1.0 - fSlow7)) / fSlow8) * fSlow9);
+		double fSlow12 = (((((fSlow1 + fSlow7) + (1.0 - fSlow5)) * fSlow1) / fSlow8) * fSlow9);
+		double fSlow13 = ((2.0 * (((fSlow1 + (-1.0 - fSlow4)) * fSlow1) / fSlow8)) * fSlow9);
+		double fSlow14 = ((((fSlow1 + (1.0 - (fSlow5 + fSlow7))) * fSlow1) / fSlow8) * fSlow9);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = (fSlow8 + (fConst1 * fRec1[1]));
-			fRec2[0] = (fSlow9 + (fConst1 * fRec2[1]));
+			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow10);
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow11);
 			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow10 + (fConst1 * fRec3[1]));
-			fRec4[0] = (fSlow11 + (fConst1 * fRec4[1]));
-			fRec5[0] = (fSlow12 + (fConst1 * fRec5[1]));
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow12);
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow13);
+			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow14);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec6[0] = (fTemp1 - ((fRec1[0] * fRec6[1]) + (fRec2[0] * fRec6[2])));
 			output1[i] = FAUSTFLOAT((((fRec3[0] * fRec6[0]) + (fRec4[0] * fRec6[1])) + (fRec5[0] * fRec6[2])));

--- a/src/sfizz/gen/filters/sfz2chPeq.cxx
+++ b/src/sfizz/gen/filters/sfz2chPeq.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chPeq_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faust2chPeq
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faust2chPeq : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -43,23 +44,21 @@ class faust2chPeq : public sfzFilterDsp {
 	double fRec3[2];
 	double fRec4[2];
 	double fRec5[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -72,14 +71,12 @@ class faust2chPeq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -92,89 +89,74 @@ class faust2chPeq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 		fPkShGain = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faust2chPeq* clone() {
 		return new faust2chPeq();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::sin(fSlow1);
 		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
@@ -190,12 +172,12 @@ class faust2chPeq : public sfzFilterDsp {
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow8);
+			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow8);
 			double fTemp2 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow9);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow9);
 			fRec0[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow11);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow12);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow12);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp2) + (fRec4[0] * fRec0[2])));
 			double fTemp3 = (fRec1[0] * fRec5[1]);
 			fRec5[0] = (fTemp1 - (fTemp3 + (fRec2[0] * fRec5[2])));
@@ -208,9 +190,7 @@ class faust2chPeq : public sfzFilterDsp {
 			fRec4[1] = fRec4[0];
 			fRec5[2] = fRec5[1];
 			fRec5[1] = fRec5[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfz2chPeq.cxx
+++ b/src/sfizz/gen/filters/sfz2chPeq.cxx
@@ -34,13 +34,12 @@ class faust2chPeq : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	FAUSTFLOAT fPkShGain;
-	double fRec0[2];
+	double fRec1[2];
 	double fRec2[2];
-	double fRec1[3];
+	double fRec0[3];
 	double fRec3[2];
 	double fRec4[2];
 	double fRec5[3];
@@ -107,8 +106,7 @@ class faust2chPeq : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -121,7 +119,7 @@ class faust2chPeq : public sfzFilterDsp {
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec0[l0] = 0.0;
+			fRec1[l0] = 0.0;
 			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
@@ -129,7 +127,7 @@ class faust2chPeq : public sfzFilterDsp {
 			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec1[l2] = 0.0;
+			fRec0[l2] = 0.0;
 			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
@@ -176,34 +174,36 @@ class faust2chPeq : public sfzFilterDsp {
 		FAUSTFLOAT* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = std::sin(fSlow0);
-		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
-		double fSlow3 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
-		double fSlow4 = (0.5 * (fSlow1 / (fSlow2 * fSlow3)));
-		double fSlow5 = (fSlow4 + 1.0);
-		double fSlow6 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow5));
-		double fSlow7 = (fConst2 * ((1.0 - fSlow4) / fSlow5));
-		double fSlow8 = (0.5 * ((fSlow1 * fSlow3) / fSlow2));
-		double fSlow9 = (fConst2 * ((fSlow8 + 1.0) / fSlow5));
-		double fSlow10 = (fConst2 * ((1.0 - fSlow8) / fSlow5));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow2 = std::sin(fSlow1);
+		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
+		double fSlow4 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
+		double fSlow5 = (0.5 * (fSlow2 / (fSlow3 * fSlow4)));
+		double fSlow6 = (fSlow5 + 1.0);
+		double fSlow7 = (1.0 - fSlow0);
+		double fSlow8 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow6) * fSlow7);
+		double fSlow9 = (((1.0 - fSlow5) / fSlow6) * fSlow7);
+		double fSlow10 = (0.5 * ((fSlow2 * fSlow4) / fSlow3));
+		double fSlow11 = (((fSlow10 + 1.0) / fSlow6) * fSlow7);
+		double fSlow12 = (((1.0 - fSlow10) / fSlow6) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = (fSlow6 + (fConst1 * fRec0[1]));
-			double fTemp2 = (fRec0[0] * fRec1[1]);
-			fRec2[0] = (fSlow7 + (fConst1 * fRec2[1]));
-			fRec1[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec1[2])));
-			fRec3[0] = (fSlow9 + (fConst1 * fRec3[1]));
-			fRec4[0] = (fSlow10 + (fConst1 * fRec4[1]));
-			output0[i] = FAUSTFLOAT((fTemp2 + ((fRec1[0] * fRec3[0]) + (fRec4[0] * fRec1[2]))));
-			double fTemp3 = (fRec0[0] * fRec5[1]);
+			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow8);
+			double fTemp2 = (fRec1[0] * fRec0[1]);
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow9);
+			fRec0[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec0[2])));
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow11);
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow12);
+			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp2) + (fRec4[0] * fRec0[2])));
+			double fTemp3 = (fRec1[0] * fRec5[1]);
 			fRec5[0] = (fTemp1 - (fTemp3 + (fRec2[0] * fRec5[2])));
 			output1[i] = FAUSTFLOAT(((fTemp3 + (fRec3[0] * fRec5[0])) + (fRec4[0] * fRec5[2])));
-			fRec0[1] = fRec0[0];
-			fRec2[1] = fRec2[0];
-			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
+			fRec2[1] = fRec2[0];
+			fRec0[2] = fRec0[1];
+			fRec0[1] = fRec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
 			fRec5[2] = fRec5[1];

--- a/src/sfizz/gen/filters/sfz2chPink.cxx
+++ b/src/sfizz/gen/filters/sfz2chPink.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faust2chPink_H__
@@ -20,6 +20,7 @@ Compilation options: -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chPink
 #endif
+
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -31,7 +32,7 @@ class faust2chPink : public sfzFilterDsp {
 	
 	double fRec0[4];
 	double fRec1[4];
-	int fSamplingFreq;
+	int fSampleRate;
 	
  public:
 	
@@ -40,15 +41,13 @@ class faust2chPink : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 2;
-		
 	}
 	virtual int getNumOutputs() {
 		return 2;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -61,14 +60,12 @@ class faust2chPink : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -81,44 +78,35 @@ class faust2chPink : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	
-	static void classInit(int samplingFreq) {
-		
+	static void classInit(int sample_rate) {
 	}
 	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
 	}
 	
 	virtual void instanceResetUserInterface() {
-		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 4); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 4); l1 = (l1 + 1)) {
 			fRec1[l1] = 0.0;
-			
 		}
-		
 	}
 	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -128,12 +116,10 @@ class faust2chPink : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -144,21 +130,17 @@ class faust2chPink : public sfzFilterDsp {
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = ((((2.4949560019999999 * fRec0[1]) + (0.52218940000000003 * fRec0[3])) + fTemp0) - (2.0172658750000001 * fRec0[2]));
+			fRec0[0] = ((fTemp0 + ((2.4949560019999999 * fRec0[1]) + (0.52218940000000003 * fRec0[3]))) - (2.0172658750000001 * fRec0[2]));
 			output0[i] = FAUSTFLOAT((((0.049922034999999997 * fRec0[0]) + (0.050612698999999997 * fRec0[2])) - ((0.095993537000000004 * fRec0[1]) + (0.0044087859999999996 * fRec0[3]))));
-			fRec1[0] = ((((2.4949560019999999 * fRec1[1]) + (0.52218940000000003 * fRec1[3])) + fTemp1) - (2.0172658750000001 * fRec1[2]));
+			fRec1[0] = ((fTemp1 + ((2.4949560019999999 * fRec1[1]) + (0.52218940000000003 * fRec1[3]))) - (2.0172658750000001 * fRec1[2]));
 			output1[i] = FAUSTFLOAT((((0.049922034999999997 * fRec1[0]) + (0.050612698999999997 * fRec1[2])) - ((0.095993537000000004 * fRec1[1]) + (0.0044087859999999996 * fRec1[3]))));
 			for (int j0 = 3; (j0 > 0); j0 = (j0 - 1)) {
 				fRec0[j0] = fRec0[(j0 - 1)];
-				
 			}
 			for (int j1 = 3; (j1 > 0); j1 = (j1 - 1)) {
 				fRec1[j1] = fRec1[(j1 - 1)];
-				
 			}
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzApf1p.cxx
+++ b/src/sfizz/gen/filters/sfzApf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustApf1p_H__
@@ -11,49 +11,48 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustApf1p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustApf1p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
-	double fConst2;
 	FAUSTFLOAT fCutoff;
+	double fConst2;
 	double fRec1[2];
 	double fRec0[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -62,14 +61,12 @@ class faustApf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -78,80 +75,67 @@ class faustApf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (6.2831853071795862 / fConst0);
-		
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
+		fConst1 = (6.2831853071795862 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec0[l1] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustApf1p* clone() {
 		return new faustApf1p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
-		double fSlow1 = (((fConst2 * double(fCutoff)) + -1.0) * (1.0 - fSlow0));
+		double fSlow0 = (fSmoothEnable ? fConst2 : 0.0);
+		double fSlow1 = (((fConst1 * double(fCutoff)) + -1.0) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow1);
+			fRec1[0] = (fSlow1 + (fSlow0 * fRec1[1]));
 			fRec0[0] = (fTemp0 - (fRec1[0] * fRec0[1]));
 			output0[i] = FAUSTFLOAT((fRec0[1] + (fRec1[0] * fRec0[0])));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzApf1p.cxx
+++ b/src/sfizz/gen/filters/sfzApf1p.cxx
@@ -34,7 +34,6 @@ class faustApf1p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec1[2];
 	double fRec0[2];
@@ -93,8 +92,7 @@ class faustApf1p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -142,10 +140,11 @@ class faustApf1p : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst2 * ((fConst3 * double(fCutoff)) + -1.0));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (((fConst2 * double(fCutoff)) + -1.0) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow0 + (fConst1 * fRec1[1]));
+			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow1);
 			fRec0[0] = (fTemp0 - (fRec1[0] * fRec0[1]));
 			output0[i] = FAUSTFLOAT((fRec0[1] + (fRec1[0] * fRec0[0])));
 			fRec1[1] = fRec1[0];

--- a/src/sfizz/gen/filters/sfzBpf1p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBpf1p_H__
@@ -11,50 +11,49 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustBpf1p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustBpf1p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
-	double fConst2;
 	FAUSTFLOAT fCutoff;
+	double fConst2;
 	double fRec2[2];
 	double fRec1[2];
 	double fRec0[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -63,14 +62,12 @@ class faustBpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -79,87 +76,73 @@ class faustBpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 / fConst0);
-		
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
+		fConst1 = (1.0 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec2[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec1[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustBpf1p* clone() {
 		return new faustBpf1p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
-		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
+		double fSlow0 = (fSmoothEnable ? fConst2 : 0.0);
+		double fSlow1 = (std::exp((fConst1 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow1);
-			fRec1[0] = ((fRec2[0] * fRec1[1]) + fTemp0);
+			fRec2[0] = (fSlow1 + (fSlow0 * fRec2[1]));
+			fRec1[0] = (fTemp0 + (fRec2[0] * fRec1[1]));
 			fRec0[0] = ((fRec1[0] * (1.0 - fRec2[0])) + (fRec2[0] * fRec0[1]));
 			double fTemp1 = (fRec2[0] + 1.0);
 			output0[i] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp1)) + (fRec0[1] * (0.0 - (0.5 * fTemp1)))));
 			fRec2[1] = fRec2[0];
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBpf1p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf1p.cxx
@@ -34,7 +34,6 @@ class faustBpf1p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec2[2];
 	double fRec1[2];
@@ -94,8 +93,7 @@ class faustBpf1p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (1.0 / fConst0);
+		fConst2 = (1.0 / fConst0);
 		
 	}
 	
@@ -147,10 +145,11 @@ class faustBpf1p : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst2 * std::exp((fConst3 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec2[0] = (fSlow0 + (fConst1 * fRec2[1]));
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow1);
 			fRec1[0] = ((fRec2[0] * fRec1[1]) + fTemp0);
 			fRec0[0] = ((fRec1[0] * (1.0 - fRec2[0])) + (fRec2[0] * fRec0[1]));
 			double fTemp1 = (fRec2[0] + 1.0);

--- a/src/sfizz/gen/filters/sfzBpf2p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBpf2p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustBpf2p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustBpf2p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -42,23 +43,21 @@ class faustBpf2p : public sfzFilterDsp {
 	double fRec3[2];
 	double fRec4[2];
 	double fRec5[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -67,14 +66,12 @@ class faustBpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -83,86 +80,71 @@ class faustBpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustBpf2p* clone() {
 		return new faustBpf2p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::sin(fSlow1);
 		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
@@ -171,17 +153,17 @@ class faustBpf2p : public sfzFilterDsp {
 		double fSlow6 = (1.0 - fSlow0);
 		double fSlow7 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow6);
 		double fSlow8 = (((1.0 - fSlow4) / fSlow5) * fSlow6);
-		double fSlow9 = (0.5 * (fSlow2 / (fSlow5 * fSlow3)));
+		double fSlow9 = (0.5 * (fSlow2 / (fSlow3 * fSlow5)));
 		double fSlow10 = (fSlow9 * fSlow6);
 		double fSlow11 = ((0.0 - fSlow9) * fSlow6);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow7);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow8);
+			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow7);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
 			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow10);
-			fRec4[0] = (fRec4[1] * fSlow0);
-			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow11);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow10);
+			fRec4[0] = (fSlow0 * fRec4[1]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow11);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
@@ -190,9 +172,7 @@ class faustBpf2p : public sfzFilterDsp {
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
 			fRec5[1] = fRec5[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBpf2p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf2p.cxx
@@ -34,13 +34,11 @@ class faustBpf2p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec1[2];
 	double fRec2[2];
 	double fRec0[3];
-	double fConst4;
 	double fRec3[2];
 	double fRec4[2];
 	double fRec5[2];
@@ -99,9 +97,7 @@ class faustBpf2p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (0.5 * fConst2);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -166,24 +162,26 @@ class faustBpf2p : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = std::sin(fSlow0);
-		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
-		double fSlow3 = (0.5 * (fSlow1 / fSlow2));
-		double fSlow4 = (fSlow3 + 1.0);
-		double fSlow5 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
-		double fSlow6 = (fConst2 * ((1.0 - fSlow3) / fSlow4));
-		double fSlow7 = (fSlow1 / (fSlow4 * fSlow2));
-		double fSlow8 = (fConst4 * fSlow7);
-		double fSlow9 = (fConst2 * (0.0 - (0.5 * fSlow7)));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow2 = std::sin(fSlow1);
+		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
+		double fSlow4 = (0.5 * (fSlow2 / fSlow3));
+		double fSlow5 = (fSlow4 + 1.0);
+		double fSlow6 = (1.0 - fSlow0);
+		double fSlow7 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow6);
+		double fSlow8 = (((1.0 - fSlow4) / fSlow5) * fSlow6);
+		double fSlow9 = (0.5 * (fSlow2 / (fSlow5 * fSlow3)));
+		double fSlow10 = (fSlow9 * fSlow6);
+		double fSlow11 = ((0.0 - fSlow9) * fSlow6);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow5 + (fConst1 * fRec1[1]));
-			fRec2[0] = (fSlow6 + (fConst1 * fRec2[1]));
+			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow7);
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow8);
 			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow8 + (fConst1 * fRec3[1]));
-			fRec4[0] = (fConst1 * fRec4[1]);
-			fRec5[0] = (fSlow9 + (fConst1 * fRec5[1]));
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow10);
+			fRec4[0] = (fRec4[1] * fSlow0);
+			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow11);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];

--- a/src/sfizz/gen/filters/sfzBpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzBpf2pSv.cxx
@@ -34,7 +34,6 @@ class faustBpf2pSv : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec3[2];
 	FAUSTFLOAT fQ;
@@ -98,8 +97,7 @@ class faustBpf2pSv : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (3.1415926535897931 / fConst0);
+		fConst2 = (3.1415926535897931 / fConst0);
 		
 	}
 	
@@ -164,16 +162,17 @@ class faustBpf2pSv : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
-		double fSlow1 = std::pow(10.0, (0.050000000000000003 * double(fQ)));
-		double fSlow2 = (1.0 / fSlow1);
-		double fSlow3 = (fConst2 / fSlow1);
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (1.0 - fSlow0);
+		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
+		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
+		double fSlow4 = (fSlow3 * fSlow1);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec3[0] = (fSlow0 + (fConst1 * fRec3[1]));
-			double fTemp1 = (fSlow2 + fRec3[0]);
-			fRec4[0] = ((fConst1 * fRec4[1]) + (fConst2 / ((fRec3[0] * fTemp1) + 1.0)));
-			fRec5[0] = ((fConst1 * fRec5[1]) + (fConst2 * fTemp1));
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow2);
+			double fTemp1 = (fSlow3 + fRec3[0]);
+			fRec4[0] = ((fRec4[1] * fSlow0) + (fSlow1 / ((fRec3[0] * fTemp1) + 1.0)));
+			fRec5[0] = ((fRec5[1] * fSlow0) + (fSlow1 * fTemp1));
 			double fTemp2 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fTemp3 = ((fRec3[0] * fRec4[0]) * fTemp2);
 			double fTemp4 = (fRec2[1] + fTemp3);
@@ -181,7 +180,7 @@ class faustBpf2pSv : public sfzFilterDsp {
 			fRec1[0] = (fRec1[1] + (2.0 * (fRec3[0] * fTemp4)));
 			double fTemp5 = (fRec2[1] + (2.0 * fTemp3));
 			fRec2[0] = fTemp5;
-			fRec6[0] = (fSlow3 + (fConst1 * fRec6[1]));
+			fRec6[0] = ((fRec6[1] * fSlow0) + fSlow4);
 			output0[i] = FAUSTFLOAT((fRec0 * fRec6[0]));
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];

--- a/src/sfizz/gen/filters/sfzBpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzBpf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBpf2pSv_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustBpf2pSv
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustBpf2pSv : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -42,23 +43,21 @@ class faustBpf2pSv : public sfzFilterDsp {
 	double fRec1[2];
 	double fRec2[2];
 	double fRec6[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -67,14 +66,12 @@ class faustBpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -83,96 +80,81 @@ class faustBpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec3[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec2[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec6[l5] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustBpf2pSv* clone() {
 		return new faustBpf2pSv();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow4 = (fSlow3 * fSlow1);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow2);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow2);
 			double fTemp1 = (fSlow3 + fRec3[0]);
-			fRec4[0] = ((fRec4[1] * fSlow0) + (fSlow1 / ((fRec3[0] * fTemp1) + 1.0)));
-			fRec5[0] = ((fRec5[1] * fSlow0) + (fSlow1 * fTemp1));
+			fRec4[0] = ((fSlow0 * fRec4[1]) + (fSlow1 / ((fRec3[0] * fTemp1) + 1.0)));
+			fRec5[0] = ((fSlow0 * fRec5[1]) + (fSlow1 * fTemp1));
 			double fTemp2 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fTemp3 = ((fRec3[0] * fRec4[0]) * fTemp2);
 			double fTemp4 = (fRec2[1] + fTemp3);
@@ -180,7 +162,7 @@ class faustBpf2pSv : public sfzFilterDsp {
 			fRec1[0] = (fRec1[1] + (2.0 * (fRec3[0] * fTemp4)));
 			double fTemp5 = (fRec2[1] + (2.0 * fTemp3));
 			fRec2[0] = fTemp5;
-			fRec6[0] = ((fRec6[1] * fSlow0) + fSlow4);
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow4);
 			output0[i] = FAUSTFLOAT((fRec0 * fRec6[0]));
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
@@ -188,9 +170,7 @@ class faustBpf2pSv : public sfzFilterDsp {
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
 			fRec6[1] = fRec6[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBpf4p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf4p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBpf4p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustBpf4p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustBpf4p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -43,23 +44,21 @@ class faustBpf4p : public sfzFilterDsp {
 	double fRec5[2];
 	double fRec6[2];
 	double fRec1[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -68,14 +67,12 @@ class faustBpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -84,96 +81,80 @@ class faustBpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec4[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec5[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec6[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec1[l6] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustBpf4p* clone() {
 		return new faustBpf4p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::sin(fSlow1);
 		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow4 = (0.5 * (fSlow2 / fSlow3));
 		double fSlow5 = (fSlow4 + 1.0);
-		double fSlow6 = (0.5 * (fSlow2 / (fSlow5 * fSlow3)));
+		double fSlow6 = (0.5 * (fSlow2 / (fSlow3 * fSlow5)));
 		double fSlow7 = (1.0 - fSlow0);
 		double fSlow8 = (fSlow6 * fSlow7);
 		double fSlow9 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
@@ -181,12 +162,12 @@ class faustBpf4p : public sfzFilterDsp {
 		double fSlow11 = ((0.0 - fSlow6) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow8);
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow9);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow10);
+			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow8);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow9);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow10);
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = (fRec5[1] * fSlow0);
-			fRec6[0] = ((fRec6[1] * fSlow0) + fSlow11);
+			fRec5[0] = (fSlow0 * fRec5[1]);
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow11);
 			fRec1[0] = ((((fRec2[0] * fRec0[0]) + (fRec5[0] * fRec2[1])) + (fRec6[0] * fRec2[2])) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec5[0] * fRec1[1])) + (fRec6[0] * fRec1[2])));
 			fRec0[1] = fRec0[0];
@@ -198,9 +179,7 @@ class faustBpf4p : public sfzFilterDsp {
 			fRec6[1] = fRec6[0];
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBpf6p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf6p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBpf6p_H__
@@ -11,56 +11,55 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustBpf6p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustBpf6p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
-	double fRec4[2];
+	double fRec3[2];
 	double fRec5[2];
-	double fRec3[3];
 	double fRec6[2];
+	double fRec4[3];
 	double fRec7[2];
 	double fRec2[3];
 	double fRec1[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -69,14 +68,12 @@ class faustBpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -85,100 +82,83 @@ class faustBpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec4[l1] = 0.0;
-			
+			fRec3[l1] = 0.0;
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
-			
 		}
-		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
-			
+		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
+			fRec6[l3] = 0.0;
 		}
-		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec6[l4] = 0.0;
-			
+		for (int l4 = 0; (l4 < 3); l4 = (l4 + 1)) {
+			fRec4[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec7[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec2[l6] = 0.0;
-			
 		}
 		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
 			fRec1[l7] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustBpf6p* clone() {
 		return new faustBpf6p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::sin(fSlow1);
 		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow4 = (0.5 * (fSlow2 / fSlow3));
 		double fSlow5 = (fSlow4 + 1.0);
-		double fSlow6 = (0.5 * (fSlow2 / (fSlow5 * fSlow3)));
+		double fSlow6 = (0.5 * (fSlow2 / (fSlow3 * fSlow5)));
 		double fSlow7 = (1.0 - fSlow0);
 		double fSlow8 = (fSlow6 * fSlow7);
 		double fSlow9 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
@@ -186,29 +166,27 @@ class faustBpf6p : public sfzFilterDsp {
 		double fSlow11 = ((0.0 - fSlow6) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow8);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow9);
-			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow10);
-			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (fRec6[1] * fSlow0);
-			fRec7[0] = ((fRec7[1] * fSlow0) + fSlow11);
-			fRec2[0] = ((((fRec3[0] * fRec0[0]) + (fRec6[0] * fRec3[1])) + (fRec7[0] * fRec3[2])) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
-			fRec1[0] = ((((fRec0[0] * fRec2[0]) + (fRec6[0] * fRec2[1])) + (fRec7[0] * fRec2[2])) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec6[0] * fRec1[1])) + (fRec7[0] * fRec1[2])));
+			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow8);
+			fRec3[0] = (fSlow0 * fRec3[1]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow9);
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow10);
+			fRec4[0] = (fTemp0 - ((fRec5[0] * fRec4[1]) + (fRec6[0] * fRec4[2])));
+			fRec7[0] = ((fSlow0 * fRec7[1]) + fSlow11);
+			fRec2[0] = (((fRec3[0] * fRec4[1]) + ((fRec4[0] * fRec0[0]) + (fRec7[0] * fRec4[2]))) - ((fRec5[0] * fRec2[1]) + (fRec6[0] * fRec2[2])));
+			fRec1[0] = ((((fRec0[0] * fRec2[0]) + (fRec3[0] * fRec2[1])) + (fRec7[0] * fRec2[2])) - ((fRec5[0] * fRec1[1]) + (fRec6[0] * fRec1[2])));
+			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec3[0] * fRec1[1])) + (fRec7[0] * fRec1[2])));
 			fRec0[1] = fRec0[0];
-			fRec4[1] = fRec4[0];
-			fRec5[1] = fRec5[0];
-			fRec3[2] = fRec3[1];
 			fRec3[1] = fRec3[0];
+			fRec5[1] = fRec5[0];
 			fRec6[1] = fRec6[0];
+			fRec4[2] = fRec4[1];
+			fRec4[1] = fRec4[0];
 			fRec7[1] = fRec7[0];
 			fRec2[2] = fRec2[1];
 			fRec2[1] = fRec2[0];
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBpf6p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf6p.cxx
@@ -34,8 +34,6 @@ class faustBpf6p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
-	double fConst4;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
@@ -101,9 +99,7 @@ class faustBpf6p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (0.5 * fConst2);
-		fConst4 = (6.2831853071795862 / fConst0);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -176,24 +172,26 @@ class faustBpf6p : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst4 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = std::sin(fSlow0);
-		double fSlow2 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
-		double fSlow3 = (0.5 * (fSlow1 / fSlow2));
-		double fSlow4 = (fSlow3 + 1.0);
-		double fSlow5 = (fSlow1 / (fSlow4 * fSlow2));
-		double fSlow6 = (fConst3 * fSlow5);
-		double fSlow7 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow4));
-		double fSlow8 = (fConst2 * ((1.0 - fSlow3) / fSlow4));
-		double fSlow9 = (fConst2 * (0.0 - (0.5 * fSlow5)));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow2 = std::sin(fSlow1);
+		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
+		double fSlow4 = (0.5 * (fSlow2 / fSlow3));
+		double fSlow5 = (fSlow4 + 1.0);
+		double fSlow6 = (0.5 * (fSlow2 / (fSlow5 * fSlow3)));
+		double fSlow7 = (1.0 - fSlow0);
+		double fSlow8 = (fSlow6 * fSlow7);
+		double fSlow9 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
+		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
+		double fSlow11 = ((0.0 - fSlow6) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow6 + (fConst1 * fRec0[1]));
-			fRec4[0] = (fSlow7 + (fConst1 * fRec4[1]));
-			fRec5[0] = (fSlow8 + (fConst1 * fRec5[1]));
+			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow8);
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow9);
+			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow10);
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (fConst1 * fRec6[1]);
-			fRec7[0] = (fSlow9 + (fConst1 * fRec7[1]));
+			fRec6[0] = (fRec6[1] * fSlow0);
+			fRec7[0] = ((fRec7[1] * fSlow0) + fSlow11);
 			fRec2[0] = ((((fRec3[0] * fRec0[0]) + (fRec6[0] * fRec3[1])) + (fRec7[0] * fRec3[2])) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = ((((fRec0[0] * fRec2[0]) + (fRec6[0] * fRec2[1])) + (fRec7[0] * fRec2[2])) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec6[0] * fRec1[1])) + (fRec7[0] * fRec1[2])));

--- a/src/sfizz/gen/filters/sfzBrf1p.cxx
+++ b/src/sfizz/gen/filters/sfzBrf1p.cxx
@@ -34,7 +34,6 @@ class faustBrf1p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec2[2];
 	double fRec1[2];
@@ -94,8 +93,7 @@ class faustBrf1p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -147,10 +145,11 @@ class faustBrf1p : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst2 * ((fConst3 * double(fCutoff)) + -1.0));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (((fConst2 * double(fCutoff)) + -1.0) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec2[0] = (fSlow0 + (fConst1 * fRec2[1]));
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow1);
 			fRec1[0] = (fTemp0 - (fRec2[0] * fRec1[1]));
 			fRec0[0] = (fRec1[1] + (fRec2[0] * (fRec1[0] - fRec0[1])));
 			output0[i] = FAUSTFLOAT(((fRec0[1] + (fRec2[0] * fRec0[0])) + fTemp0));

--- a/src/sfizz/gen/filters/sfzBrf1p.cxx
+++ b/src/sfizz/gen/filters/sfzBrf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBrf1p_H__
@@ -11,50 +11,49 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustBrf1p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustBrf1p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
-	double fConst2;
 	FAUSTFLOAT fCutoff;
+	double fConst2;
 	double fRec2[2];
 	double fRec1[2];
 	double fRec0[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -63,14 +62,12 @@ class faustBrf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -79,86 +76,72 @@ class faustBrf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (6.2831853071795862 / fConst0);
-		
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
+		fConst1 = (6.2831853071795862 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec2[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec1[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustBrf1p* clone() {
 		return new faustBrf1p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
-		double fSlow1 = (((fConst2 * double(fCutoff)) + -1.0) * (1.0 - fSlow0));
+		double fSlow0 = (fSmoothEnable ? fConst2 : 0.0);
+		double fSlow1 = (((fConst1 * double(fCutoff)) + -1.0) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow1);
+			fRec2[0] = (fSlow1 + (fSlow0 * fRec2[1]));
 			fRec1[0] = (fTemp0 - (fRec2[0] * fRec1[1]));
 			fRec0[0] = (fRec1[1] + (fRec2[0] * (fRec1[0] - fRec0[1])));
-			output0[i] = FAUSTFLOAT(((fRec0[1] + (fRec2[0] * fRec0[0])) + fTemp0));
+			output0[i] = FAUSTFLOAT((fTemp0 + (fRec0[1] + (fRec2[0] * fRec0[0]))));
 			fRec2[1] = fRec2[0];
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBrf2p.cxx
+++ b/src/sfizz/gen/filters/sfzBrf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBrf2p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustBrf2p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustBrf2p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -40,23 +41,21 @@ class faustBrf2p : public sfzFilterDsp {
 	double fRec2[2];
 	double fRec1[3];
 	double fRec3[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -65,14 +64,12 @@ class faustBrf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -81,78 +78,65 @@ class faustBrf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec1[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustBrf2p* clone() {
 		return new faustBrf2p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
@@ -162,20 +146,18 @@ class faustBrf2p : public sfzFilterDsp {
 		double fSlow7 = ((1.0 / fSlow3) * fSlow4);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow5);
+			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow5);
 			double fTemp1 = (fRec0[0] * fRec1[1]);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow6);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
 			fRec1[0] = (fTemp0 - (fTemp1 + (fRec2[0] * fRec1[2])));
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow7);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow7);
 			output0[i] = FAUSTFLOAT((fTemp1 + (fRec3[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
 			fRec3[1] = fRec3[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzBrf2p.cxx
+++ b/src/sfizz/gen/filters/sfzBrf2p.cxx
@@ -34,7 +34,6 @@ class faustBrf2p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
@@ -96,8 +95,7 @@ class faustBrf2p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -154,19 +152,21 @@ class faustBrf2p : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
-		double fSlow2 = (fSlow1 + 1.0);
-		double fSlow3 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow0))) / fSlow2));
-		double fSlow4 = (fConst2 * ((1.0 - fSlow1) / fSlow2));
-		double fSlow5 = (fConst2 / fSlow2);
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow2 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
+		double fSlow3 = (fSlow2 + 1.0);
+		double fSlow4 = (1.0 - fSlow0);
+		double fSlow5 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow3) * fSlow4);
+		double fSlow6 = (((1.0 - fSlow2) / fSlow3) * fSlow4);
+		double fSlow7 = ((1.0 / fSlow3) * fSlow4);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow3 + (fConst1 * fRec0[1]));
+			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow5);
 			double fTemp1 = (fRec0[0] * fRec1[1]);
-			fRec2[0] = (fSlow4 + (fConst1 * fRec2[1]));
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow6);
 			fRec1[0] = (fTemp0 - (fTemp1 + (fRec2[0] * fRec1[2])));
-			fRec3[0] = (fSlow5 + (fConst1 * fRec3[1]));
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow7);
 			output0[i] = FAUSTFLOAT((fTemp1 + (fRec3[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];

--- a/src/sfizz/gen/filters/sfzBrf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzBrf2pSv.cxx
@@ -34,7 +34,6 @@ class faustBrf2pSv : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec5[2];
 	FAUSTFLOAT fQ;
@@ -97,8 +96,7 @@ class faustBrf2pSv : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (3.1415926535897931 / fConst0);
+		fConst2 = (3.1415926535897931 / fConst0);
 		
 	}
 	
@@ -159,14 +157,16 @@ class faustBrf2pSv : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
-		double fSlow1 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (1.0 - fSlow0);
+		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
+		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec5[0] = (fSlow0 + (fConst1 * fRec5[1]));
-			double fTemp1 = (fSlow1 + fRec5[0]);
-			fRec4[0] = ((fConst1 * fRec4[1]) + (fConst2 / ((fRec5[0] * fTemp1) + 1.0)));
-			fRec6[0] = ((fConst1 * fRec6[1]) + (fConst2 * fTemp1));
+			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow2);
+			double fTemp1 = (fSlow3 + fRec5[0]);
+			fRec4[0] = ((fRec4[1] * fSlow0) + (fSlow1 / ((fRec5[0] * fTemp1) + 1.0)));
+			fRec6[0] = ((fRec6[1] * fSlow0) + (fSlow1 * fTemp1));
 			double fTemp2 = (fTemp0 - (fRec2[1] + (fRec6[0] * fRec3[1])));
 			double fRec0 = (fRec4[0] * fTemp2);
 			double fTemp3 = ((fRec5[0] * fRec4[0]) * fTemp2);

--- a/src/sfizz/gen/filters/sfzBrf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzBrf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustBrf2pSv_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustBrf2pSv
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustBrf2pSv : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -41,23 +42,21 @@ class faustBrf2pSv : public sfzFilterDsp {
 	double fRec6[2];
 	double fRec2[2];
 	double fRec3[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -66,14 +65,12 @@ class faustBrf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -82,91 +79,77 @@ class faustBrf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec5[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec6[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec3[l4] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustBrf2pSv* clone() {
 		return new faustBrf2pSv();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow2);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow2);
 			double fTemp1 = (fSlow3 + fRec5[0]);
-			fRec4[0] = ((fRec4[1] * fSlow0) + (fSlow1 / ((fRec5[0] * fTemp1) + 1.0)));
-			fRec6[0] = ((fRec6[1] * fSlow0) + (fSlow1 * fTemp1));
+			fRec4[0] = ((fSlow0 * fRec4[1]) + (fSlow1 / ((fRec5[0] * fTemp1) + 1.0)));
+			fRec6[0] = ((fSlow0 * fRec6[1]) + (fSlow1 * fTemp1));
 			double fTemp2 = (fTemp0 - (fRec2[1] + (fRec6[0] * fRec3[1])));
 			double fRec0 = (fRec4[0] * fTemp2);
 			double fTemp3 = ((fRec5[0] * fRec4[0]) * fTemp2);
@@ -181,9 +164,7 @@ class faustBrf2pSv : public sfzFilterDsp {
 			fRec6[1] = fRec6[0];
 			fRec2[1] = fRec2[0];
 			fRec3[1] = fRec3[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzEq.cxx
+++ b/src/sfizz/gen/filters/sfzEq.cxx
@@ -35,9 +35,8 @@ class faustEq : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
-	double fConst4;
+	double fConst3;
 	FAUSTFLOAT fBandwidth;
 	FAUSTFLOAT fPkShGain;
 	double fRec1[2];
@@ -100,9 +99,8 @@ class faustEq : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (2.1775860903036022 / fConst0);
+		fConst2 = (6.2831853071795862 / fConst0);
+		fConst3 = (2.1775860903036022 / fConst0);
 		
 	}
 	
@@ -164,26 +162,28 @@ class faustEq : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = std::max<double>(0.0, double(fCutoff));
-		double fSlow1 = (fConst3 * fSlow0);
-		double fSlow2 = std::sin(fSlow1);
-		double fSlow3 = std::max<double>(0.001, (0.5 / double(sinh(double((fConst4 * ((fSlow0 * double(fBandwidth)) / fSlow2)))))));
-		double fSlow4 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
-		double fSlow5 = (0.5 * (fSlow2 / (fSlow3 * fSlow4)));
-		double fSlow6 = (fSlow5 + 1.0);
-		double fSlow7 = (fConst2 * ((0.0 - (2.0 * std::cos(fSlow1))) / fSlow6));
-		double fSlow8 = (fConst2 * ((1.0 - fSlow5) / fSlow6));
-		double fSlow9 = (0.5 * ((fSlow2 * fSlow4) / fSlow3));
-		double fSlow10 = (fConst2 * ((fSlow9 + 1.0) / fSlow6));
-		double fSlow11 = (fConst2 * ((1.0 - fSlow9) / fSlow6));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = std::max<double>(0.0, double(fCutoff));
+		double fSlow2 = (fConst2 * fSlow1);
+		double fSlow3 = std::sin(fSlow2);
+		double fSlow4 = std::max<double>(0.001, (0.5 / double(sinh(double((fConst3 * ((fSlow1 * double(fBandwidth)) / fSlow3)))))));
+		double fSlow5 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
+		double fSlow6 = (0.5 * (fSlow3 / (fSlow4 * fSlow5)));
+		double fSlow7 = (fSlow6 + 1.0);
+		double fSlow8 = (1.0 - fSlow0);
+		double fSlow9 = (((0.0 - (2.0 * std::cos(fSlow2))) / fSlow7) * fSlow8);
+		double fSlow10 = (((1.0 - fSlow6) / fSlow7) * fSlow8);
+		double fSlow11 = (0.5 * ((fSlow3 * fSlow5) / fSlow4));
+		double fSlow12 = (((fSlow11 + 1.0) / fSlow7) * fSlow8);
+		double fSlow13 = (((1.0 - fSlow11) / fSlow7) * fSlow8);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow7 + (fConst1 * fRec1[1]));
+			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow9);
 			double fTemp1 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = (fSlow8 + (fConst1 * fRec2[1]));
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow10);
 			fRec0[0] = (fTemp0 - (fTemp1 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow10 + (fConst1 * fRec3[1]));
-			fRec4[0] = (fSlow11 + (fConst1 * fRec4[1]));
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow12);
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow13);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp1) + (fRec4[0] * fRec0[2])));
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];

--- a/src/sfizz/gen/filters/sfzEq.cxx
+++ b/src/sfizz/gen/filters/sfzEq.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustEq_H__
@@ -11,7 +11,7 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 /* link with : "" */
 #include <algorithm>
@@ -19,19 +19,20 @@ Compilation options: -inpl -double -ftz 0
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustEq
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustEq : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -44,23 +45,21 @@ class faustEq : public sfzFilterDsp {
 	double fRec0[3];
 	double fRec3[2];
 	double fRec4[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -69,14 +68,12 @@ class faustEq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -85,84 +82,70 @@ class faustEq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		fConst3 = (2.1775860903036022 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fBandwidth = FAUSTFLOAT(1.0);
 		fPkShGain = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustEq* clone() {
 		return new faustEq();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = std::max<double>(0.0, double(fCutoff));
 		double fSlow2 = (fConst2 * fSlow1);
 		double fSlow3 = std::sin(fSlow2);
@@ -178,12 +161,12 @@ class faustEq : public sfzFilterDsp {
 		double fSlow13 = (((1.0 - fSlow11) / fSlow7) * fSlow8);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow9);
+			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow9);
 			double fTemp1 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow10);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow10);
 			fRec0[0] = (fTemp0 - (fTemp1 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow12);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow13);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp1) + (fRec4[0] * fRec0[2])));
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
@@ -191,9 +174,7 @@ class faustEq : public sfzFilterDsp {
 			fRec0[1] = fRec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzHpf1p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustHpf1p_H__
@@ -11,49 +11,48 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustHpf1p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustHpf1p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
-	double fConst2;
 	FAUSTFLOAT fCutoff;
+	double fConst2;
 	double fRec1[2];
 	double fRec0[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -62,14 +61,12 @@ class faustHpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -78,81 +75,68 @@ class faustHpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 / fConst0);
-		
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
+		fConst1 = (1.0 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec0[l1] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustHpf1p* clone() {
 		return new faustHpf1p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
-		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
+		double fSlow0 = (fSmoothEnable ? fConst2 : 0.0);
+		double fSlow1 = (std::exp((fConst1 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow1);
-			fRec0[0] = ((fRec1[0] * fRec0[1]) + fTemp0);
+			fRec1[0] = (fSlow1 + (fSlow0 * fRec1[1]));
+			fRec0[0] = (fTemp0 + (fRec1[0] * fRec0[1]));
 			double fTemp1 = (fRec1[0] + 1.0);
 			output0[i] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp1)) + (fRec0[1] * (0.0 - (0.5 * fTemp1)))));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzHpf1p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf1p.cxx
@@ -34,7 +34,6 @@ class faustHpf1p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec1[2];
 	double fRec0[2];
@@ -93,8 +92,7 @@ class faustHpf1p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (1.0 / fConst0);
+		fConst2 = (1.0 / fConst0);
 		
 	}
 	
@@ -142,10 +140,11 @@ class faustHpf1p : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst2 * std::exp((fConst3 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow0 + (fConst1 * fRec1[1]));
+			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow1);
 			fRec0[0] = ((fRec1[0] * fRec0[1]) + fTemp0);
 			double fTemp1 = (fRec1[0] + 1.0);
 			output0[i] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp1)) + (fRec0[1] * (0.0 - (0.5 * fTemp1)))));

--- a/src/sfizz/gen/filters/sfzHpf2p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustHpf2p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustHpf2p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustHpf2p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -41,23 +42,21 @@ class faustHpf2p : public sfzFilterDsp {
 	double fRec3[2];
 	double fRec1[3];
 	double fRec4[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -66,14 +65,12 @@ class faustHpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -82,82 +79,68 @@ class faustHpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec3[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustHpf2p* clone() {
 		return new faustHpf2p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::cos(fSlow1);
 		double fSlow3 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
@@ -169,11 +152,11 @@ class faustHpf2p : public sfzFilterDsp {
 		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow6);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow7);
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow8);
+			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow6);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow7);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow8);
 			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow9);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow9);
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec4[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];
@@ -181,9 +164,7 @@ class faustHpf2p : public sfzFilterDsp {
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
 			fRec4[1] = fRec4[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzHpf2p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf2p.cxx
@@ -34,14 +34,12 @@ class faustHpf2p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec2[2];
 	double fRec3[2];
 	double fRec1[3];
-	double fConst4;
 	double fRec4[2];
 	
  public:
@@ -98,9 +96,7 @@ class faustHpf2p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (0.5 * fConst2);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -161,21 +157,23 @@ class faustHpf2p : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = std::cos(fSlow0);
-		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
-		double fSlow3 = (fSlow2 + 1.0);
-		double fSlow4 = (fConst2 * ((-1.0 - fSlow1) / fSlow3));
-		double fSlow5 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow6 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow7 = (fConst4 * ((fSlow1 + 1.0) / fSlow3));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow2 = std::cos(fSlow1);
+		double fSlow3 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
+		double fSlow4 = (fSlow3 + 1.0);
+		double fSlow5 = (1.0 - fSlow0);
+		double fSlow6 = (((-1.0 - fSlow2) / fSlow4) * fSlow5);
+		double fSlow7 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
+		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
+		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow4 + (fConst1 * fRec0[1]));
-			fRec2[0] = (fSlow5 + (fConst1 * fRec2[1]));
-			fRec3[0] = (fSlow6 + (fConst1 * fRec3[1]));
+			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow6);
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow7);
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow8);
 			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
-			fRec4[0] = (fSlow7 + (fConst1 * fRec4[1]));
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow9);
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec4[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];

--- a/src/sfizz/gen/filters/sfzHpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzHpf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustHpf2pSv_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustHpf2pSv
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustHpf2pSv : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -41,23 +42,21 @@ class faustHpf2pSv : public sfzFilterDsp {
 	double fRec5[2];
 	double fRec1[2];
 	double fRec2[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -66,14 +65,12 @@ class faustHpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -82,91 +79,77 @@ class faustHpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec4[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec2[l4] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustHpf2pSv* clone() {
 		return new faustHpf2pSv();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow2);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow2);
 			double fTemp1 = (fSlow3 + fRec4[0]);
-			fRec3[0] = ((fRec3[1] * fSlow0) + (fSlow1 / ((fRec4[0] * fTemp1) + 1.0)));
-			fRec5[0] = ((fRec5[1] * fSlow0) + (fSlow1 * fTemp1));
+			fRec3[0] = ((fSlow0 * fRec3[1]) + (fSlow1 / ((fRec4[0] * fTemp1) + 1.0)));
+			fRec5[0] = ((fSlow0 * fRec5[1]) + (fSlow1 * fTemp1));
 			double fTemp2 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fRec0 = (fRec3[0] * fTemp2);
 			double fTemp3 = ((fRec4[0] * fRec3[0]) * fTemp2);
@@ -180,9 +163,7 @@ class faustHpf2pSv : public sfzFilterDsp {
 			fRec5[1] = fRec5[0];
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzHpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzHpf2pSv.cxx
@@ -34,7 +34,6 @@ class faustHpf2pSv : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec4[2];
 	FAUSTFLOAT fQ;
@@ -97,8 +96,7 @@ class faustHpf2pSv : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (3.1415926535897931 / fConst0);
+		fConst2 = (3.1415926535897931 / fConst0);
 		
 	}
 	
@@ -159,14 +157,16 @@ class faustHpf2pSv : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
-		double fSlow1 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (1.0 - fSlow0);
+		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
+		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec4[0] = (fSlow0 + (fConst1 * fRec4[1]));
-			double fTemp1 = (fSlow1 + fRec4[0]);
-			fRec3[0] = ((fConst1 * fRec3[1]) + (fConst2 / ((fRec4[0] * fTemp1) + 1.0)));
-			fRec5[0] = ((fConst1 * fRec5[1]) + (fConst2 * fTemp1));
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow2);
+			double fTemp1 = (fSlow3 + fRec4[0]);
+			fRec3[0] = ((fRec3[1] * fSlow0) + (fSlow1 / ((fRec4[0] * fTemp1) + 1.0)));
+			fRec5[0] = ((fRec5[1] * fSlow0) + (fSlow1 * fTemp1));
 			double fTemp2 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fRec0 = (fRec3[0] * fTemp2);
 			double fTemp3 = ((fRec4[0] * fRec3[0]) * fTemp2);

--- a/src/sfizz/gen/filters/sfzHpf4p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf4p.cxx
@@ -34,14 +34,12 @@ class faustHpf4p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec3[2];
 	double fRec4[2];
 	double fRec2[3];
-	double fConst4;
 	double fRec5[2];
 	double fRec1[3];
 	
@@ -99,9 +97,7 @@ class faustHpf4p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (0.5 * fConst2);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -166,21 +162,23 @@ class faustHpf4p : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = std::cos(fSlow0);
-		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
-		double fSlow3 = (fSlow2 + 1.0);
-		double fSlow4 = (fConst2 * ((-1.0 - fSlow1) / fSlow3));
-		double fSlow5 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow6 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow7 = (fConst4 * ((fSlow1 + 1.0) / fSlow3));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow2 = std::cos(fSlow1);
+		double fSlow3 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
+		double fSlow4 = (fSlow3 + 1.0);
+		double fSlow5 = (1.0 - fSlow0);
+		double fSlow6 = (((-1.0 - fSlow2) / fSlow4) * fSlow5);
+		double fSlow7 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
+		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
+		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow4 + (fConst1 * fRec0[1]));
-			fRec3[0] = (fSlow5 + (fConst1 * fRec3[1]));
-			fRec4[0] = (fSlow6 + (fConst1 * fRec4[1]));
+			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow6);
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow7);
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow8);
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = (fSlow7 + (fConst1 * fRec5[1]));
+			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow9);
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec5[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];

--- a/src/sfizz/gen/filters/sfzHpf4p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf4p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustHpf4p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustHpf4p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustHpf4p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -42,23 +43,21 @@ class faustHpf4p : public sfzFilterDsp {
 	double fRec2[3];
 	double fRec5[2];
 	double fRec1[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -67,14 +66,12 @@ class faustHpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -83,86 +80,71 @@ class faustHpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec4[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec5[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec1[l5] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustHpf4p* clone() {
 		return new faustHpf4p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::cos(fSlow1);
 		double fSlow3 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
@@ -174,11 +156,11 @@ class faustHpf4p : public sfzFilterDsp {
 		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow6);
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow7);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow8);
+			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow6);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow7);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow8);
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow9);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow9);
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec5[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];
@@ -189,9 +171,7 @@ class faustHpf4p : public sfzFilterDsp {
 			fRec5[1] = fRec5[0];
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzHpf6p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf6p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustHpf6p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustHpf6p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustHpf6p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -43,23 +44,21 @@ class faustHpf6p : public sfzFilterDsp {
 	double fRec6[2];
 	double fRec2[3];
 	double fRec1[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -68,14 +67,12 @@ class faustHpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -84,90 +81,74 @@ class faustHpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec6[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec2[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec1[l6] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustHpf6p* clone() {
 		return new faustHpf6p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::cos(fSlow1);
 		double fSlow3 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
@@ -179,11 +160,11 @@ class faustHpf6p : public sfzFilterDsp {
 		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow6);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow7);
-			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow8);
+			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow6);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow7);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow8);
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = ((fRec6[1] * fSlow0) + fSlow9);
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow9);
 			fRec2[0] = (((fRec0[0] * fRec3[1]) + (fRec6[0] * (fRec3[0] + fRec3[2]))) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec6[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec6[0] * (fRec1[0] + fRec1[2]))));
@@ -197,9 +178,7 @@ class faustHpf6p : public sfzFilterDsp {
 			fRec2[1] = fRec2[0];
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzHpf6p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf6p.cxx
@@ -34,14 +34,12 @@ class faustHpf6p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec0[2];
 	double fRec4[2];
 	double fRec5[2];
 	double fRec3[3];
-	double fConst4;
 	double fRec6[2];
 	double fRec2[3];
 	double fRec1[3];
@@ -100,9 +98,7 @@ class faustHpf6p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (0.5 * fConst2);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -171,21 +167,23 @@ class faustHpf6p : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow1 = std::cos(fSlow0);
-		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
-		double fSlow3 = (fSlow2 + 1.0);
-		double fSlow4 = (fConst2 * ((-1.0 - fSlow1) / fSlow3));
-		double fSlow5 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow6 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow7 = (fConst4 * ((fSlow1 + 1.0) / fSlow3));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow2 = std::cos(fSlow1);
+		double fSlow3 = (0.5 * (std::sin(fSlow1) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
+		double fSlow4 = (fSlow3 + 1.0);
+		double fSlow5 = (1.0 - fSlow0);
+		double fSlow6 = (((-1.0 - fSlow2) / fSlow4) * fSlow5);
+		double fSlow7 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
+		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
+		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow4 + (fConst1 * fRec0[1]));
-			fRec4[0] = (fSlow5 + (fConst1 * fRec4[1]));
-			fRec5[0] = (fSlow6 + (fConst1 * fRec5[1]));
+			fRec0[0] = ((fRec0[1] * fSlow0) + fSlow6);
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow7);
+			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow8);
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (fSlow7 + (fConst1 * fRec6[1]));
+			fRec6[0] = ((fRec6[1] * fSlow0) + fSlow9);
 			fRec2[0] = (((fRec0[0] * fRec3[1]) + (fRec6[0] * (fRec3[0] + fRec3[2]))) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec6[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec6[0] * (fRec1[0] + fRec1[2]))));

--- a/src/sfizz/gen/filters/sfzHsh.cxx
+++ b/src/sfizz/gen/filters/sfzHsh.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustHsh_H__
@@ -11,55 +11,54 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustHsh
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustHsh : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fPkShGain;
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec1[2];
+	double fRec0[2];
 	double fRec2[2];
-	double fRec0[3];
 	double fRec3[2];
+	double fRec1[3];
 	double fRec4[2];
 	double fRec5[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -68,14 +67,12 @@ class faustHsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -84,120 +81,103 @@ class faustHsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fPkShGain = FAUSTFLOAT(0.0);
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
-			
+			fRec0[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
-			
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
-		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
-			
+		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
+			fRec1[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustHsh* clone() {
 		return new faustHsh();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
 		double fSlow2 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow3 = std::cos(fSlow2);
-		double fSlow4 = ((fSlow1 + 1.0) * fSlow3);
+		double fSlow4 = (fSlow3 * (fSlow1 + 1.0));
 		double fSlow5 = ((std::sqrt(fSlow1) * std::sin(fSlow2)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
-		double fSlow6 = ((fSlow1 + -1.0) * fSlow3);
+		double fSlow6 = (fSlow3 * (fSlow1 + -1.0));
 		double fSlow7 = ((fSlow1 + fSlow5) + (1.0 - fSlow6));
 		double fSlow8 = (1.0 - fSlow0);
-		double fSlow9 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow7)) * fSlow8);
-		double fSlow10 = (((fSlow1 + (1.0 - (fSlow6 + fSlow5))) / fSlow7) * fSlow8);
-		double fSlow11 = (fSlow6 + fSlow1);
-		double fSlow12 = (((((fSlow11 + fSlow5) + 1.0) * fSlow1) / fSlow7) * fSlow8);
-		double fSlow13 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow4 + fSlow1) + -1.0)) / fSlow7) * fSlow8);
-		double fSlow14 = ((((fSlow11 + (1.0 - fSlow5)) * fSlow1) / fSlow7) * fSlow8);
+		double fSlow9 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow1 + fSlow4) + -1.0)) / fSlow7) * fSlow8);
+		double fSlow10 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow7)) * fSlow8);
+		double fSlow11 = (((fSlow1 + (1.0 - (fSlow5 + fSlow6))) / fSlow7) * fSlow8);
+		double fSlow12 = (fSlow1 + fSlow6);
+		double fSlow13 = (((fSlow1 * ((fSlow5 + fSlow12) + 1.0)) / fSlow7) * fSlow8);
+		double fSlow14 = (((fSlow1 * (fSlow12 + (1.0 - fSlow5))) / fSlow7) * fSlow8);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow9);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow10);
-			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow12);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow13);
-			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow14);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
-			fRec1[1] = fRec1[0];
-			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
+			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow9);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow10);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
+			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow14);
+			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + ((fRec1[0] * fRec4[0]) + (fRec5[0] * fRec1[2]))));
 			fRec0[1] = fRec0[0];
+			fRec2[1] = fRec2[0];
 			fRec3[1] = fRec3[0];
+			fRec1[2] = fRec1[1];
+			fRec1[1] = fRec1[0];
 			fRec4[1] = fRec4[0];
 			fRec5[1] = fRec5[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzHsh.cxx
+++ b/src/sfizz/gen/filters/sfzHsh.cxx
@@ -33,13 +33,11 @@ class faustHsh : public sfzFilterDsp {
 	int fSamplingFreq;
 	double fConst0;
 	double fConst1;
-	double fConst2;
 	FAUSTFLOAT fPkShGain;
-	double fConst3;
+	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec1[2];
-	double fConst4;
 	double fRec2[2];
 	double fRec0[3];
 	double fRec3[2];
@@ -100,9 +98,7 @@ class faustHsh : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (2.0 * fConst2);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -168,27 +164,29 @@ class faustHsh : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
-		double fSlow1 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow2 = std::cos(fSlow1);
-		double fSlow3 = ((fSlow0 + -1.0) * fSlow2);
-		double fSlow4 = ((std::sqrt(fSlow0) * std::sin(fSlow1)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
-		double fSlow5 = ((fSlow0 + fSlow4) + (1.0 - fSlow3));
-		double fSlow6 = (fConst2 * ((fSlow0 + (1.0 - (fSlow3 + fSlow4))) / fSlow5));
-		double fSlow7 = ((fSlow0 + 1.0) * fSlow2);
-		double fSlow8 = (fConst4 * ((fSlow0 + (-1.0 - fSlow7)) / fSlow5));
-		double fSlow9 = (fSlow3 + fSlow0);
-		double fSlow10 = (fConst2 * ((((fSlow9 + fSlow4) + 1.0) * fSlow0) / fSlow5));
-		double fSlow11 = (fConst2 * (((0.0 - (2.0 * fSlow0)) * ((fSlow7 + fSlow0) + -1.0)) / fSlow5));
-		double fSlow12 = (fConst2 * (((fSlow9 + (1.0 - fSlow4)) * fSlow0) / fSlow5));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
+		double fSlow2 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow3 = std::cos(fSlow2);
+		double fSlow4 = ((fSlow1 + 1.0) * fSlow3);
+		double fSlow5 = ((std::sqrt(fSlow1) * std::sin(fSlow2)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
+		double fSlow6 = ((fSlow1 + -1.0) * fSlow3);
+		double fSlow7 = ((fSlow1 + fSlow5) + (1.0 - fSlow6));
+		double fSlow8 = (1.0 - fSlow0);
+		double fSlow9 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow7)) * fSlow8);
+		double fSlow10 = (((fSlow1 + (1.0 - (fSlow6 + fSlow5))) / fSlow7) * fSlow8);
+		double fSlow11 = (fSlow6 + fSlow1);
+		double fSlow12 = (((((fSlow11 + fSlow5) + 1.0) * fSlow1) / fSlow7) * fSlow8);
+		double fSlow13 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow4 + fSlow1) + -1.0)) / fSlow7) * fSlow8);
+		double fSlow14 = ((((fSlow11 + (1.0 - fSlow5)) * fSlow1) / fSlow7) * fSlow8);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow6 + (fConst1 * fRec1[1]));
-			fRec2[0] = (fSlow8 + (fConst1 * fRec2[1]));
-			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[2]) + (fRec2[0] * fRec0[1])));
-			fRec3[0] = (fSlow10 + (fConst1 * fRec3[1]));
-			fRec4[0] = (fSlow11 + (fConst1 * fRec4[1]));
-			fRec5[0] = (fSlow12 + (fConst1 * fRec5[1]));
+			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow9);
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow10);
+			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow12);
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow13);
+			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow14);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];

--- a/src/sfizz/gen/filters/sfzLpf1p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf1p.cxx
@@ -34,7 +34,6 @@ class faustLpf1p : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec1[2];
 	double fRec0[2];
@@ -93,8 +92,7 @@ class faustLpf1p : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (1.0 / fConst0);
+		fConst2 = (1.0 / fConst0);
 		
 	}
 	
@@ -142,10 +140,11 @@ class faustLpf1p : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst2 * std::exp((fConst3 * (0.0 - (6.2831853071795862 * double(fCutoff))))));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow0 + (fConst1 * fRec1[1]));
+			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow1);
 			fRec0[0] = ((fRec1[0] * fRec0[1]) + fTemp0);
 			output0[i] = FAUSTFLOAT((fRec0[0] * (1.0 - fRec1[0])));
 			fRec1[1] = fRec1[0];

--- a/src/sfizz/gen/filters/sfzLpf1p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf1p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustLpf1p_H__
@@ -11,49 +11,48 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustLpf1p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustLpf1p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
-	double fConst2;
 	FAUSTFLOAT fCutoff;
+	double fConst2;
 	double fRec1[2];
 	double fRec0[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -62,14 +61,12 @@ class faustLpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -78,80 +75,67 @@ class faustLpf1p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 / fConst0);
-		
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
+		fConst1 = (1.0 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec0[l1] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustLpf1p* clone() {
 		return new faustLpf1p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
-		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
+		double fSlow0 = (fSmoothEnable ? fConst2 : 0.0);
+		double fSlow1 = (std::exp((fConst1 * (0.0 - (6.2831853071795862 * double(fCutoff))))) * (1.0 - fSlow0));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow1);
-			fRec0[0] = ((fRec1[0] * fRec0[1]) + fTemp0);
+			fRec1[0] = (fSlow1 + (fSlow0 * fRec1[1]));
+			fRec0[0] = (fTemp0 + (fRec1[0] * fRec0[1]));
 			output0[i] = FAUSTFLOAT((fRec0[0] * (1.0 - fRec1[0])));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzLpf2p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf2p.cxx
@@ -33,15 +33,13 @@ class faustLpf2p : public sfzFilterDsp {
 	int fSamplingFreq;
 	double fConst0;
 	double fConst1;
-	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
+	double fConst2;
 	double fRec0[2];
 	double fRec2[2];
 	double fRec3[2];
 	double fRec1[3];
-	double fConst4;
 	double fRec4[2];
 	
  public:
@@ -97,10 +95,8 @@ class faustLpf2p : public sfzFilterDsp {
 	virtual void instanceConstants(int samplingFreq) {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (0.5 * fConst2);
+		fConst1 = (6.2831853071795862 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 		
 	}
 	
@@ -161,22 +157,24 @@ class faustLpf2p : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst1 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (fConst2 * fSlow4);
-		double fSlow6 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow7 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow8 = (fConst4 * fSlow4);
+		double fSlow5 = (fSmoothEnable?fConst2:0.0);
+		double fSlow6 = (1.0 - fSlow5);
+		double fSlow7 = (fSlow4 * fSlow6);
+		double fSlow8 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
+		double fSlow9 = (((1.0 - fSlow2) / fSlow3) * fSlow6);
+		double fSlow10 = ((0.5 * fSlow4) * fSlow6);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow5 + (fConst1 * fRec0[1]));
-			fRec2[0] = (fSlow6 + (fConst1 * fRec2[1]));
-			fRec3[0] = (fSlow7 + (fConst1 * fRec3[1]));
+			fRec0[0] = (fSlow7 + (fRec0[1] * fSlow5));
+			fRec2[0] = ((fRec2[1] * fSlow5) + fSlow8);
+			fRec3[0] = ((fRec3[1] * fSlow5) + fSlow9);
 			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
-			fRec4[0] = (fSlow8 + (fConst1 * fRec4[1]));
+			fRec4[0] = ((fRec4[1] * fSlow5) + fSlow10);
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec4[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];

--- a/src/sfizz/gen/filters/sfzLpf2p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf2p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustLpf2p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustLpf2p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustLpf2p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fCutoff;
@@ -41,23 +42,21 @@ class faustLpf2p : public sfzFilterDsp {
 	double fRec3[2];
 	double fRec1[3];
 	double fRec4[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -66,14 +65,12 @@ class faustLpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -82,78 +79,64 @@ class faustLpf2p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = (6.2831853071795862 / fConst0);
 		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec3[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustLpf2p* clone() {
 		return new faustLpf2p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
@@ -162,7 +145,7 @@ class faustLpf2p : public sfzFilterDsp {
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (fSmoothEnable?fConst2:0.0);
+		double fSlow5 = (fSmoothEnable ? fConst2 : 0.0);
 		double fSlow6 = (1.0 - fSlow5);
 		double fSlow7 = (fSlow4 * fSlow6);
 		double fSlow8 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
@@ -170,11 +153,11 @@ class faustLpf2p : public sfzFilterDsp {
 		double fSlow10 = ((0.5 * fSlow4) * fSlow6);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow7 + (fRec0[1] * fSlow5));
-			fRec2[0] = ((fRec2[1] * fSlow5) + fSlow8);
-			fRec3[0] = ((fRec3[1] * fSlow5) + fSlow9);
+			fRec0[0] = (fSlow7 + (fSlow5 * fRec0[1]));
+			fRec2[0] = ((fSlow5 * fRec2[1]) + fSlow8);
+			fRec3[0] = ((fSlow5 * fRec3[1]) + fSlow9);
 			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
-			fRec4[0] = ((fRec4[1] * fSlow5) + fSlow10);
+			fRec4[0] = ((fSlow5 * fRec4[1]) + fSlow10);
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec4[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];
@@ -182,9 +165,7 @@ class faustLpf2p : public sfzFilterDsp {
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
 			fRec4[1] = fRec4[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzLpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzLpf2pSv.cxx
@@ -34,7 +34,6 @@ class faustLpf2pSv : public sfzFilterDsp {
 	double fConst0;
 	double fConst1;
 	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	double fRec3[2];
 	FAUSTFLOAT fQ;
@@ -97,8 +96,7 @@ class faustLpf2pSv : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (3.1415926535897931 / fConst0);
+		fConst2 = (3.1415926535897931 / fConst0);
 		
 	}
 	
@@ -159,14 +157,16 @@ class faustLpf2pSv : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst2 * std::tan((fConst3 * double(fCutoff))));
-		double fSlow1 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = (1.0 - fSlow0);
+		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
+		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec3[0] = (fSlow0 + (fConst1 * fRec3[1]));
-			double fTemp1 = (fSlow1 + fRec3[0]);
-			fRec4[0] = ((fConst1 * fRec4[1]) + (fConst2 / ((fRec3[0] * fTemp1) + 1.0)));
-			fRec5[0] = ((fConst1 * fRec5[1]) + (fConst2 * fTemp1));
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow2);
+			double fTemp1 = (fSlow3 + fRec3[0]);
+			fRec4[0] = ((fRec4[1] * fSlow0) + (fSlow1 / ((fRec3[0] * fTemp1) + 1.0)));
+			fRec5[0] = ((fRec5[1] * fSlow0) + (fSlow1 * fTemp1));
 			double fTemp2 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fTemp3 = ((fRec3[0] * fRec4[0]) * fTemp2);
 			double fTemp4 = (fRec2[1] + (2.0 * fTemp3));

--- a/src/sfizz/gen/filters/sfzLpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzLpf2pSv.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustLpf2pSv_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustLpf2pSv
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustLpf2pSv : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -41,23 +42,21 @@ class faustLpf2pSv : public sfzFilterDsp {
 	double fRec5[2];
 	double fRec1[2];
 	double fRec2[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -66,14 +65,12 @@ class faustLpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -82,91 +79,77 @@ class faustLpf2pSv : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec3[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec1[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec2[l4] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustLpf2pSv* clone() {
 		return new faustLpf2pSv();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow2);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow2);
 			double fTemp1 = (fSlow3 + fRec3[0]);
-			fRec4[0] = ((fRec4[1] * fSlow0) + (fSlow1 / ((fRec3[0] * fTemp1) + 1.0)));
-			fRec5[0] = ((fRec5[1] * fSlow0) + (fSlow1 * fTemp1));
+			fRec4[0] = ((fSlow0 * fRec4[1]) + (fSlow1 / ((fRec3[0] * fTemp1) + 1.0)));
+			fRec5[0] = ((fSlow0 * fRec5[1]) + (fSlow1 * fTemp1));
 			double fTemp2 = (fTemp0 - (fRec1[1] + (fRec5[0] * fRec2[1])));
 			double fTemp3 = ((fRec3[0] * fRec4[0]) * fTemp2);
 			double fTemp4 = (fRec2[1] + (2.0 * fTemp3));
@@ -180,9 +163,7 @@ class faustLpf2pSv : public sfzFilterDsp {
 			fRec5[1] = fRec5[0];
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzLpf4p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf4p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustLpf4p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustLpf4p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustLpf4p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fCutoff;
@@ -42,23 +43,21 @@ class faustLpf4p : public sfzFilterDsp {
 	double fRec2[3];
 	double fRec5[2];
 	double fRec1[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -67,14 +66,12 @@ class faustLpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -83,82 +80,67 @@ class faustLpf4p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = (6.2831853071795862 / fConst0);
 		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec3[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec4[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec2[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec5[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec1[l5] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustLpf4p* clone() {
 		return new faustLpf4p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
@@ -167,7 +149,7 @@ class faustLpf4p : public sfzFilterDsp {
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (fSmoothEnable?fConst2:0.0);
+		double fSlow5 = (fSmoothEnable ? fConst2 : 0.0);
 		double fSlow6 = (1.0 - fSlow5);
 		double fSlow7 = (fSlow4 * fSlow6);
 		double fSlow8 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
@@ -175,11 +157,11 @@ class faustLpf4p : public sfzFilterDsp {
 		double fSlow10 = ((0.5 * fSlow4) * fSlow6);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow7 + (fRec0[1] * fSlow5));
-			fRec3[0] = ((fRec3[1] * fSlow5) + fSlow8);
-			fRec4[0] = ((fRec4[1] * fSlow5) + fSlow9);
+			fRec0[0] = (fSlow7 + (fSlow5 * fRec0[1]));
+			fRec3[0] = ((fSlow5 * fRec3[1]) + fSlow8);
+			fRec4[0] = ((fSlow5 * fRec4[1]) + fSlow9);
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = ((fRec5[1] * fSlow5) + fSlow10);
+			fRec5[0] = ((fSlow5 * fRec5[1]) + fSlow10);
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec5[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];
@@ -190,9 +172,7 @@ class faustLpf4p : public sfzFilterDsp {
 			fRec5[1] = fRec5[0];
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzLpf4p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf4p.cxx
@@ -33,15 +33,13 @@ class faustLpf4p : public sfzFilterDsp {
 	int fSamplingFreq;
 	double fConst0;
 	double fConst1;
-	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
+	double fConst2;
 	double fRec0[2];
 	double fRec3[2];
 	double fRec4[2];
 	double fRec2[3];
-	double fConst4;
 	double fRec5[2];
 	double fRec1[3];
 	
@@ -98,10 +96,8 @@ class faustLpf4p : public sfzFilterDsp {
 	virtual void instanceConstants(int samplingFreq) {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (0.5 * fConst2);
+		fConst1 = (6.2831853071795862 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 		
 	}
 	
@@ -166,23 +162,25 @@ class faustLpf4p : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst1 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (fConst2 * fSlow4);
-		double fSlow6 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow7 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow8 = (fConst4 * fSlow4);
+		double fSlow5 = (fSmoothEnable?fConst2:0.0);
+		double fSlow6 = (1.0 - fSlow5);
+		double fSlow7 = (fSlow4 * fSlow6);
+		double fSlow8 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
+		double fSlow9 = (((1.0 - fSlow2) / fSlow3) * fSlow6);
+		double fSlow10 = ((0.5 * fSlow4) * fSlow6);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow5 + (fConst1 * fRec0[1]));
-			fRec3[0] = (fSlow6 + (fConst1 * fRec3[1]));
-			fRec4[0] = (fSlow7 + (fConst1 * fRec4[1]));
+			fRec0[0] = (fSlow7 + (fRec0[1] * fSlow5));
+			fRec3[0] = ((fRec3[1] * fSlow5) + fSlow8);
+			fRec4[0] = ((fRec4[1] * fSlow5) + fSlow9);
 			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = (fSlow8 + (fConst1 * fRec5[1]));
-			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[2]) + (fRec3[0] * fRec1[1])));
+			fRec5[0] = ((fRec5[1] * fSlow5) + fSlow10);
+			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec5[0] * (fRec1[0] + fRec1[2]))));
 			fRec0[1] = fRec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfzLpf6p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf6p.cxx
@@ -33,15 +33,13 @@ class faustLpf6p : public sfzFilterDsp {
 	int fSamplingFreq;
 	double fConst0;
 	double fConst1;
-	double fConst2;
-	double fConst3;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
+	double fConst2;
 	double fRec0[2];
 	double fRec4[2];
 	double fRec5[2];
 	double fRec3[3];
-	double fConst4;
 	double fRec6[2];
 	double fRec2[3];
 	double fRec1[3];
@@ -99,10 +97,8 @@ class faustLpf6p : public sfzFilterDsp {
 	virtual void instanceConstants(int samplingFreq) {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
-		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (0.5 * fConst2);
+		fConst1 = (6.2831853071795862 / fConst0);
+		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 		
 	}
 	
@@ -171,22 +167,24 @@ class faustLpf6p : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow0 = (fConst1 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow1 = std::cos(fSlow0);
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (fConst2 * fSlow4);
-		double fSlow6 = (fConst2 * ((0.0 - (2.0 * fSlow1)) / fSlow3));
-		double fSlow7 = (fConst2 * ((1.0 - fSlow2) / fSlow3));
-		double fSlow8 = (fConst4 * fSlow4);
+		double fSlow5 = (fSmoothEnable?fConst2:0.0);
+		double fSlow6 = (1.0 - fSlow5);
+		double fSlow7 = (fSlow4 * fSlow6);
+		double fSlow8 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
+		double fSlow9 = (((1.0 - fSlow2) / fSlow3) * fSlow6);
+		double fSlow10 = ((0.5 * fSlow4) * fSlow6);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow5 + (fConst1 * fRec0[1]));
-			fRec4[0] = (fSlow6 + (fConst1 * fRec4[1]));
-			fRec5[0] = (fSlow7 + (fConst1 * fRec5[1]));
+			fRec0[0] = (fSlow7 + (fRec0[1] * fSlow5));
+			fRec4[0] = ((fRec4[1] * fSlow5) + fSlow8);
+			fRec5[0] = ((fRec5[1] * fSlow5) + fSlow9);
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (fSlow8 + (fConst1 * fRec6[1]));
+			fRec6[0] = ((fRec6[1] * fSlow5) + fSlow10);
 			fRec2[0] = (((fRec0[0] * fRec3[1]) + (fRec6[0] * (fRec3[0] + fRec3[2]))) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec6[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec6[0] * (fRec1[0] + fRec1[2]))));

--- a/src/sfizz/gen/filters/sfzLpf6p.cxx
+++ b/src/sfizz/gen/filters/sfzLpf6p.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustLpf6p_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustLpf6p
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustLpf6p : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fCutoff;
@@ -43,23 +44,21 @@ class faustLpf6p : public sfzFilterDsp {
 	double fRec6[2];
 	double fRec2[3];
 	double fRec1[3];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -68,14 +67,12 @@ class faustLpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -84,86 +81,70 @@ class faustLpf6p : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = (6.2831853071795862 / fConst0);
 		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec4[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec5[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec6[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
 			fRec2[l5] = 0.0;
-			
 		}
 		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
 			fRec1[l6] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustLpf6p* clone() {
 		return new faustLpf6p();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
@@ -172,7 +153,7 @@ class faustLpf6p : public sfzFilterDsp {
 		double fSlow2 = (0.5 * (std::sin(fSlow0) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))))));
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = ((1.0 - fSlow1) / fSlow3);
-		double fSlow5 = (fSmoothEnable?fConst2:0.0);
+		double fSlow5 = (fSmoothEnable ? fConst2 : 0.0);
 		double fSlow6 = (1.0 - fSlow5);
 		double fSlow7 = (fSlow4 * fSlow6);
 		double fSlow8 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
@@ -180,11 +161,11 @@ class faustLpf6p : public sfzFilterDsp {
 		double fSlow10 = ((0.5 * fSlow4) * fSlow6);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = (fSlow7 + (fRec0[1] * fSlow5));
-			fRec4[0] = ((fRec4[1] * fSlow5) + fSlow8);
-			fRec5[0] = ((fRec5[1] * fSlow5) + fSlow9);
+			fRec0[0] = (fSlow7 + (fSlow5 * fRec0[1]));
+			fRec4[0] = ((fSlow5 * fRec4[1]) + fSlow8);
+			fRec5[0] = ((fSlow5 * fRec5[1]) + fSlow9);
 			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = ((fRec6[1] * fSlow5) + fSlow10);
+			fRec6[0] = ((fSlow5 * fRec6[1]) + fSlow10);
 			fRec2[0] = (((fRec0[0] * fRec3[1]) + (fRec6[0] * (fRec3[0] + fRec3[2]))) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
 			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec6[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
 			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec6[0] * (fRec1[0] + fRec1[2]))));
@@ -198,9 +179,7 @@ class faustLpf6p : public sfzFilterDsp {
 			fRec2[1] = fRec2[0];
 			fRec1[2] = fRec1[1];
 			fRec1[1] = fRec1[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzLsh.cxx
+++ b/src/sfizz/gen/filters/sfzLsh.cxx
@@ -33,16 +33,14 @@ class faustLsh : public sfzFilterDsp {
 	int fSamplingFreq;
 	double fConst0;
 	double fConst1;
-	double fConst2;
 	FAUSTFLOAT fPkShGain;
-	double fConst3;
+	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	double fRec1[2];
 	double fRec2[2];
 	double fRec0[3];
 	double fRec3[2];
-	double fConst4;
 	double fRec4[2];
 	double fRec5[2];
 	
@@ -100,9 +98,7 @@ class faustLsh : public sfzFilterDsp {
 		fSamplingFreq = samplingFreq;
 		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
-		fConst2 = (1.0 - fConst1);
-		fConst3 = (6.2831853071795862 / fConst0);
-		fConst4 = (2.0 * fConst2);
+		fConst2 = (6.2831853071795862 / fConst0);
 		
 	}
 	
@@ -168,27 +164,29 @@ class faustLsh : public sfzFilterDsp {
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
-		double fSlow1 = (fConst3 * std::max<double>(0.0, double(fCutoff)));
-		double fSlow2 = std::cos(fSlow1);
-		double fSlow3 = ((fSlow0 + 1.0) * fSlow2);
-		double fSlow4 = ((fSlow0 + -1.0) * fSlow2);
-		double fSlow5 = (fSlow4 + fSlow0);
-		double fSlow6 = ((std::sqrt(fSlow0) * std::sin(fSlow1)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
-		double fSlow7 = ((fSlow5 + fSlow6) + 1.0);
-		double fSlow8 = (fConst2 * ((0.0 - (2.0 * ((fSlow3 + fSlow0) + -1.0))) / fSlow7));
-		double fSlow9 = (fConst2 * ((fSlow5 + (1.0 - fSlow6)) / fSlow7));
-		double fSlow10 = (fConst2 * ((((fSlow0 + fSlow6) + (1.0 - fSlow4)) * fSlow0) / fSlow7));
-		double fSlow11 = (fConst4 * (((fSlow0 + (-1.0 - fSlow3)) * fSlow0) / fSlow7));
-		double fSlow12 = (fConst2 * (((fSlow0 + (1.0 - (fSlow4 + fSlow6))) * fSlow0) / fSlow7));
+		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow1 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
+		double fSlow2 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
+		double fSlow3 = std::cos(fSlow2);
+		double fSlow4 = ((fSlow1 + 1.0) * fSlow3);
+		double fSlow5 = ((fSlow1 + -1.0) * fSlow3);
+		double fSlow6 = (fSlow5 + fSlow1);
+		double fSlow7 = ((std::sqrt(fSlow1) * std::sin(fSlow2)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
+		double fSlow8 = ((fSlow6 + fSlow7) + 1.0);
+		double fSlow9 = (1.0 - fSlow0);
+		double fSlow10 = (((0.0 - (2.0 * ((fSlow4 + fSlow1) + -1.0))) / fSlow8) * fSlow9);
+		double fSlow11 = (((fSlow6 + (1.0 - fSlow7)) / fSlow8) * fSlow9);
+		double fSlow12 = (((((fSlow1 + fSlow7) + (1.0 - fSlow5)) * fSlow1) / fSlow8) * fSlow9);
+		double fSlow13 = ((2.0 * (((fSlow1 + (-1.0 - fSlow4)) * fSlow1) / fSlow8)) * fSlow9);
+		double fSlow14 = ((((fSlow1 + (1.0 - (fSlow5 + fSlow7))) * fSlow1) / fSlow8) * fSlow9);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = (fSlow8 + (fConst1 * fRec1[1]));
-			fRec2[0] = (fSlow9 + (fConst1 * fRec2[1]));
+			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow10);
+			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow11);
 			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = (fSlow10 + (fConst1 * fRec3[1]));
-			fRec4[0] = (fSlow11 + (fConst1 * fRec4[1]));
-			fRec5[0] = (fSlow12 + (fConst1 * fRec5[1]));
+			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow12);
+			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow13);
+			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow14);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];

--- a/src/sfizz/gen/filters/sfzLsh.cxx
+++ b/src/sfizz/gen/filters/sfzLsh.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustLsh_H__
@@ -11,55 +11,54 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustLsh
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustLsh : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fPkShGain;
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec1[2];
+	double fRec0[2];
 	double fRec2[2];
-	double fRec0[3];
 	double fRec3[2];
+	double fRec1[3];
 	double fRec4[2];
 	double fRec5[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -68,14 +67,12 @@ class faustLsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -84,120 +81,103 @@ class faustLsh : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fPkShGain = FAUSTFLOAT(0.0);
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
-			
+			fRec0[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
-			
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
-		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
-			
+		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
+			fRec1[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustLsh* clone() {
 		return new faustLsh();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = std::pow(10.0, (0.025000000000000001 * double(fPkShGain)));
 		double fSlow2 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow3 = std::cos(fSlow2);
-		double fSlow4 = ((fSlow1 + 1.0) * fSlow3);
-		double fSlow5 = ((fSlow1 + -1.0) * fSlow3);
-		double fSlow6 = (fSlow5 + fSlow1);
-		double fSlow7 = ((std::sqrt(fSlow1) * std::sin(fSlow2)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
-		double fSlow8 = ((fSlow6 + fSlow7) + 1.0);
+		double fSlow4 = (fSlow3 * (fSlow1 + 1.0));
+		double fSlow5 = ((std::sqrt(fSlow1) * std::sin(fSlow2)) / std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ)))));
+		double fSlow6 = (fSlow3 * (fSlow1 + -1.0));
+		double fSlow7 = (fSlow1 + fSlow6);
+		double fSlow8 = ((fSlow5 + fSlow7) + 1.0);
 		double fSlow9 = (1.0 - fSlow0);
-		double fSlow10 = (((0.0 - (2.0 * ((fSlow4 + fSlow1) + -1.0))) / fSlow8) * fSlow9);
-		double fSlow11 = (((fSlow6 + (1.0 - fSlow7)) / fSlow8) * fSlow9);
-		double fSlow12 = (((((fSlow1 + fSlow7) + (1.0 - fSlow5)) * fSlow1) / fSlow8) * fSlow9);
-		double fSlow13 = ((2.0 * (((fSlow1 + (-1.0 - fSlow4)) * fSlow1) / fSlow8)) * fSlow9);
-		double fSlow14 = ((((fSlow1 + (1.0 - (fSlow5 + fSlow7))) * fSlow1) / fSlow8) * fSlow9);
+		double fSlow10 = ((2.0 * ((fSlow1 * (fSlow1 + (-1.0 - fSlow4))) / fSlow8)) * fSlow9);
+		double fSlow11 = (((0.0 - (2.0 * ((fSlow1 + fSlow4) + -1.0))) / fSlow8) * fSlow9);
+		double fSlow12 = (((fSlow7 + (1.0 - fSlow5)) / fSlow8) * fSlow9);
+		double fSlow13 = (((fSlow1 * ((fSlow1 + fSlow5) + (1.0 - fSlow6))) / fSlow8) * fSlow9);
+		double fSlow14 = (((fSlow1 * (fSlow1 + (1.0 - (fSlow5 + fSlow6)))) / fSlow8) * fSlow9);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow10);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow11);
-			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow12);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow13);
-			fRec5[0] = ((fRec5[1] * fSlow0) + fSlow14);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
-			fRec1[1] = fRec1[0];
-			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
+			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow10);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow11);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
+			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow14);
+			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + ((fRec1[0] * fRec4[0]) + (fRec5[0] * fRec1[2]))));
 			fRec0[1] = fRec0[0];
+			fRec2[1] = fRec2[0];
 			fRec3[1] = fRec3[0];
+			fRec1[2] = fRec1[1];
+			fRec1[1] = fRec1[0];
 			fRec4[1] = fRec4[0];
 			fRec5[1] = fRec5[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzPeq.cxx
+++ b/src/sfizz/gen/filters/sfzPeq.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustPeq_H__
@@ -11,26 +11,27 @@ Compilation options: -inpl -double -ftz 0
 
 #ifndef FAUSTFLOAT
 #define FAUSTFLOAT float
-#endif 
+#endif
 
 #include <algorithm>
 #include <cmath>
 #include <math.h>
 
 
-#ifndef FAUSTCLASS 
+#ifndef FAUSTCLASS
 #define FAUSTCLASS faustPeq
 #endif
-#ifdef __APPLE__ 
+
+#ifdef __APPLE__
 #define exp10f __exp10f
 #define exp10 __exp10
 #endif
 
 class faustPeq : public sfzFilterDsp {
-	
+
  public:
-	
-	int fSamplingFreq;
+
+	int fSampleRate;
 	double fConst0;
 	double fConst1;
 	double fConst2;
@@ -42,23 +43,21 @@ class faustPeq : public sfzFilterDsp {
 	double fRec0[3];
 	double fRec3[2];
 	double fRec4[2];
-	
+
  public:
-	
-	void metadata(Meta* m) { 
+
+	void metadata(Meta* m) {
 	}
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -67,14 +66,12 @@ class faustPeq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -83,83 +80,69 @@ class faustPeq : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
-	
-	static void classInit(int samplingFreq) {
-		
+
+	static void classInit(int sample_rate) {
 	}
-	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSamplingFreq)));
+
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
+		fConst0 = std::min<double>(192000.0, std::max<double>(1.0, double(fSampleRate)));
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
-		
 	}
-	
+
 	virtual void instanceResetUserInterface() {
 		fCutoff = FAUSTFLOAT(440.0);
 		fQ = FAUSTFLOAT(0.0);
 		fPkShGain = FAUSTFLOAT(0.0);
-		
 	}
-	
+
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
 			fRec1[l0] = 0.0;
-			
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
 			fRec2[l1] = 0.0;
-			
 		}
 		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
 			fRec0[l2] = 0.0;
-			
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
 			fRec3[l3] = 0.0;
-			
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
-			
 		}
-		
 	}
-	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
-	
+
 	virtual faustPeq* clone() {
 		return new faustPeq();
 	}
-	
+
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
-	
+
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
-	
+
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
 		FAUSTFLOAT* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		double fSlow0 = (fSmoothEnable?fConst1:0.0);
+		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (fConst2 * std::max<double>(0.0, double(fCutoff)));
 		double fSlow2 = std::sin(fSlow1);
 		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
@@ -174,12 +157,12 @@ class faustPeq : public sfzFilterDsp {
 		double fSlow12 = (((1.0 - fSlow10) / fSlow6) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fRec1[1] * fSlow0) + fSlow8);
+			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow8);
 			double fTemp1 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = ((fRec2[1] * fSlow0) + fSlow9);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow9);
 			fRec0[0] = (fTemp0 - (fTemp1 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fRec3[1] * fSlow0) + fSlow11);
-			fRec4[0] = ((fRec4[1] * fSlow0) + fSlow12);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow12);
 			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp1) + (fRec4[0] * fRec0[2])));
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
@@ -187,9 +170,7 @@ class faustPeq : public sfzFilterDsp {
 			fRec0[1] = fRec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
-			
 		}
-		
 	}
 
 };

--- a/src/sfizz/gen/filters/sfzPink.cxx
+++ b/src/sfizz/gen/filters/sfzPink.cxx
@@ -2,8 +2,8 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.15.11 (https://faust.grame.fr)
-Compilation options: -inpl -double -ftz 0
+Code generated with Faust 2.20.2 (https://faust.grame.fr)
+Compilation options: -lang cpp -inpl -double -ftz 0
 ------------------------------------------------------------ */
 
 #ifndef  __faustPink_H__
@@ -20,6 +20,7 @@ Compilation options: -inpl -double -ftz 0
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustPink
 #endif
+
 #ifdef __APPLE__ 
 #define exp10f __exp10f
 #define exp10 __exp10
@@ -30,7 +31,7 @@ class faustPink : public sfzFilterDsp {
  public:
 	
 	double fRec0[4];
-	int fSamplingFreq;
+	int fSampleRate;
 	
  public:
 	
@@ -39,15 +40,13 @@ class faustPink : public sfzFilterDsp {
 
 	virtual int getNumInputs() {
 		return 1;
-		
 	}
 	virtual int getNumOutputs() {
 		return 1;
-		
 	}
 	virtual int getInputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -56,14 +55,12 @@ class faustPink : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	virtual int getOutputRate(int channel) {
 		int rate;
-		switch (channel) {
+		switch ((channel)) {
 			case 0: {
 				rate = 1;
 				break;
@@ -72,40 +69,32 @@ class faustPink : public sfzFilterDsp {
 				rate = -1;
 				break;
 			}
-			
 		}
 		return rate;
-		
 	}
 	
-	static void classInit(int samplingFreq) {
-		
+	static void classInit(int sample_rate) {
 	}
 	
-	virtual void instanceConstants(int samplingFreq) {
-		fSamplingFreq = samplingFreq;
-		
+	virtual void instanceConstants(int sample_rate) {
+		fSampleRate = sample_rate;
 	}
 	
 	virtual void instanceResetUserInterface() {
-		
 	}
 	
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 4); l0 = (l0 + 1)) {
 			fRec0[l0] = 0.0;
-			
 		}
-		
 	}
 	
-	virtual void init(int samplingFreq) {
-		classInit(samplingFreq);
-		instanceInit(samplingFreq);
+	virtual void init(int sample_rate) {
+		classInit(sample_rate);
+		instanceInit(sample_rate);
 	}
-	
-	virtual void instanceInit(int samplingFreq) {
-		instanceConstants(samplingFreq);
+	virtual void instanceInit(int sample_rate) {
+		instanceConstants(sample_rate);
 		instanceResetUserInterface();
 		instanceClear();
 	}
@@ -115,12 +104,10 @@ class faustPink : public sfzFilterDsp {
 	}
 	
 	virtual int getSampleRate() {
-		return fSamplingFreq;
-		
+		return fSampleRate;
 	}
 	
 	virtual void buildUserInterface(UI* ui_interface) {
-		
 	}
 	
 	virtual void compute(int count, FAUSTFLOAT** inputs, FAUSTFLOAT** outputs) {
@@ -128,15 +115,12 @@ class faustPink : public sfzFilterDsp {
 		FAUSTFLOAT* output0 = outputs[0];
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = ((((2.4949560019999999 * fRec0[1]) + (0.52218940000000003 * fRec0[3])) + fTemp0) - (2.0172658750000001 * fRec0[2]));
+			fRec0[0] = ((fTemp0 + ((2.4949560019999999 * fRec0[1]) + (0.52218940000000003 * fRec0[3]))) - (2.0172658750000001 * fRec0[2]));
 			output0[i] = FAUSTFLOAT((((0.049922034999999997 * fRec0[0]) + (0.050612698999999997 * fRec0[2])) - ((0.095993537000000004 * fRec0[1]) + (0.0044087859999999996 * fRec0[3]))));
 			for (int j0 = 3; (j0 > 0); j0 = (j0 - 1)) {
 				fRec0[j0] = fRec0[(j0 - 1)];
-				
 			}
-			
 		}
-		
 	}
 
 };


### PR DESCRIPTION
This adds a method `prepare` into the filter and eq wrappers.
It should set initial coeffs of the filter without being affected by smoothing.

The trick is to use an external boolean fed from C++ to Faust code.
When the boolean is on, it forces the pole to 0, hence disable smoothing.
When it runs a single dummy cycle of the filter, it is forced to take the immediate value.

By this method, the spaceship sound can be reliably eliminated.

(generated files not included in commit, don't forget to remake them)