### PR TITLE
Effects

### DIFF
--- a/benchmarks/BM_multiplyAddFixedGain.cpp
+++ b/benchmarks/BM_multiplyAddFixedGain.cpp
@@ -14,58 +14,64 @@
 
 class MultiplyAddFixedGain : public benchmark::Fixture {
 public:
-  void SetUp(const ::benchmark::State& state) {
-    std::random_device rd { };
-    std::mt19937 gen { rd() };
-    std::uniform_real_distribution<float> dist { 0, 1 };
-    input = std::vector<float>(state.range(0));
-    output = std::vector<float>(state.range(0));
-    gain = dist(gen);
-    std::fill(output.begin(), output.end(), 1.0f );
-    std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
-  }
+    void SetUp(const ::benchmark::State& state)
+    {
+        std::random_device rd {};
+        std::mt19937 gen { rd() };
+        std::uniform_real_distribution<float> dist { 0, 1 };
+        input = std::vector<float>(state.range(0));
+        output = std::vector<float>(state.range(0));
+        gain = dist(gen);
+        std::fill(output.begin(), output.end(), 1.0f);
+        std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
+    }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+    void TearDown(const ::benchmark::State& state [[maybe_unused]])
+    {
+    }
 
-  }
-
-  float gain = {};
-  std::vector<float> input;
-  std::vector<float> output;
+    float gain = {};
+    std::vector<float> input;
+    std::vector<float> output;
 };
 
-BENCHMARK_DEFINE_F(MultiplyAddFixedGain, Straight)(benchmark::State& state) {
-    for (auto _ : state)
-    {
+BENCHMARK_DEFINE_F(MultiplyAddFixedGain, Straight)
+(benchmark::State& state)
+{
+    for (auto _ : state) {
         for (int i = 0; i < state.range(0); ++i)
             output[i] += gain * input[i];
     }
 }
 
-BENCHMARK_DEFINE_F(MultiplyAddFixedGain, Scalar)(benchmark::State& state) {
-    for (auto _ : state)
-    {
+BENCHMARK_DEFINE_F(MultiplyAddFixedGain, Scalar)
+(benchmark::State& state)
+{
+    for (auto _ : state) {
         sfz::multiplyAdd<float, false>(gain, input, absl::MakeSpan(output));
     }
 }
 
-BENCHMARK_DEFINE_F(MultiplyAddFixedGain, SIMD)(benchmark::State& state) {
-    for (auto _ : state)
-    {
+BENCHMARK_DEFINE_F(MultiplyAddFixedGain, SIMD)
+(benchmark::State& state)
+{
+    for (auto _ : state) {
         sfz::multiplyAdd<float, true>(gain, input, absl::MakeSpan(output));
     }
 }
 
-BENCHMARK_DEFINE_F(MultiplyAddFixedGain, Scalar_Unaligned)(benchmark::State& state) {
-    for (auto _ : state)
-    {
+BENCHMARK_DEFINE_F(MultiplyAddFixedGain, Scalar_Unaligned)
+(benchmark::State& state)
+{
+    for (auto _ : state) {
         sfz::multiplyAdd<float, false>(gain, absl::MakeSpan(input).subspan(1), absl::MakeSpan(output).subspan(1));
     }
 }
 
-BENCHMARK_DEFINE_F(MultiplyAddFixedGain, SIMD_Unaligned)(benchmark::State& state) {
-    for (auto _ : state)
-    {
+BENCHMARK_DEFINE_F(MultiplyAddFixedGain, SIMD_Unaligned)
+(benchmark::State& state)
+{
+    for (auto _ : state) {
         sfz::multiplyAdd<float, true>(gain, absl::MakeSpan(input).subspan(1), absl::MakeSpan(output).subspan(1));
     }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,9 @@ set (SFIZZ_SOURCES
     sfizz/FloatEnvelopes.cpp
     sfizz/Logger.cpp
     sfizz/SfzFilter.cpp
+    sfizz/Effects.cpp
+    sfizz/effects/Nothing.cpp
+    sfizz/effects/Lofi.cpp
 )
 include (SfizzSIMDSourceFiles)
 

--- a/src/sfizz/AudioSpan.h
+++ b/src/sfizz/AudioSpan.h
@@ -210,6 +210,22 @@ public:
     }
 
     /**
+     * @brief Convert implicitly to a pointer of channels
+     */
+    operator const float* const *() const noexcept
+    {
+        return spans.data();
+    }
+
+    /**
+     * @brief Convert implicitly to a pointer of channels
+     */
+    operator float* const *() noexcept
+    {
+        return spans.data();
+    }
+
+    /**
      * @brief Get a Span<Type> corresponding to a specific channel
      *
      * @param channelIndex the channel

--- a/src/sfizz/AudioSpan.h
+++ b/src/sfizz/AudioSpan.h
@@ -212,7 +212,7 @@ public:
     /**
      * @brief Convert implicitly to a pointer of channels
      */
-    operator const float* const *() const noexcept
+    operator const float* const*() const noexcept
     {
         return spans.data();
     }
@@ -220,7 +220,7 @@ public:
     /**
      * @brief Convert implicitly to a pointer of channels
      */
-    operator float* const *() noexcept
+    operator float* const*() noexcept
     {
         return spans.data();
     }

--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -69,6 +69,10 @@ namespace config {
      */
     const absl::string_view midnamManufacturer { "The Sfizz authors" };
     const absl::string_view midnamModel { "Sfizz" };
+    /**
+       Limit of how many "fxN" buses are accepted (in SFZv2, maximum is 4)
+     */
+    constexpr int maxEffectBuses { 256 };
 } // namespace config
 
 // Enable or disable SIMD accelerators by default

--- a/src/sfizz/Effects.cpp
+++ b/src/sfizz/Effects.cpp
@@ -29,7 +29,7 @@ void EffectFactory::registerEffectType(absl::string_view name, Effect::MakeInsta
     _entries.push_back(std::move(ent));
 }
 
-Effect* EffectFactory::makeEffect(absl::Span<const Opcode> members)
+std::unique_ptr<Effect> EffectFactory::makeEffect(absl::Span<const Opcode> members)
 {
     const Opcode* opcode = nullptr;
 
@@ -40,7 +40,7 @@ Effect* EffectFactory::makeEffect(absl::Span<const Opcode> members)
 
     if (!opcode) {
         DBG("The effect does not specify a type");
-        return new sfz::fx::Nothing;
+        return std::make_unique<sfz::fx::Nothing>();
     }
 
     absl::string_view type = opcode->value;
@@ -52,13 +52,13 @@ Effect* EffectFactory::makeEffect(absl::Span<const Opcode> members)
 
     if (it == end) {
         DBG("Unsupported effect type: " << type);
-        return new sfz::fx::Nothing;
+        return std::make_unique<sfz::fx::Nothing>();
     }
 
-    Effect* fx = it->make(members);
+    auto fx = std::unique_ptr<Effect>(it->make(members));
     if (!fx) {
         DBG("Could not instantiate effect of type: " << type);
-        return new sfz::fx::Nothing;
+        return std::make_unique<sfz::fx::Nothing>();
     }
 
     return fx;

--- a/src/sfizz/Effects.cpp
+++ b/src/sfizz/Effects.cpp
@@ -91,10 +91,10 @@ void EffectBus::addToInputs(const float* const addInput[], float addGain, unsign
     }
 }
 
-void EffectBus::init(double sampleRate)
+void EffectBus::setSampleRate(double sampleRate)
 {
     for (const auto& effectPtr : _effects)
-        effectPtr->init(sampleRate);
+        effectPtr->setSampleRate(sampleRate);
 }
 
 void EffectBus::clear()
@@ -130,6 +130,10 @@ void EffectBus::mixOutputsTo(float* const mainOutput[], float* const mixOutput[]
     }
 }
 
+size_t EffectBus::numEffects() const noexcept
+{
+    return _effects.size();
+}
 void EffectBus::setSamplesPerBlock(int samplesPerBlock) noexcept
 {
     _inputs.resize(samplesPerBlock);

--- a/src/sfizz/Effects.cpp
+++ b/src/sfizz/Effects.cpp
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "Effects.h"
+#include "AudioSpan.h"
+#include "Opcode.h"
+#include "SIMDHelpers.h"
+#include "Config.h"
+#include "effects/Nothing.h"
+#include "effects/Lofi.h"
+#include <algorithm>
+
+namespace sfz {
+
+void EffectFactory::registerStandardEffectTypes()
+{
+    // TODO
+    registerEffectType("lofi", fx::Lofi::makeInstance);
+}
+
+void EffectFactory::registerEffectType(absl::string_view name, Effect::MakeInstance& make)
+{
+    FactoryEntry ent;
+    ent.name = std::string(name);
+    ent.make = &make;
+    _entries.push_back(std::move(ent));
+}
+
+Effect* EffectFactory::makeEffect(absl::Span<const Opcode> members)
+{
+    const Opcode* opcode = nullptr;
+
+    for (auto it = members.rbegin(); it != members.rend() && !opcode; ++it) {
+        if (it->lettersOnlyHash == hash("type"))
+            opcode = &*it;
+    }
+
+    if (!opcode) {
+        DBG("The effect does not specify a type");
+        return new sfz::fx::Nothing;
+    }
+
+    absl::string_view type = opcode->value;
+
+    auto it = _entries.begin();
+    auto end = _entries.end();
+    for (; it != end && it->name != type; ++it)
+        ;
+
+    if (it == end) {
+        DBG("Unsupported effect type: " << type);
+        return new sfz::fx::Nothing;
+    }
+
+    Effect* fx = it->make(members);
+    if (!fx) {
+        DBG("Could not instantiate effect of type: " << type);
+        return new sfz::fx::Nothing;
+    }
+
+    return fx;
+}
+
+///
+EffectBus::EffectBus()
+{
+}
+
+EffectBus::~EffectBus()
+{
+}
+
+void EffectBus::addEffect(std::unique_ptr<Effect> fx)
+{
+    _effects.emplace_back(std::move(fx));
+}
+
+void EffectBus::clearInputs(unsigned nframes)
+{
+    AudioSpan<float>(_inputs).first(nframes).fill(0.0f);
+    AudioSpan<float>(_outputs).first(nframes).fill(0.0f);
+}
+
+void EffectBus::addToInputs(const float* const addInput[], float addGain, unsigned nframes)
+{
+    if (addGain == 0)
+        return;
+
+    for (unsigned c = 0; c < EffectChannels; ++c) {
+        absl::Span<const float> addIn(addInput[c], nframes);
+        sfz::multiplyAdd(addGain, addIn, _inputs.getSpan(c));
+    }
+}
+
+void EffectBus::init(double sampleRate)
+{
+    for (const auto& effectPtr : _effects)
+        effectPtr->init(sampleRate);
+}
+
+void EffectBus::clear()
+{
+    for (const auto& effectPtr : _effects)
+        effectPtr->clear();
+}
+
+void EffectBus::process(unsigned nframes)
+{
+    size_t numEffects = _effects.size();
+
+    if (numEffects > 0 && hasNonZeroOutput()) {
+        _effects[0]->process(
+            AudioSpan<float>(_inputs), AudioSpan<float>(_outputs), nframes);
+        for (size_t i = 1; i < numEffects; ++i)
+            _effects[i]->process(
+                AudioSpan<float>(_outputs), AudioSpan<float>(_outputs), nframes);
+    } else
+        fx::Nothing().process(
+            AudioSpan<float>(_inputs), AudioSpan<float>(_outputs), nframes);
+}
+
+void EffectBus::mixOutputsTo(float* const mainOutput[], float* const mixOutput[], unsigned nframes)
+{
+    const float gainToMain = _gainToMain;
+    const float gainToMix = _gainToMix;
+
+    for (unsigned c = 0; c < EffectChannels; ++c) {
+        absl::Span<const float> fxOut = _outputs.getConstSpan(c);
+        sfz::multiplyAdd(gainToMain, fxOut, absl::Span<float>(mainOutput[c], nframes));
+        sfz::multiplyAdd(gainToMix, fxOut, absl::Span<float>(mixOutput[c], nframes));
+    }
+}
+
+} // namespace sfz

--- a/src/sfizz/Effects.cpp
+++ b/src/sfizz/Effects.cpp
@@ -124,10 +124,16 @@ void EffectBus::mixOutputsTo(float* const mainOutput[], float* const mixOutput[]
     const float gainToMix = _gainToMix;
 
     for (unsigned c = 0; c < EffectChannels; ++c) {
-        absl::Span<const float> fxOut = _outputs.getConstSpan(c);
+        auto fxOut = _outputs.getConstSpan(c);
         sfz::multiplyAdd(gainToMain, fxOut, absl::Span<float>(mainOutput[c], nframes));
         sfz::multiplyAdd(gainToMix, fxOut, absl::Span<float>(mixOutput[c], nframes));
     }
+}
+
+void EffectBus::setSamplesPerBlock(int samplesPerBlock) noexcept
+{
+    _inputs.resize(samplesPerBlock);
+    _outputs.resize(samplesPerBlock);
 }
 
 } // namespace sfz

--- a/src/sfizz/Effects.cpp
+++ b/src/sfizz/Effects.cpp
@@ -138,6 +138,9 @@ void EffectBus::setSamplesPerBlock(int samplesPerBlock) noexcept
 {
     _inputs.resize(samplesPerBlock);
     _outputs.resize(samplesPerBlock);
+
+    for (const auto& effectPtr : _effects)
+        effectPtr->setSamplesPerBlock(samplesPerBlock);
 }
 
 } // namespace sfz

--- a/src/sfizz/Effects.cpp
+++ b/src/sfizz/Effects.cpp
@@ -45,12 +45,8 @@ std::unique_ptr<Effect> EffectFactory::makeEffect(absl::Span<const Opcode> membe
 
     absl::string_view type = opcode->value;
 
-    auto it = _entries.begin();
-    auto end = _entries.end();
-    for (; it != end && it->name != type; ++it)
-        ;
-
-    if (it == end) {
+    const auto it = absl::c_find_if(_entries, [&](auto&& entry) { return entry.name == type; });
+    if (it == _entries.end()) {
         DBG("Unsupported effect type: " << type);
         return std::make_unique<sfz::fx::Nothing>();
     }

--- a/src/sfizz/Effects.cpp
+++ b/src/sfizz/Effects.cpp
@@ -86,7 +86,7 @@ void EffectBus::addToInputs(const float* const addInput[], float addGain, unsign
         return;
 
     for (unsigned c = 0; c < EffectChannels; ++c) {
-        absl::Span<const float> addIn{ addInput[c], nframes };
+        absl::Span<const float> addIn { addInput[c], nframes };
         sfz::multiplyAdd(addGain, addIn, _inputs.getSpan(c));
     }
 }

--- a/src/sfizz/Effects.cpp
+++ b/src/sfizz/Effects.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<Effect> EffectFactory::makeEffect(absl::Span<const Opcode> membe
         return std::make_unique<sfz::fx::Nothing>();
     }
 
-    auto fx = std::unique_ptr<Effect>(it->make(members));
+    auto fx = it->make(members);
     if (!fx) {
         DBG("Could not instantiate effect of type: " << type);
         return std::make_unique<sfz::fx::Nothing>();

--- a/src/sfizz/Effects.cpp
+++ b/src/sfizz/Effects.cpp
@@ -43,7 +43,7 @@ std::unique_ptr<Effect> EffectFactory::makeEffect(absl::Span<const Opcode> membe
         return std::make_unique<sfz::fx::Nothing>();
     }
 
-    absl::string_view type = opcode->value;
+    const absl::string_view type = opcode->value;
 
     const auto it = absl::c_find_if(_entries, [&](auto&& entry) { return entry.name == type; });
     if (it == _entries.end()) {
@@ -86,7 +86,7 @@ void EffectBus::addToInputs(const float* const addInput[], float addGain, unsign
         return;
 
     for (unsigned c = 0; c < EffectChannels; ++c) {
-        absl::Span<const float> addIn(addInput[c], nframes);
+        absl::Span<const float> addIn{ addInput[c], nframes };
         sfz::multiplyAdd(addGain, addIn, _inputs.getSpan(c));
     }
 }

--- a/src/sfizz/Effects.h
+++ b/src/sfizz/Effects.h
@@ -33,6 +33,12 @@ public:
     virtual void setSampleRate(double sampleRate) = 0;
 
     /**
+     * @brief Sets the maximum number of frames to render at a time. The actual
+     * value can be lower but should never be higher.
+     */
+    virtual void setSamplesPerBlock(int samplesPerBlock) = 0;
+
+    /**
        @brief Reset the state to initial.
      */
     virtual void clear() = 0;

--- a/src/sfizz/Effects.h
+++ b/src/sfizz/Effects.h
@@ -30,7 +30,7 @@ public:
     /**
        @brief Initializes with the given sample rate.
      */
-    virtual void init(double sampleRate) = 0;
+    virtual void setSampleRate(double sampleRate) = 0;
 
     /**
        @brief Reset the state to initial.
@@ -133,7 +133,7 @@ public:
     /**
        @brief Initializes all effects in the bus with the given sample rate.
      */
-    void init(double sampleRate);
+    void setSampleRate(double sampleRate);
 
     /**
        @brief Resets the state of all effects in the bus.

--- a/src/sfizz/Effects.h
+++ b/src/sfizz/Effects.h
@@ -136,10 +136,17 @@ public:
      */
     void mixOutputsTo(float* const mainOutput[], float* const mixOutput[], unsigned nframes);
 
+    /**
+     * @brief Sets the maximum number of frames to render at a time. The actual value can be lower
+     * but should never be higher.
+     *
+     */
+    void setSamplesPerBlock(int samplesPerBlock) noexcept;
+
 private:
     std::vector<std::unique_ptr<Effect>> _effects;
     AudioBuffer<float> _inputs { EffectChannels, config::defaultSamplesPerBlock };
-    AudioBuffer<float> _outputs { EffectChannels, config::defaultSamplesPerBlock };
+    AudioBuffer<float> _outputs { EffectChannels,  config::defaultSamplesPerBlock };
     float _gainToMain = 0.0;
     float _gainToMix = 0.0;
 };

--- a/src/sfizz/Effects.h
+++ b/src/sfizz/Effects.h
@@ -107,6 +107,20 @@ public:
     void setGainToMix(float gain) { _gainToMix = gain; }
 
     /**
+     * @brief Returns the gain for the main out
+     *
+     * @return float
+     */
+    float gainToMain() const { return _gainToMain; }
+
+    /**
+     * @brief Returns the gain for the mix out
+     *
+     * @return float
+     */
+    float gainToMix() const { return _gainToMix; }
+
+    /**
        @brief Resets the input buffers to zero.
      */
     void clearInputs(unsigned nframes);
@@ -143,6 +157,12 @@ public:
      */
     void setSamplesPerBlock(int samplesPerBlock) noexcept;
 
+    /**
+     * @brief Return the number of effects in the bus
+     *
+     * @return size_t
+     */
+    size_t numEffects() const noexcept;
 private:
     std::vector<std::unique_ptr<Effect>> _effects;
     AudioBuffer<float> _inputs { EffectChannels, config::defaultSamplesPerBlock };

--- a/src/sfizz/Effects.h
+++ b/src/sfizz/Effects.h
@@ -46,7 +46,7 @@ public:
        @brief Type of the factory function used to instantiate an effect given
               the contents of the <effect> block
      */
-    typedef std::unique_ptr<Effect> (MakeInstance)(absl::Span<const Opcode> members);
+    typedef std::unique_ptr<Effect>(MakeInstance)(absl::Span<const Opcode> members);
 };
 
 /**
@@ -146,7 +146,7 @@ public:
 private:
     std::vector<std::unique_ptr<Effect>> _effects;
     AudioBuffer<float> _inputs { EffectChannels, config::defaultSamplesPerBlock };
-    AudioBuffer<float> _outputs { EffectChannels,  config::defaultSamplesPerBlock };
+    AudioBuffer<float> _outputs { EffectChannels, config::defaultSamplesPerBlock };
     float _gainToMain = 0.0;
     float _gainToMix = 0.0;
 };

--- a/src/sfizz/Effects.h
+++ b/src/sfizz/Effects.h
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include "AudioBuffer.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include <array>
+#include <vector>
+#include <memory>
+
+namespace sfz {
+struct Opcode;
+
+enum {
+    // Number of channels processed by effects
+    EffectChannels = 2,
+};
+
+/**
+   @brief Abstract base of SFZ effects
+ */
+class Effect {
+public:
+    virtual ~Effect() {}
+
+    /**
+       @brief Initializes with the given sample rate.
+     */
+    virtual void init(double sampleRate) = 0;
+
+    /**
+       @brief Reset the state to initial.
+     */
+    virtual void clear() = 0;
+
+    /**
+       @brief Computes a cycle of the effect in stereo.
+     */
+    virtual void process(const float* const inputs[], float* const outputs[], unsigned nframes) = 0;
+
+    /**
+       @brief Type of the factory function used to instantiate an effect given
+              the contents of the <effect> block
+     */
+    typedef Effect* (MakeInstance)(absl::Span<const Opcode> members);
+};
+
+/**
+   @brief SFZ effects factory
+ */
+class EffectFactory {
+public:
+    /**
+       @brief Registers all available standard effects into the factory.
+     */
+    void registerStandardEffectTypes();
+
+    /**
+       @brief Registers a user-defined effect into the factory.
+     */
+    void registerEffectType(absl::string_view name, Effect::MakeInstance& make);
+
+    /**
+       @brief Instantiates an effect given the contents of the <effect> block.
+     */
+    Effect* makeEffect(absl::Span<const Opcode> members);
+
+private:
+    struct FactoryEntry {
+        std::string name;
+        Effect::MakeInstance* make;
+    };
+
+    std::vector<FactoryEntry> _entries;
+};
+
+/**
+   @brief Sequence of effects processed in series
+ */
+class EffectBus {
+public:
+    EffectBus();
+    ~EffectBus();
+
+    /**
+       @brief Adds an effect at the end of the bus.
+     */
+    void addEffect(std::unique_ptr<Effect> fx);
+
+    /**
+       @brief Checks whether this bus can produce output.
+     */
+    bool hasNonZeroOutput() const { return _gainToMain != 0 || _gainToMix != 0; }
+
+    /**
+       @brief Sets the amount of effect output going to the main.
+     */
+    void setGainToMain(float gain) { _gainToMain = gain; }
+
+    /**
+       @brief Sets the amount of effect output going to the mix.
+     */
+    void setGainToMix(float gain) { _gainToMix = gain; }
+
+    /**
+       @brief Resets the input buffers to zero.
+     */
+    void clearInputs(unsigned nframes);
+
+    /**
+       @brief Adds some audio into the input buffer.
+     */
+    void addToInputs(const float* const addInput[], float addGain, unsigned nframes);
+
+    /**
+       @brief Initializes all effects in the bus with the given sample rate.
+     */
+    void init(double sampleRate);
+
+    /**
+       @brief Resets the state of all effects in the bus.
+     */
+    void clear();
+
+    /**
+       @brief Computes a cycle of the effect bus.
+     */
+    void process(unsigned nframes);
+
+    /**
+       @brief Mixes the outputs into a pair of stereo signals: Main and Mix.
+     */
+    void mixOutputsTo(float* const mainOutput[], float* const mixOutput[], unsigned nframes);
+
+private:
+    std::vector<std::unique_ptr<Effect>> _effects;
+    AudioBuffer<float> _inputs { EffectChannels, config::defaultSamplesPerBlock };
+    AudioBuffer<float> _outputs { EffectChannels, config::defaultSamplesPerBlock };
+    float _gainToMain = 0.0;
+    float _gainToMix = 0.0;
+};
+
+} // namespace sfz

--- a/src/sfizz/Effects.h
+++ b/src/sfizz/Effects.h
@@ -46,7 +46,7 @@ public:
        @brief Type of the factory function used to instantiate an effect given
               the contents of the <effect> block
      */
-    typedef Effect* (MakeInstance)(absl::Span<const Opcode> members);
+    typedef std::unique_ptr<Effect> (MakeInstance)(absl::Span<const Opcode> members);
 };
 
 /**
@@ -67,7 +67,7 @@ public:
     /**
        @brief Instantiates an effect given the contents of the <effect> block.
      */
-    Effect* makeEffect(absl::Span<const Opcode> members);
+    std::unique_ptr<Effect> makeEffect(absl::Span<const Opcode> members);
 
 private:
     struct FactoryEntry {

--- a/src/sfizz/Logger.cpp
+++ b/src/sfizz/Logger.cpp
@@ -83,7 +83,7 @@ sfz::Logger::~Logger()
         fs::path callbackLogPath{ fs::current_path() / callbackLogFilename.str() };
         std::cout << "Logging " << callbackTimes.size() << " callback times to " << callbackLogPath.filename() << '\n';
         std::ofstream callbackLogFile { callbackLogPath.string() };
-        callbackLogFile << "Dispatch,RenderMethod,Data,Amplitude,Filters,Panning,NumVoices,NumSamples" << '\n';
+        callbackLogFile << "Dispatch,RenderMethod,Data,Amplitude,Filters,Panning,Effects,NumVoices,NumSamples" << '\n';
         for (auto& time: callbackTimes)
             callbackLogFile << time.breakdown.dispatch.count() << ','
                             << time.breakdown.renderMethod.count() << ','
@@ -91,6 +91,7 @@ sfz::Logger::~Logger()
                             << time.breakdown.amplitude.count() << ','
                             << time.breakdown.filters.count() << ','
                             << time.breakdown.panning.count() << ','
+                            << time.breakdown.effects.count() << ','
                             << time.numVoices << ','
                             << time.numSamples << '\n';
     }

--- a/src/sfizz/Logger.h
+++ b/src/sfizz/Logger.h
@@ -61,6 +61,7 @@ struct CallbackBreakdown
     Duration amplitude { 0 };
     Duration filters { 0 };
     Duration panning { 0 };
+    Duration effects { 0 };
 };
 
 struct CallbackTime

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -734,18 +734,18 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         break;
 
     case hash("effect"): // effect&
-        {
-            const auto effectNumber = opcode.backParameter();
-            if (!effectNumber || *effectNumber < 1 || *effectNumber > config::maxEffectBuses)
-                break;
-            auto value = readOpcode<float>(opcode.value, {0, 100});
-            if (!value)
-                break;
-            if (static_cast<size_t>(*effectNumber + 1) > gainToEffect.size())
-                gainToEffect.resize(*effectNumber + 1);
-            gainToEffect[*effectNumber] = *value / 100;
+    {
+        const auto effectNumber = opcode.backParameter();
+        if (!effectNumber || *effectNumber < 1 || *effectNumber > config::maxEffectBuses)
             break;
-        }
+        auto value = readOpcode<float>(opcode.value, { 0, 100 });
+        if (!value)
+            break;
+        if (static_cast<size_t>(*effectNumber + 1) > gainToEffect.size())
+            gainToEffect.resize(*effectNumber + 1);
+        gainToEffect[*effectNumber] = *value / 100;
+        break;
+    }
 
     // Ignored opcodes
     case hash("hichan"):

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -733,6 +733,20 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         setCCPairFromOpcode(opcode, amplitudeEG.ccSustain, Default::egOnCCPercentRange);
         break;
 
+    case hash("effect"): // effect&
+        {
+            const auto effectNumber = opcode.backParameter();
+            if (!effectNumber || *effectNumber < 1 || *effectNumber > config::maxEffectBuses)
+                break;
+            auto value = readOpcode<float>(opcode.value, {0, 100});
+            if (!value)
+                break;
+            if (static_cast<size_t>(*effectNumber + 1) > gainToEffect.size())
+                gainToEffect.resize(*effectNumber + 1);
+            gainToEffect[*effectNumber] = *value / 100;
+            break;
+        }
+
     // Ignored opcodes
     case hash("hichan"):
     case hash("lochan"):
@@ -1072,4 +1086,12 @@ void sfz::Region::offsetAllKeys(int offset) noexcept
         crossfadeKeyOutRange.setStart(offsetAndClamp(start, offset, Default::keyRange));
         crossfadeKeyOutRange.setEnd(offsetAndClamp(end, offset, Default::keyRange));
     }
+}
+
+float sfz::Region::getGainToEffectBus(unsigned number) const noexcept
+{
+    if (number >= gainToEffect.size())
+        return 0.0;
+
+    return gainToEffect[number];
 }

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -733,17 +733,17 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         setCCPairFromOpcode(opcode, amplitudeEG.ccSustain, Default::egOnCCPercentRange);
         break;
 
-    case hash("effect"): // effect&
+    case hash("effect&"):
     {
-        const auto effectNumber = opcode.backParameter();
-        if (!effectNumber || *effectNumber < 1 || *effectNumber > config::maxEffectBuses)
+        const auto effectNumber = opcode.parameters.back();
+        if (!effectNumber || effectNumber < 1 || effectNumber > config::maxEffectBuses)
             break;
         auto value = readOpcode<float>(opcode.value, { 0, 100 });
         if (!value)
             break;
-        if (static_cast<size_t>(*effectNumber + 1) > gainToEffect.size())
-            gainToEffect.resize(*effectNumber + 1);
-        gainToEffect[*effectNumber] = *value / 100;
+        if (static_cast<size_t>(effectNumber + 1) > gainToEffect.size())
+            gainToEffect.resize(effectNumber + 1);
+        gainToEffect[effectNumber] = *value / 100;
         break;
     }
 

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -39,6 +39,9 @@ struct Region {
     : midiState(midiState), defaultPath(std::move(defaultPath))
     {
         ccSwitched.set();
+
+        gainToEffect.reserve(5); // sufficient room for main and fx1-4
+        gainToEffect.push_back(1.0); // contribute 100% into the main bus
     }
     Region(const Region&) = default;
     ~Region() = default;
@@ -206,6 +209,12 @@ struct Region {
 
     bool hasKeyswitches() const noexcept { return keyswitchDown || keyswitchUp || keyswitch || previousNote; }
 
+    /**
+     * @brief Get the gain this region contributes into the input of the Nth
+     *        effect bus
+     */
+    float getGainToEffectBus(unsigned number) const noexcept;
+
     // Sound source: sample playback
     std::string sample {}; // Sample
     float delay { Default::delay }; // delay
@@ -297,6 +306,10 @@ struct Region {
     EGDescription filterEG;
 
     bool isStereo { false };
+
+    // Effects
+    std::vector<float> gainToEffect;
+
 private:
     const MidiState& midiState;
     bool keySwitched { true };

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -223,24 +223,18 @@ void sfz::Synth::handleEffectOpcodes(const std::vector<Opcode>& members)
                 getOrCreateBus(0).setGainToMain(*valueOpt / 100);
             break;
 
-        case hash("fxtomain"): // fx&tomain
-            if (auto numberOpt = opcode.firstParameter()) {
-                unsigned number = *numberOpt;
-                if (number < 1 || number > config::maxEffectBuses)
-                    break;
-                if (auto valueOpt = readOpcode<float>(opcode.value, { 0, 100 }))
-                    getOrCreateBus(number).setGainToMain(*valueOpt / 100);
-            }
+        case hash("fx&tomain"): // fx&tomain
+            if (opcode.parameters.front() < 1 || opcode.parameters.front() > config::maxEffectBuses)
+                break;
+            if (auto valueOpt = readOpcode<float>(opcode.value, { 0, 100 }))
+                getOrCreateBus(opcode.parameters.front()).setGainToMain(*valueOpt / 100);
             break;
 
-        case hash("fxtomix"): // fx&tomix
-            if (auto numberOpt = opcode.firstParameter()) {
-                unsigned number = *numberOpt;
-                if (number < 1 || number > config::maxEffectBuses)
-                    break;
-                if (auto valueOpt = readOpcode<float>(opcode.value, { 0, 100 }))
-                    getOrCreateBus(number).setGainToMix(*valueOpt / 100);
-            }
+        case hash("fx&tomix"): // fx&tomix
+            if (opcode.parameters.front() < 1 || opcode.parameters.front() > config::maxEffectBuses)
+                break;
+            if (auto valueOpt = readOpcode<float>(opcode.value, { 0, 100 }))
+                getOrCreateBus(opcode.parameters.front()).setGainToMix(*valueOpt / 100);
             break;
         }
     }

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -810,6 +810,11 @@ const sfz::Region* sfz::Synth::getRegionView(int idx) const noexcept
     return (size_t)idx < regions.size() ? regions[idx].get() : nullptr;
 }
 
+const sfz::EffectBus* sfz::Synth::getEffectBusView(int idx) const noexcept
+{
+    return (size_t)idx < effectBuses.size() ? effectBuses[idx].get() : nullptr;
+}
+
 const sfz::Voice* sfz::Synth::getVoiceView(int idx) const noexcept
 {
     return (size_t)idx < voices.size() ? voices[idx].get() : nullptr;

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -123,9 +123,8 @@ void sfz::Synth::clear()
         list.clear();
     regions.clear();
     effectBuses.clear();
-    EffectBus* mainBus = new EffectBus;
-    effectBuses.emplace_back(mainBus);
-    mainBus->setGainToMain(1.0);
+    effectBuses.emplace_back(new EffectBus);
+    effectBuses[0]->setGainToMain(1.0);
     resources.filePool.clear();
     resources.logger.clear();
     numGroups = 0;

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -529,7 +529,7 @@ void sfz::Synth::renderBlock(AudioSpan<float> buffer) noexcept
             voice->renderBlock(temp);
 
             { // Add the output into the effects linked to this region
-                ScopedTiming logger { callbackBreakdown.renderMethod, ScopedTiming::Operation::addToDuration };
+                ScopedTiming logger { callbackBreakdown.effects, ScopedTiming::Operation::addToDuration };
                 for (size_t i = 0; i < numEffectBuses; ++i) {
                     if (EffectBus* bus = effectBuses[i].get()) {
                         float addGain = region->getGainToEffectBus(i);
@@ -548,7 +548,7 @@ void sfz::Synth::renderBlock(AudioSpan<float> buffer) noexcept
     { // Apply effect buses
         // -- note(jpc) there is always a "main" bus which is initially empty.
         //    without any <effect>, the signal is just going to flow through it.
-        ScopedTiming logger { callbackBreakdown.renderMethod, ScopedTiming::Operation::addToDuration };
+        ScopedTiming logger { callbackBreakdown.effects, ScopedTiming::Operation::addToDuration };
 
         for (size_t i = 0; i < numEffectBuses; ++i) {
             if (EffectBus* bus = effectBuses[i].get()) {

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -256,10 +256,9 @@ void sfz::Synth::handleEffectOpcodes(const std::vector<Opcode>& members)
 
     // create the effect and add it
     EffectBus& bus = getOrCreateBus(busIndex);
-    Effect* fx = effectFactory.makeEffect(members);
-    bus.addEffect(std::unique_ptr<Effect>(fx));
-
+    auto fx = effectFactory.makeEffect(members);
     fx->init(sampleRate);
+    bus.addEffect(std::move(fx));
 }
 
 void addEndpointsToVelocityCurve(sfz::Region& region)

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -459,8 +459,10 @@ void sfz::Synth::setSamplesPerBlock(int samplesPerBlock) noexcept
     this->tempMixNodeBuffer.resize(samplesPerBlock);
     for (auto& voice : voices)
         voice->setSamplesPerBlock(samplesPerBlock);
-    for (auto& bus : effectBuses)
-        bus->setSamplesPerBlock(samplesPerBlock);
+    for (size_t i = 0, n = effectBuses.size(); i < n; ++i) {
+        if (EffectBus* bus = effectBuses[i].get())
+            bus->setSamplesPerBlock(samplesPerBlock);
+    }
 }
 
 void sfz::Synth::setSampleRate(float sampleRate) noexcept

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -201,7 +201,7 @@ void sfz::Synth::handleEffectOpcodes(const std::vector<Opcode>& members)
     auto getOrCreateBus = [this](unsigned index) -> EffectBus& {
         if (index + 1 > effectBuses.size())
             effectBuses.resize(index + 1);
-        EffectBusPtr &slot = effectBuses[index];
+        EffectBusPtr& slot = effectBuses[index];
         if (!slot)
             slot.reset(new EffectBus);
         return *slot;
@@ -213,10 +213,10 @@ void sfz::Synth::handleEffectOpcodes(const std::vector<Opcode>& members)
             busName = opcode.value;
             break;
 
-        // note(jpc): gain opcodes are linear volumes in % units
+            // note(jpc): gain opcodes are linear volumes in % units
 
         case hash("directtomain"):
-            if (auto valueOpt = readOpcode<float>(opcode.value, {0, 100}))
+            if (auto valueOpt = readOpcode<float>(opcode.value, { 0, 100 }))
                 getOrCreateBus(0).setGainToMain(*valueOpt / 100);
             break;
 
@@ -225,7 +225,7 @@ void sfz::Synth::handleEffectOpcodes(const std::vector<Opcode>& members)
                 unsigned number = *numberOpt;
                 if (number < 1 || number > config::maxEffectBuses)
                     break;
-                if (auto valueOpt = readOpcode<float>(opcode.value, {0, 100}))
+                if (auto valueOpt = readOpcode<float>(opcode.value, { 0, 100 }))
                     getOrCreateBus(number).setGainToMain(*valueOpt / 100);
             }
             break;
@@ -235,7 +235,7 @@ void sfz::Synth::handleEffectOpcodes(const std::vector<Opcode>& members)
                 unsigned number = *numberOpt;
                 if (number < 1 || number > config::maxEffectBuses)
                     break;
-                if (auto valueOpt = readOpcode<float>(opcode.value, {0, 100}))
+                if (auto valueOpt = readOpcode<float>(opcode.value, { 0, 100 }))
                     getOrCreateBus(number).setGainToMix(*valueOpt / 100);
             }
             break;
@@ -245,12 +245,9 @@ void sfz::Synth::handleEffectOpcodes(const std::vector<Opcode>& members)
     unsigned busIndex;
     if (busName.empty() || busName == "main")
         busIndex = 0;
-    else if (busName.size() > 2 && busName.substr(0, 2) == "fx" &&
-             absl::SimpleAtoi(busName.substr(2), &busIndex) &&
-             busIndex >= 1 && busIndex <= config::maxEffectBuses) {
+    else if (busName.size() > 2 && busName.substr(0, 2) == "fx" && absl::SimpleAtoi(busName.substr(2), &busIndex) && busIndex >= 1 && busIndex <= config::maxEffectBuses) {
         // an effect bus fxN, with N usually in [1,4]
-    }
-    else {
+    } else {
         DBG("Unsupported effect bus: " << busName);
         return;
     }
@@ -465,7 +462,7 @@ void sfz::Synth::setSamplesPerBlock(int samplesPerBlock) noexcept
     this->tempMixNodeBuffer.resize(samplesPerBlock);
     for (auto& voice : voices)
         voice->setSamplesPerBlock(samplesPerBlock);
-    for (auto& bus: effectBuses)
+    for (auto& bus : effectBuses)
         bus->setSamplesPerBlock(samplesPerBlock);
 }
 

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -125,6 +125,8 @@ void sfz::Synth::clear()
     effectBuses.clear();
     effectBuses.emplace_back(new EffectBus);
     effectBuses[0]->setGainToMain(1.0);
+    effectBuses[0]->setSamplesPerBlock(samplesPerBlock);
+    effectBuses[0]->init(sampleRate);
     resources.filePool.clear();
     resources.logger.clear();
     numGroups = 0;
@@ -463,6 +465,8 @@ void sfz::Synth::setSamplesPerBlock(int samplesPerBlock) noexcept
     this->tempMixNodeBuffer.resize(samplesPerBlock);
     for (auto& voice : voices)
         voice->setSamplesPerBlock(samplesPerBlock);
+    for (auto& bus: effectBuses)
+        bus->setSamplesPerBlock(samplesPerBlock);
 }
 
 void sfz::Synth::setSampleRate(float sampleRate) noexcept

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -133,6 +133,14 @@ public:
      */
     const Voice* getVoiceView(int idx) const noexcept;
     /**
+     * @brief Get a raw view into a specific voice. This is mostly used
+     * for testing.
+     *
+     * @param idx
+     * @return const Region*
+     */
+    const EffectBus* getEffectBusView(int idx) const noexcept;
+    /**
      * @brief Get a list of unknown opcodes. The lifetime of the
      * string views in the code are linked to the currently loaded
      * sfz file.

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -9,6 +9,7 @@
 #include "Parser.h"
 #include "Voice.h"
 #include "Region.h"
+#include "Effects.h"
 #include "LeakDetector.h"
 #include "MidiState.h"
 #include "AudioSpan.h"
@@ -401,6 +402,12 @@ private:
      */
     void handleControlOpcodes(const std::vector<Opcode>& members);
     /**
+     * @brief Helper function to dispatch <effect> opcodes
+     *
+     * @param members the opcodes of the <effect> block
+     */
+    void handleEffectOpcodes(const std::vector<Opcode>& members);
+    /**
      * @brief Helper function to merge all the currently active opcodes
      * as set by the successive callbacks and create a new region to store
      * in the synth.
@@ -441,8 +448,14 @@ private:
     std::array<RegionPtrVector, 128> noteActivationLists;
     std::array<RegionPtrVector, config::numCCs> ccActivationLists;
 
-    // Internal temporary buffer
+    // Effect factory and buses
+    EffectFactory effectFactory;
+    typedef std::unique_ptr<EffectBus> EffectBusPtr;
+    std::vector<EffectBusPtr> effectBuses; // 0 is "main", 1-N are "fx1"-"fxN"
+
+    // Intermediate buffers
     AudioBuffer<float> tempBuffer { 2, config::defaultSamplesPerBlock };
+    AudioBuffer<float> tempMixNodeBuffer { 2, config::defaultSamplesPerBlock };
 
     int samplesPerBlock { config::defaultSamplesPerBlock };
     float sampleRate { config::defaultSampleRate };

--- a/src/sfizz/effects/Lofi.cpp
+++ b/src/sfizz/effects/Lofi.cpp
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+/**
+   Note(jpc): implementation status
+
+- [x] bitred
+- [ ] bitred_oncc
+- [ ] bitred_smoothcc
+- [ ] bitred_stepcc
+- [ ] bitred_curvecc
+
+- [x] decim
+- [ ] decim_oncc
+- [ ] decim_smoothcc
+- [ ] decim_stepcc
+- [ ] decim_curvecc
+
+- [ ] egN_bitred
+- [ ] egN_bitred_oncc
+- [ ] lfoN_bitred
+- [ ] lfoN_bitred_oncc
+- [ ] lfoN_bitred_smoothcc
+- [ ] lfoN_bitred_stepcc
+
+- [ ] egN_decim
+- [ ] egN_decim_oncc
+- [ ] lfoN_decim
+- [ ] lfoN_decim_oncc
+- [ ] lfoN_decim_smoothcc
+- [ ] lfoN_decim_stepcc
+
+ */
+
+#include "Lofi.h"
+#include "Opcode.h"
+#include <memory>
+#include <algorithm>
+#include <cstring>
+#include <cmath>
+
+namespace sfz {
+namespace fx {
+
+    void Lofi::init(double sampleRate)
+    {
+        for (unsigned c = 0; c < EffectChannels; ++c) {
+            _bitred[c].init(sampleRate);
+            _decim[c].init(sampleRate);
+        }
+    }
+
+    void Lofi::clear()
+    {
+        for (unsigned c = 0; c < EffectChannels; ++c) {
+            _bitred[c].clear();
+            _decim[c].clear();
+        }
+    }
+
+    void Lofi::process(const float* const inputs[2], float* const outputs[2], unsigned nframes)
+    {
+        for (unsigned c = 0; c < EffectChannels; ++c) {
+            _bitred[c].setDepth(_bitred_depth);
+            _bitred[c].process(inputs[c], outputs[c], nframes);
+
+            _decim[c].setDepth(_decim_depth);
+            _decim[c].process(outputs[c], outputs[c], nframes);
+        }
+    }
+
+    Effect* Lofi::makeInstance(absl::Span<const Opcode> members)
+    {
+        std::unique_ptr<Lofi> fx { new Lofi };
+
+        for (const Opcode& opcode : members) {
+            switch (opcode.lettersOnlyHash) {
+            case hash("bitred"):
+                setValueFromOpcode(opcode, fx->_bitred_depth, { 0.0, 100.0 });
+                break;
+            case hash("decim"):
+                setValueFromOpcode(opcode, fx->_decim_depth, { 0.0, 100.0 });
+                break;
+            }
+        }
+
+        return fx.release();
+    }
+
+    ///
+    void Lofi::Bitred::init(double sampleRate)
+    {
+        (void)sampleRate;
+
+        static constexpr double coefs2x[12] = { 0.036681502163648017, 0.13654762463195794, 0.27463175937945444, 0.42313861743656711, 0.56109869787919531, 0.67754004997416184, 0.76974183386322703, 0.83988962484963892, 0.89226081800387902, 0.9315419599631839, 0.96209454837808417, 0.98781637073289585 };
+        fDownsampler2x.set_coefs(coefs2x);
+    }
+
+    void Lofi::Bitred::clear()
+    {
+        fLastValue = 0.0;
+        fDownsampler2x.clear_buffers();
+    }
+
+    void Lofi::Bitred::setDepth(float depth)
+    {
+        fDepth = std::max(0.0f, std::min(100.0f, depth));
+    }
+
+    void Lofi::Bitred::process(const float* in, float* out, uint32_t nframes)
+    {
+        float depth = fDepth;
+
+        if (depth == 0) {
+            if (in != out)
+                std::memcpy(out, in, nframes * sizeof(float));
+            clear();
+            return;
+        }
+
+        float lastValue = fLastValue;
+        hiir::Downsampler2xFpu<12>& downsampler2x = fDownsampler2x;
+
+        float steps = (1.0f + (100.0f - depth)) * 0.75f;
+
+        for (uint32_t i = 0; i < nframes; ++i) {
+            float x = in[i];
+
+            float y = std::copysign((int)(0.5f + std::fabs(x * steps)), x) * (1 / steps);
+
+            float y2x[2];
+            y2x[0] = (y != lastValue) ? (0.5f * (y + lastValue)) : y;
+            y2x[1] = y;
+
+            lastValue = y;
+
+            y = downsampler2x.process_sample(y2x);
+            out[i] = y;
+        }
+
+        fLastValue = lastValue;
+    }
+
+    ///
+    void Lofi::Decim::init(double sampleRate)
+    {
+        fSampleTime = 1.0 / sampleRate;
+
+        static constexpr double coefs2x[12] = { 0.036681502163648017, 0.13654762463195794, 0.27463175937945444, 0.42313861743656711, 0.56109869787919531, 0.67754004997416184, 0.76974183386322703, 0.83988962484963892, 0.89226081800387902, 0.9315419599631839, 0.96209454837808417, 0.98781637073289585 };
+        fDownsampler2x.set_coefs(coefs2x);
+    }
+
+    void Lofi::Decim::clear()
+    {
+        fPhase = 0.0;
+        fLastValue = 0.0;
+        fDownsampler2x.clear_buffers();
+    }
+
+    void Lofi::Decim::setDepth(float depth)
+    {
+        fDepth = std::max(0.0f, std::min(100.0f, depth));
+    }
+
+    void Lofi::Decim::process(const float* in, float* out, uint32_t nframes)
+    {
+        float depth = fDepth;
+
+        if (depth == 0) {
+            if (in != out)
+                std::memcpy(out, in, nframes * sizeof(float));
+            clear();
+            return;
+        }
+
+        float dt;
+        {
+            // exponential curve fit
+            float a = 1.289079e+00, b = 1.384141e-01, c = 1.313298e-04;
+            dt = std::pow(a, b * depth) * c - c;
+            dt = fSampleTime / dt;
+        }
+
+        float phase = fPhase;
+        float lastValue = fLastValue;
+        hiir::Downsampler2xFpu<12>& downsampler2x = fDownsampler2x;
+
+        for (uint32_t i = 0; i < nframes; ++i) {
+            float x = in[i];
+
+            phase += dt;
+            float y = (phase > 1.0f) ? x : lastValue;
+            phase -= (int)phase;
+
+            float y2x[2];
+            y2x[0] = (y != lastValue) ? (0.5f * (y + lastValue)) : y;
+            y2x[1] = y;
+
+            lastValue = y;
+
+            y = downsampler2x.process_sample(y2x);
+            out[i] = y;
+        }
+
+        fPhase = phase;
+        fLastValue = lastValue;
+    }
+
+} // namespace fx
+} // namespace sfz

--- a/src/sfizz/effects/Lofi.cpp
+++ b/src/sfizz/effects/Lofi.cpp
@@ -120,7 +120,6 @@ namespace fx {
         }
 
         float lastValue = fLastValue;
-        hiir::Downsampler2xFpu<12>& downsampler2x = fDownsampler2x;
 
         const float steps = (1.0f + (100.0f - fDepth)) * 0.75f;
         const float invSteps = 1.0f / steps;
@@ -136,7 +135,7 @@ namespace fx {
 
             lastValue = y;
 
-            y = downsampler2x.process_sample(y2x);
+            y = fDownsampler2x.process_sample(y2x);
             out[i] = y;
         }
 
@@ -182,7 +181,6 @@ namespace fx {
 
         float phase = fPhase;
         float lastValue = fLastValue;
-        hiir::Downsampler2xFpu<12>& downsampler2x = fDownsampler2x;
 
         for (uint32_t i = 0; i < nframes; ++i) {
             float x = in[i];
@@ -197,7 +195,7 @@ namespace fx {
 
             lastValue = y;
 
-            y = downsampler2x.process_sample(y2x);
+            y = fDownsampler2x.process_sample(y2x);
             out[i] = y;
         }
 

--- a/src/sfizz/effects/Lofi.cpp
+++ b/src/sfizz/effects/Lofi.cpp
@@ -53,6 +53,11 @@ namespace fx {
         }
     }
 
+    void Lofi::setSamplesPerBlock(int samplesPerBlock)
+    {
+        (void)samplesPerBlock;
+    }
+
     void Lofi::clear()
     {
         for (unsigned c = 0; c < EffectChannels; ++c) {

--- a/src/sfizz/effects/Lofi.cpp
+++ b/src/sfizz/effects/Lofi.cpp
@@ -45,7 +45,7 @@
 namespace sfz {
 namespace fx {
 
-    void Lofi::init(double sampleRate)
+    void Lofi::setSampleRate(double sampleRate)
     {
         for (unsigned c = 0; c < EffectChannels; ++c) {
             _bitred[c].init(sampleRate);

--- a/src/sfizz/effects/Lofi.cpp
+++ b/src/sfizz/effects/Lofi.cpp
@@ -72,9 +72,9 @@ namespace fx {
         }
     }
 
-    Effect* Lofi::makeInstance(absl::Span<const Opcode> members)
+    std::unique_ptr<Effect> Lofi::makeInstance(absl::Span<const Opcode> members)
     {
-        std::unique_ptr<Lofi> fx { new Lofi };
+        auto fx = std::make_unique<Lofi>();
 
         for (const Opcode& opcode : members) {
             switch (opcode.lettersOnlyHash) {
@@ -87,7 +87,7 @@ namespace fx {
             }
         }
 
-        return fx.release();
+        return fx;
     }
 
     ///

--- a/src/sfizz/effects/Lofi.h
+++ b/src/sfizz/effects/Lofi.h
@@ -22,6 +22,12 @@ namespace fx {
         void setSampleRate(double sampleRate) override;
 
         /**
+         * @brief Sets the maximum number of frames to render at a time. The actual
+         * value can be lower but should never be higher.
+         */
+        void setSamplesPerBlock(int samplesPerBlock) override;
+
+        /**
          * @brief Reset the state to initial.
          */
         void clear() override;

--- a/src/sfizz/effects/Lofi.h
+++ b/src/sfizz/effects/Lofi.h
@@ -34,7 +34,7 @@ namespace fx {
         /**
           * @brief Instantiates given the contents of the <effect> block.
           */
-        static Effect* makeInstance(absl::Span<const Opcode> members);
+        static std::unique_ptr<Effect> makeInstance(absl::Span<const Opcode> members);
 
     private:
         float _bitred_depth = 0;

--- a/src/sfizz/effects/Lofi.h
+++ b/src/sfizz/effects/Lofi.h
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include "Effects.h"
+#include "hiir/Downsampler2xFpu.h"
+
+namespace sfz {
+namespace fx {
+
+    /**
+     * @brief Bit crushing effect
+     */
+    class Lofi : public Effect {
+    public:
+        /**
+         * @brief Initializes with the given sample rate.
+         */
+        void init(double sampleRate) override;
+
+        /**
+         * @brief Reset the state to initial.
+         */
+        void clear() override;
+
+        /**
+          * @brief Computes a cycle of the effect in stereo.
+          */
+        void process(const float* const inputs[], float* const outputs[], unsigned nframes) override;
+
+        /**
+          * @brief Instantiates given the contents of the <effect> block.
+          */
+        static Effect* makeInstance(absl::Span<const Opcode> members);
+
+    private:
+        float _bitred_depth = 0;
+        float _decim_depth = 0;
+
+        ///
+        class Bitred {
+        public:
+            void init(double sampleRate);
+            void clear();
+            void setDepth(float depth);
+            void process(const float* in, float* out, uint32_t nframes);
+
+        private:
+            float fDepth = 0.0;
+            float fLastValue = 0.0;
+            hiir::Downsampler2xFpu<12> fDownsampler2x;
+        };
+
+        ///
+        class Decim {
+        public:
+            void init(double sampleRate);
+            void clear();
+            void setDepth(float depth);
+            void process(const float* in, float* out, uint32_t nframes);
+
+        private:
+            float fSampleTime = 0.0;
+            float fDepth = 0.0;
+            float fPhase = 0.0;
+            float fLastValue = 0.0;
+            hiir::Downsampler2xFpu<12> fDownsampler2x;
+        };
+
+        ///
+        Bitred _bitred[EffectChannels];
+        Decim _decim[EffectChannels];
+    };
+
+} // namespace fx
+} // namespace sfz

--- a/src/sfizz/effects/Lofi.h
+++ b/src/sfizz/effects/Lofi.h
@@ -19,7 +19,7 @@ namespace fx {
         /**
          * @brief Initializes with the given sample rate.
          */
-        void init(double sampleRate) override;
+        void setSampleRate(double sampleRate) override;
 
         /**
          * @brief Reset the state to initial.

--- a/src/sfizz/effects/Nothing.cpp
+++ b/src/sfizz/effects/Nothing.cpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "Nothing.h"
+#include <cstring>
+
+namespace sfz {
+namespace fx {
+
+    void Nothing::init(double sampleRate)
+    {
+        (void)sampleRate;
+    }
+
+    void Nothing::clear()
+    {
+    }
+
+    void Nothing::process(const float* const inputs[], float* const outputs[], unsigned nframes)
+    {
+        for (unsigned c = 0; c < EffectChannels; ++c) {
+            if (inputs[c] != outputs[c])
+                std::memcpy(outputs[c], inputs[c], nframes * sizeof(float));
+        }
+    }
+
+} // namespace fx
+} // namespace sfz

--- a/src/sfizz/effects/Nothing.cpp
+++ b/src/sfizz/effects/Nothing.cpp
@@ -15,6 +15,11 @@ namespace fx {
         (void)sampleRate;
     }
 
+    void Nothing::setSamplesPerBlock(int samplesPerBlock)
+    {
+        (void)samplesPerBlock;
+    }
+
     void Nothing::clear()
     {
     }

--- a/src/sfizz/effects/Nothing.cpp
+++ b/src/sfizz/effects/Nothing.cpp
@@ -10,7 +10,7 @@
 namespace sfz {
 namespace fx {
 
-    void Nothing::init(double sampleRate)
+    void Nothing::setSampleRate(double sampleRate)
     {
         (void)sampleRate;
     }

--- a/src/sfizz/effects/Nothing.h
+++ b/src/sfizz/effects/Nothing.h
@@ -21,6 +21,12 @@ namespace fx {
         void setSampleRate(double sampleRate) override;
 
         /**
+         * @brief Sets the maximum number of frames to render at a time. The actual
+         * value can be lower but should never be higher.
+         */
+        void setSamplesPerBlock(int samplesPerBlock) override;
+
+        /**
          * @brief Reset the state to initial.
          */
         void clear() override;

--- a/src/sfizz/effects/Nothing.h
+++ b/src/sfizz/effects/Nothing.h
@@ -18,7 +18,7 @@ namespace fx {
         /**
          * @brief Initializes with the given sample rate.
          */
-        void init(double sampleRate) override;
+        void setSampleRate(double sampleRate) override;
 
         /**
          * @brief Reset the state to initial.

--- a/src/sfizz/effects/Nothing.h
+++ b/src/sfizz/effects/Nothing.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include "Effects.h"
+
+namespace sfz {
+namespace fx {
+
+    /**
+     * @brief Effect which does nothing
+     */
+    class Nothing : public Effect {
+    public:
+        /**
+         * @brief Initializes with the given sample rate.
+         */
+        void init(double sampleRate) override;
+
+        /**
+         * @brief Reset the state to initial.
+         */
+        void clear() override;
+
+        /**
+         * @brief Copy the input signal to the output
+         */
+        void process(const float* const inputs[], float* const outputs[], unsigned nframes) override;
+    };
+
+} // namespace fx
+} // namespace sfz

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -1350,6 +1350,23 @@ TEST_CASE("[Region] Parsing opcodes")
         region.parseOpcode({ "eq1_freqcc15", "50000" });
         REQUIRE(region.equalizers[0].frequencyCC[15] == 30000.0f);
     }
+
+    SECTION("Effects send")
+    {
+        REQUIRE(region.gainToEffect.size() == 1);
+        REQUIRE(region.gainToEffect[0] == 1.0f);
+        region.parseOpcode({ "effect1", "50.4" });
+        REQUIRE(region.gainToEffect.size() == 2);
+        REQUIRE(region.gainToEffect[1] == 0.504f);
+        region.parseOpcode({ "effect3", "100" });
+        REQUIRE(region.gainToEffect.size() == 4);
+        REQUIRE(region.gainToEffect[2] == 0.0f);
+        REQUIRE(region.gainToEffect[3] == 1.0f);
+        region.parseOpcode({ "effect3", "150.1" });
+        REQUIRE(region.gainToEffect[3] == 1.0f);
+        region.parseOpcode({ "effect3", "-50.65" });
+        REQUIRE(region.gainToEffect[3] == 0.0f);
+    }
 }
 
 // Specific region bugs

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -77,6 +77,7 @@ TEST_CASE("[Synth] Check that we can change the size of the preload before and a
 {
     sfz::Synth synth;
     synth.setPreloadSize(512);
+    synth.setSamplesPerBlock(blockSize);
     sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/groups_avl.sfz");
     synth.setPreloadSize(1024);
@@ -92,6 +93,7 @@ TEST_CASE("[Synth] Check that we can change the oversampling factor before and a
 {
     sfz::Synth synth;
     synth.setOversamplingFactor(sfz::Oversampling::x2);
+    synth.setSamplesPerBlock(blockSize);
     sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/groups_avl.sfz");
     synth.setOversamplingFactor(sfz::Oversampling::x4);

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -259,3 +259,63 @@ TEST_CASE("[Synth] No effect in the main bus")
     REQUIRE( bus->gainToMain() == 1 );
     REQUIRE( bus->gainToMix() == 0 );
 }
+
+TEST_CASE("[Synth] One effect")
+{
+    sfz::Synth synth;
+    synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Effects/bitcrusher_1.sfz");
+    auto bus = synth.getEffectBusView(0);
+    REQUIRE( bus != nullptr); // We have a main bus
+    REQUIRE( bus->numEffects() == 1 );
+    REQUIRE( bus->gainToMain() == 1 );
+    REQUIRE( bus->gainToMix() == 0 );
+}
+
+TEST_CASE("[Synth] Effect on a second bus")
+{
+    sfz::Synth synth;
+    synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Effects/bitcrusher_2.sfz");
+    auto bus = synth.getEffectBusView(0);
+    REQUIRE( bus != nullptr); // We have a main bus
+    REQUIRE( bus->numEffects() == 0 );
+    REQUIRE( bus->gainToMain() == 0.5 );
+    REQUIRE( bus->gainToMix() == 0 );
+    bus = synth.getEffectBusView(1);
+    REQUIRE( bus != nullptr);
+    REQUIRE( bus->numEffects() == 1 );
+    REQUIRE( bus->gainToMain() == 0.5 );
+    REQUIRE( bus->gainToMix() == 0 );
+}
+
+
+TEST_CASE("[Synth] Effect on a third bus")
+{
+    sfz::Synth synth;
+    synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Effects/bitcrusher_3.sfz");
+    auto bus = synth.getEffectBusView(0);
+    REQUIRE( bus != nullptr); // We have a main bus
+    REQUIRE( bus->numEffects() == 0 );
+    REQUIRE( bus->gainToMain() == 0.5 );
+    REQUIRE( bus->gainToMix() == 0 );
+    bus = synth.getEffectBusView(3);
+    REQUIRE( bus != nullptr);
+    REQUIRE( bus->numEffects() == 1 );
+    REQUIRE( bus->gainToMain() == 0.5 );
+    REQUIRE( bus->gainToMix() == 0 );
+}
+
+TEST_CASE("[Synth] Gain to mix")
+{
+    sfz::Synth synth;
+    synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Effects/to_mix.sfz");
+    auto bus = synth.getEffectBusView(0);
+    REQUIRE( bus != nullptr); // We have a main bus
+    REQUIRE( bus->numEffects() == 0 );
+    REQUIRE( bus->gainToMain() == 1 );
+    REQUIRE( bus->gainToMix() == 0 );
+    bus = synth.getEffectBusView(1);
+    REQUIRE( bus != nullptr);
+    REQUIRE( bus->numEffects() == 1 );
+    REQUIRE( bus->gainToMain() == 0 );
+    REQUIRE( bus->gainToMix() == 0.5 );
+}

--- a/tests/TestFiles/Effects/base.sfz
+++ b/tests/TestFiles/Effects/base.sfz
@@ -1,0 +1,4 @@
+<region>
+lokey=0
+hikey=127
+sample=*sine

--- a/tests/TestFiles/Effects/bitcrusher_1.sfz
+++ b/tests/TestFiles/Effects/bitcrusher_1.sfz
@@ -1,0 +1,9 @@
+<region>
+lokey=0
+hikey=127
+sample=*sine
+
+<effect>
+type=lofi
+bitred=90
+decim=10

--- a/tests/TestFiles/Effects/bitcrusher_2.sfz
+++ b/tests/TestFiles/Effects/bitcrusher_2.sfz
@@ -1,0 +1,13 @@
+<region>
+lokey=0
+hikey=127
+sample=*sine
+effect1=100
+
+<effect>
+directtomain=50
+fx1tomain=50
+type=lofi
+bus=fx1
+bitred=90
+decim=10

--- a/tests/TestFiles/Effects/bitcrusher_3.sfz
+++ b/tests/TestFiles/Effects/bitcrusher_3.sfz
@@ -1,0 +1,13 @@
+<region>
+lokey=0
+hikey=127
+sample=*sine
+effect1=100
+
+<effect>
+directtomain=50
+fx3tomain=50
+type=lofi
+bus=fx3
+bitred=90
+decim=10

--- a/tests/TestFiles/Effects/to_mix.sfz
+++ b/tests/TestFiles/Effects/to_mix.sfz
@@ -1,0 +1,11 @@
+<region>
+lokey=0
+hikey=127
+sample=*sine
+
+<effect>
+fx1tomix=50
+bus=fx1
+type=lofi
+bitred=90
+decim=10

--- a/tests/TestFiles/Effects/to_mix.sfz
+++ b/tests/TestFiles/Effects/to_mix.sfz
@@ -2,6 +2,7 @@
 lokey=0
 hikey=127
 sample=*sine
+effect1=100
 
 <effect>
 fx1tomix=50


### PR DESCRIPTION
Add effects and their routing. Work in progress

- Effect factory

Designed such that it can receive user-defined effects.
An effect is designated by its "type" opcode.

- Routing with main bus and up to 256 effect buses
- Mixing per-region
- Basic "lofi" effect to start which is relatively CW-compliant

**TODO**
- review the mixing behavior in case of use of main/fx buses together, or one of these only

There are still some things and dirty and it's not tried.
Regardless, I submit the code for review if you would like to have a peek.

Remark: I would like if we can introduce HIIR downsampler separately of this PR