### PR TITLE
Changed the way the parser handles multiple parameters in opcodes

### DIFF
--- a/src/sfizz/Opcode.cpp
+++ b/src/sfizz/Opcode.cpp
@@ -24,11 +24,11 @@ sfz::Opcode::Opcode(absl::string_view inputOpcode, absl::string_view inputValue)
         nextCharIndex = opcode.find_first_not_of("1234567890", nextNumIndex);
 
         uint32_t returnedValue;
-        hasBackParameter = (nextCharIndex == opcode.npos);
-        const auto numDigits = hasBackParameter ? opcode.npos : nextCharIndex - nextNumIndex;
+        const auto numDigits = (nextCharIndex == opcode.npos) ? opcode.npos : nextCharIndex - nextNumIndex;
         if (absl::SimpleAtoi(opcode.substr(nextNumIndex, numDigits), &returnedValue)) {
             // ASSERT(returnedValue < std::numeric_limits<uint8_t>::max());
-            parameterPositions.push_back(parameterPosition);
+            // parameterPositions.push_back(parameterPosition);
+            lettersOnlyHash = hash("&", lettersOnlyHash);
             parameters.push_back(returnedValue);
         }
 
@@ -37,34 +37,4 @@ sfz::Opcode::Opcode(absl::string_view inputOpcode, absl::string_view inputValue)
 
     if (nextCharIndex != opcode.npos)
         lettersOnlyHash = hash(opcode.substr(nextCharIndex), lettersOnlyHash);
-}
-
-absl::optional<uint8_t> sfz::Opcode::backParameter() const noexcept
-{
-    if (hasBackParameter && !parameters.empty())
-        return parameters.back();
-
-    return {};
-}
-
-absl::optional<uint8_t> sfz::Opcode::firstParameter() const noexcept
-{
-    if (!hasBackParameter && !parameters.empty())
-        return parameters.front();
-
-    if (hasBackParameter && parameters.size() > 1)
-        return parameters.front();
-
-    return {};
-}
-
-absl::optional<uint8_t> sfz::Opcode::middleParameter() const noexcept
-{
-    if (!hasBackParameter && parameters.size() > 1)
-        return parameters[1];
-
-    if (hasBackParameter && parameters.size() > 2)
-        return parameters[1];
-
-    return {};
 }

--- a/src/sfizz/Opcode.cpp
+++ b/src/sfizz/Opcode.cpp
@@ -26,8 +26,6 @@ sfz::Opcode::Opcode(absl::string_view inputOpcode, absl::string_view inputValue)
         uint32_t returnedValue;
         const auto numDigits = (nextCharIndex == opcode.npos) ? opcode.npos : nextCharIndex - nextNumIndex;
         if (absl::SimpleAtoi(opcode.substr(nextNumIndex, numDigits), &returnedValue)) {
-            // ASSERT(returnedValue < std::numeric_limits<uint8_t>::max());
-            // parameterPositions.push_back(parameterPosition);
             lettersOnlyHash = hash("&", lettersOnlyHash);
             parameters.push_back(returnedValue);
         }

--- a/src/sfizz/Opcode.cpp
+++ b/src/sfizz/Opcode.cpp
@@ -20,7 +20,7 @@ sfz::Opcode::Opcode(absl::string_view inputOpcode, absl::string_view inputValue)
     while (nextNumIndex != opcode.npos) {
         const auto numLetters = nextNumIndex - nextCharIndex;
         parameterPosition += numLetters;
-        lettersOnlyHash = hash(opcode.substr(nextCharIndex, numLetters), lettersOnlyHash);
+        lettersOnlyHash = hashNoAmpersand(opcode.substr(nextCharIndex, numLetters), lettersOnlyHash);
         nextCharIndex = opcode.find_first_not_of("1234567890", nextNumIndex);
 
         uint32_t returnedValue;
@@ -34,5 +34,5 @@ sfz::Opcode::Opcode(absl::string_view inputOpcode, absl::string_view inputValue)
     }
 
     if (nextCharIndex != opcode.npos)
-        lettersOnlyHash = hash(opcode.substr(nextCharIndex), lettersOnlyHash);
+        lettersOnlyHash = hashNoAmpersand(opcode.substr(nextCharIndex), lettersOnlyHash);
 }

--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -31,7 +31,7 @@ struct Opcode {
     absl::string_view value {};
     uint64_t lettersOnlyHash { Fnv1aBasis };
     // This is to handle the integer parameters of some opcodes
-    std::vector<uint8_t> parameters;
+    std::vector<uint16_t> parameters;
     LEAK_DETECTOR(Opcode);
 };
 

--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -26,17 +26,12 @@ namespace sfz {
  */
 struct Opcode {
     Opcode() = delete;
-    absl::optional<uint8_t> backParameter() const noexcept;
-    absl::optional<uint8_t> firstParameter() const noexcept;
-    absl::optional<uint8_t> middleParameter() const noexcept;
     Opcode(absl::string_view inputOpcode, absl::string_view inputValue);
     absl::string_view opcode {};
     absl::string_view value {};
     uint64_t lettersOnlyHash { Fnv1aBasis };
     // This is to handle the integer parameters of some opcodes
     std::vector<uint8_t> parameters;
-    std::vector<int> parameterPositions;
-    bool hasBackParameter { false };
     LEAK_DETECTOR(Opcode);
 };
 
@@ -192,9 +187,8 @@ template <class ValueType>
 inline void setCCPairFromOpcode(const Opcode& opcode, absl::optional<CCValuePair>& target, const Range<ValueType>& validRange)
 {
     auto value = readOpcode(opcode.value, validRange);
-    const auto backParameter = opcode.backParameter();
-    if (value && backParameter && Default::ccNumberRange.containsWithEnd(*backParameter))
-        target = std::make_pair(*backParameter, *value);
+    if (value && Default::ccNumberRange.containsWithEnd(opcode.parameters.back()))
+        target = std::make_pair(opcode.parameters.back(), *value);
     else
         target = {};
 }

--- a/src/sfizz/StringViewHelpers.h
+++ b/src/sfizz/StringViewHelpers.h
@@ -66,3 +66,24 @@ constexpr uint64_t hash(absl::string_view s, uint64_t h = Fnv1aBasis)
 
     return h;
 }
+
+/**
+ * @brief Same function as `hash()` but ignores ampersands (&)
+ *
+ * See e.g. the Region.cpp file
+ *
+ * @param s the input string to be hashed
+ * @param h the hashing seed to use
+ * @return uint64_t
+ */
+constexpr uint64_t hashNoAmpersand(absl::string_view s, uint64_t h = Fnv1aBasis)
+{
+    if (s.length() > 0) {
+        if (s.front() == '&')
+            return hashNoAmpersand( { s.data() + 1, s.length() - 1 }, h );
+        else
+            return hashNoAmpersand( { s.data() + 1, s.length() - 1 }, (h ^ s.front()) * Fnv1aPrime );
+    }
+
+    return h;
+}

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -153,21 +153,18 @@ void sfz::Synth::handleGlobalOpcodes(const std::vector<Opcode>& members)
 void sfz::Synth::handleControlOpcodes(const std::vector<Opcode>& members)
 {
     for (auto& member : members) {
-        const auto backParameter = member.backParameter();
         switch (member.lettersOnlyHash) {
-        case hash("Set_cc"):
-            [[fallthrough]];
-        case hash("set_cc"):
-            if (backParameter && Default::ccNumberRange.containsWithEnd(*backParameter)) {
+        case hash("Set_cc&"): [[fallthrough]];
+        case hash("set_cc&"):
+            if (Default::ccNumberRange.containsWithEnd(member.parameters.back())) {
                 const auto ccValue = readOpcode(member.value, Default::ccValueRange).value_or(0);
-                resources.midiState.ccEvent(*backParameter, ccValue);
+                resources.midiState.ccEvent(member.parameters.back(), ccValue);
             }
             break;
-        case hash("Label_cc"):
-            [[fallthrough]];
-        case hash("label_cc"):
-            if (backParameter && Default::ccNumberRange.containsWithEnd(*backParameter))
-                ccNames.emplace_back(*backParameter, std::string(member.value));
+        case hash("Label_cc&"): [[fallthrough]];
+        case hash("label_cc&"):
+            if (Default::ccNumberRange.containsWithEnd(member.parameters.back()))
+                ccNames.emplace_back(member.parameters.back(), std::string(member.value));
             break;
         case hash("Default_path"):
             [[fallthrough]];

--- a/tests/OpcodeT.cpp
+++ b/tests/OpcodeT.cpp
@@ -28,10 +28,38 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.value == "dummy");
     }
 
+    SECTION("Normal construction with ampersand")
+    {
+        sfz::Opcode opcode { "sample&_ampersand", "dummy" };
+        REQUIRE(opcode.opcode == "sample&_ampersand");
+        REQUIRE(opcode.lettersOnlyHash == hash("sample_ampersand"));
+        REQUIRE(opcode.parameters.empty());
+        REQUIRE(opcode.value == "dummy");
+    }
+
+    SECTION("Normal construction with multiple ampersands")
+    {
+        sfz::Opcode opcode { "&sample&_ampersand&", "dummy" };
+        REQUIRE(opcode.opcode == "&sample&_ampersand&");
+        REQUIRE(opcode.lettersOnlyHash == hash("sample_ampersand"));
+        REQUIRE(opcode.parameters.empty());
+        REQUIRE(opcode.value == "dummy");
+    }
+
     SECTION("Parameterized opcode")
     {
         sfz::Opcode opcode { "sample123", "dummy" };
         REQUIRE(opcode.opcode == "sample123");
+        REQUIRE(opcode.lettersOnlyHash == hash("sample&"));
+        REQUIRE(opcode.value == "dummy");
+        REQUIRE(opcode.parameters.size() == 1);
+        REQUIRE(opcode.parameters == std::vector<uint16_t>({ 123 }));
+    }
+
+    SECTION("Parameterized opcode with ampersand")
+    {
+        sfz::Opcode opcode { "sample&123", "dummy" };
+        REQUIRE(opcode.opcode == "sample&123");
         REQUIRE(opcode.lettersOnlyHash == hash("sample&"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters.size() == 1);

--- a/tests/OpcodeT.cpp
+++ b/tests/OpcodeT.cpp
@@ -35,7 +35,7 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.lettersOnlyHash == hash("sample&"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters.size() == 1);
-        REQUIRE(opcode.parameters == std::vector<uint8_t>({ 123 }));
+        REQUIRE(opcode.parameters == std::vector<uint16_t>({ 123 }));
     }
 
     SECTION("Parameterized opcode with underscore")
@@ -44,7 +44,7 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.opcode == "sample_underscore123");
         REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore&"));
         REQUIRE(opcode.value == "dummy");
-        REQUIRE(opcode.parameters == std::vector<uint8_t>({ 123 }));
+        REQUIRE(opcode.parameters == std::vector<uint16_t>({ 123 }));
     }
 
     SECTION("Parameterized opcode within the opcode")
@@ -53,7 +53,7 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.opcode == "sample1_underscore");
         REQUIRE(opcode.lettersOnlyHash == hash("sample&_underscore"));
         REQUIRE(opcode.value == "dummy");
-        REQUIRE(opcode.parameters == std::vector<uint8_t>({ 1 }));
+        REQUIRE(opcode.parameters == std::vector<uint16_t>({ 1 }));
     }
 
     SECTION("Parameterized opcode within the opcode")
@@ -75,7 +75,7 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.parameters.size() == 2);
         REQUIRE(opcode.parameters[0] == 123);
         REQUIRE(opcode.parameters[1] == 44);
-        REQUIRE(opcode.parameters == std::vector<uint8_t>({ 123, 44 }));
+        REQUIRE(opcode.parameters == std::vector<uint16_t>({ 123, 44 }));
     }
 
     SECTION("Parameterized opcode within the opcode twice, with a back parameter")
@@ -85,7 +85,7 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.lettersOnlyHash == hash("sample&_double&_underscore&"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters.size() == 3);
-        REQUIRE(opcode.parameters == std::vector<uint8_t>({ 123, 44, 23 }));
+        REQUIRE(opcode.parameters == std::vector<uint16_t>({ 123, 44, 23 }));
     }
 }
 

--- a/tests/OpcodeT.cpp
+++ b/tests/OpcodeT.cpp
@@ -17,9 +17,6 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.lettersOnlyHash == hash("sample"));
         REQUIRE(opcode.parameters.empty());
         REQUIRE(opcode.value == "dummy");
-        REQUIRE(!opcode.backParameter());
-        REQUIRE(!opcode.firstParameter());
-        REQUIRE(!opcode.middleParameter());
     }
 
     SECTION("Normal construction with underscore")
@@ -29,56 +26,41 @@ TEST_CASE("[Opcode] Construction")
         REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore"));
         REQUIRE(opcode.parameters.empty());
         REQUIRE(opcode.value == "dummy");
-        REQUIRE(!opcode.backParameter());
-        REQUIRE(!opcode.firstParameter());
-        REQUIRE(!opcode.middleParameter());
     }
 
     SECTION("Parameterized opcode")
     {
         sfz::Opcode opcode { "sample123", "dummy" };
         REQUIRE(opcode.opcode == "sample123");
-        REQUIRE(opcode.lettersOnlyHash == hash("sample"));
+        REQUIRE(opcode.lettersOnlyHash == hash("sample&"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters.size() == 1);
         REQUIRE(opcode.parameters == std::vector<uint8_t>({ 123 }));
-        REQUIRE(opcode.parameterPositions == std::vector<int>({ 6 }));
-        REQUIRE(opcode.backParameter());
-        REQUIRE(*opcode.backParameter() == 123);
-        REQUIRE(!opcode.firstParameter());
-        REQUIRE(!opcode.middleParameter());
     }
 
     SECTION("Parameterized opcode with underscore")
     {
         sfz::Opcode opcode { "sample_underscore123", "dummy" };
         REQUIRE(opcode.opcode == "sample_underscore123");
-        REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore"));
+        REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore&"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters == std::vector<uint8_t>({ 123 }));
-        REQUIRE(opcode.parameterPositions == std::vector<int>({ 17 }));
-        REQUIRE(opcode.backParameter());
-        REQUIRE(*opcode.backParameter() == 123);
     }
 
     SECTION("Parameterized opcode within the opcode")
     {
         sfz::Opcode opcode { "sample1_underscore", "dummy" };
         REQUIRE(opcode.opcode == "sample1_underscore");
-        REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore"));
+        REQUIRE(opcode.lettersOnlyHash == hash("sample&_underscore"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters == std::vector<uint8_t>({ 1 }));
-        REQUIRE(!opcode.backParameter());
-        REQUIRE(opcode.firstParameter());
-        REQUIRE(*opcode.firstParameter() == 1);
-        REQUIRE(!opcode.middleParameter());
     }
 
     SECTION("Parameterized opcode within the opcode")
     {
         sfz::Opcode opcode { "sample123_underscore", "dummy" };
         REQUIRE(opcode.opcode == "sample123_underscore");
-        REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore"));
+        REQUIRE(opcode.lettersOnlyHash == hash("sample&_underscore"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters.size() == 1);
         REQUIRE(opcode.parameters[0] == 123);
@@ -88,35 +70,22 @@ TEST_CASE("[Opcode] Construction")
     {
         sfz::Opcode opcode { "sample123_double44_underscore", "dummy" };
         REQUIRE(opcode.opcode == "sample123_double44_underscore");
-        REQUIRE(opcode.lettersOnlyHash == hash("sample_double_underscore"));
+        REQUIRE(opcode.lettersOnlyHash == hash("sample&_double&_underscore"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters.size() == 2);
         REQUIRE(opcode.parameters[0] == 123);
         REQUIRE(opcode.parameters[1] == 44);
         REQUIRE(opcode.parameters == std::vector<uint8_t>({ 123, 44 }));
-        REQUIRE(opcode.parameterPositions == std::vector<int>({ 6, 13 }));
-        REQUIRE(!opcode.backParameter());
-        REQUIRE(opcode.firstParameter());
-        REQUIRE(*opcode.firstParameter() == 123);
-        REQUIRE(opcode.middleParameter());
-        REQUIRE(*opcode.middleParameter() == 44);
     }
 
     SECTION("Parameterized opcode within the opcode twice, with a back parameter")
     {
         sfz::Opcode opcode { "sample123_double44_underscore23", "dummy" };
         REQUIRE(opcode.opcode == "sample123_double44_underscore23");
-        REQUIRE(opcode.lettersOnlyHash == hash("sample_double_underscore"));
+        REQUIRE(opcode.lettersOnlyHash == hash("sample&_double&_underscore&"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters.size() == 3);
         REQUIRE(opcode.parameters == std::vector<uint8_t>({ 123, 44, 23 }));
-        REQUIRE(opcode.parameterPositions == std::vector<int>({ 6, 13, 24 }));
-        REQUIRE(opcode.backParameter());
-        REQUIRE(*opcode.backParameter() == 23);
-        REQUIRE(opcode.firstParameter());
-        REQUIRE(*opcode.firstParameter() == 123);
-        REQUIRE(opcode.middleParameter());
-        REQUIRE(*opcode.middleParameter() == 44);
     }
 }
 


### PR DESCRIPTION
Idea from @jpcima :)

The resulting code is much cleaner and properly handles wrong positioning of parameters, with basically no cost. Also changed the parameters to be `u16` to handle values larger than 256 for the CC number.