### PR TITLE
Add a clang-tidy check on CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,38 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,performance-*,-abseil-no-internal-dependencies'
+WarningsAsErrors: 'clang-diagnostic-*,clang-analyzer-*,abseil-*,bugprone-*,performance-*'
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+User:            paul
+CheckOptions:
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,31 @@ jobs:
     after_success:
     - true
 
+  - os:   linux
+    dist: bionic
+    env:
+    - BUILD_TYPE=tidy
+    addons:
+      apt:
+        packages:
+        - clang-tidy
+        - libsndfile-dev
+
+    before_install:
+    - true
+
+    install:
+    - true
+
+    script:
+    - scripts/run_clang_tidy.sh
+
+    after_failure:
+    - true
+
+    after_success:
+    - true
+
 before_install:
 - bash ${TRAVIS_BUILD_DIR}/.travis/before_install.sh
 

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+clang-tidy \
+  src/sfizz/ADSREnvelope.cpp \
+  src/sfizz/Effects.cpp \
+  src/sfizz/EQPool.cpp \
+  src/sfizz/EventEnvelopes.cpp \
+  src/sfizz/FilePool.cpp \
+  src/sfizz/FilterPool.cpp \
+  src/sfizz/FloatEnvelopes.cpp \
+  src/sfizz/Logger.cpp \
+  src/sfizz/MidiState.cpp \
+  src/sfizz/Opcode.cpp \
+  src/sfizz/Oversampler.cpp \
+  src/sfizz/Parser.cpp \
+  src/sfizz/sfizz.cpp \
+  src/sfizz/Region.cpp \
+  src/sfizz/SfzHelpers.cpp \
+  src/sfizz/SIMDSSE.cpp \
+  src/sfizz/Synth.cpp \
+  src/sfizz/Voice.cpp \
+  src/sfizz/effects/Lofi.cpp \
+  src/sfizz/effects/Nothing.cpp \
+  -- -Iexternal/abseil-cpp -Isrc/external -Isrc/external/pugixml/src -Isrc/sfizz -Isrc

--- a/src/sfizz/ADSREnvelope.cpp
+++ b/src/sfizz/ADSREnvelope.cpp
@@ -178,7 +178,8 @@ void ADSREnvelope<Type>::getBlock(absl::Span<Type> output) noexcept
 
     if (shouldRelease) {
         remainingSamples = static_cast<int>(originalSpan.size());
-        if (releaseDelay > remainingSamples) {
+        if (releaseDelay > remainingSamples)
+        {
             releaseDelay -= remainingSamples;
             return;
         }

--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -125,7 +125,7 @@ namespace Default
 	constexpr Range<float> rtDecayRange { 0.0f, 200.0f };
 
     // Performance parameters: Filters
-    constexpr float numFilters { 2 };
+    constexpr int numFilters { 2 };
     constexpr float filterCutoff { 0 };
     constexpr float filterResonance { 0 };
     constexpr float filterGain { 0 };
@@ -147,7 +147,7 @@ namespace Default
     constexpr Range<float> filterResonanceModRange { 0.0f, 96.0f };
 
     // Performance parameters: EQ
-    constexpr float numEQs { 3 };
+    constexpr int numEQs { 3 };
     constexpr float eqBandwidth { 1.0f };
     constexpr float eqBandwidthCC { 0.0f };
     constexpr float eqFrequencyUnset { 0.0f };

--- a/src/sfizz/FilePool.cpp
+++ b/src/sfizz/FilePool.cpp
@@ -218,7 +218,7 @@ bool sfz::FilePool::preloadFile(const std::string& filename, uint32_t maxOffset)
     } else {
         preloadedFiles.insert_or_assign(filename, {
             readFromFile<float>(sndFile, framesToLoad, oversamplingFactor),
-            static_cast<float>(oversamplingFactor) * sndFile.samplerate()
+            static_cast<float>(oversamplingFactor) * static_cast<float>(sndFile.samplerate())
         });
     }
 

--- a/src/sfizz/FilterPool.cpp
+++ b/src/sfizz/FilterPool.cpp
@@ -31,7 +31,7 @@ void sfz::FilterHolder::setup(const FilterDescription& description, unsigned num
     }
     const auto keytrack = description.keytrack * (noteNumber - description.keycenter);
     baseCutoff *= centsFactor(keytrack);
-    const auto veltrack = description.veltrack * normalizeVelocity(velocity);
+    const auto veltrack = static_cast<float>(description.veltrack) * normalizeVelocity(velocity);
     baseCutoff *= centsFactor(veltrack);
     baseCutoff = Default::filterCutoffRange.clamp(baseCutoff);
 

--- a/src/sfizz/Logger.cpp
+++ b/src/sfizz/Logger.cpp
@@ -98,12 +98,12 @@ sfz::Logger::~Logger()
 }
 
 
-void sfz::Logger::logCallbackTime(CallbackBreakdown&& breakdown, int numVoices, size_t numSamples)
+void sfz::Logger::logCallbackTime(const CallbackBreakdown& breakdown, int numVoices, size_t numSamples)
 {
     if (!loggingEnabled)
         return;
 
-    callbackTimeQueue.try_push<CallbackTime>({ std::move(breakdown), numVoices, numSamples });
+    callbackTimeQueue.try_push<CallbackTime>({ breakdown, numVoices, numSamples });
 }
 
 void sfz::Logger::logFileTime(std::chrono::duration<double> waitDuration, std::chrono::duration<double> loadDuration, uint32_t fileSize, absl::string_view filename)

--- a/src/sfizz/Logger.h
+++ b/src/sfizz/Logger.h
@@ -108,7 +108,7 @@ public:
      * @param numVoices The number of active voices
      * @param numSamples The number of samples in the callback
      */
-    void logCallbackTime(CallbackBreakdown&& breakdown, int numVoices, size_t numSamples);
+    void logCallbackTime(const CallbackBreakdown& breakdown, int numVoices, size_t numSamples);
 
     /**
      * @brief Log a file loading and waiting duration

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -250,7 +250,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
     case hash("volume"):
         setValueFromOpcode(opcode, volume, Default::volumeRange);
         break;
-    case hash("gain_cc&"): [[fallthrough]];
+    case hash("gain_cc&"):
     case hash("gain_oncc&"): [[fallthrough]];
     case hash("volume_oncc&"):
         setCCPairFromOpcode(opcode, volumeCC, Default::volumeCCRange);
@@ -395,8 +395,8 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             setValueFromOpcode(opcode, filters[filterIndex].resonance, Default::filterResonanceRange);
         }
         break;
-    case hash("cutoff_oncc&"): [[fallthrough]];
-    case hash("cutoff_cc&"): [[fallthrough]];
+    case hash("cutoff_oncc&"):
+    case hash("cutoff_cc&"):
     case hash("cutoff&_oncc&"): [[fallthrough]];
     case hash("cutoff&_cc&"):
         {
@@ -411,8 +411,8 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             );
         }
         break;
-    case hash("resonance&_oncc&"): [[fallthrough]];
-    case hash("resonance&_cc&"): [[fallthrough]];
+    case hash("resonance&_oncc&"):
+    case hash("resonance&_cc&"):
     case hash("resonance_oncc&"): [[fallthrough]];
     case hash("resonance_cc&"):
         {

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -567,7 +567,7 @@ void sfz::Synth::renderBlock(AudioSpan<float> buffer) noexcept
     buffer.applyGain(db2mag(volume));
 
     callbackBreakdown.dispatch = dispatchDuration;
-    resources.logger.logCallbackTime(std::move(callbackBreakdown), numActiveVoices, numFrames);
+    resources.logger.logCallbackTime(callbackBreakdown, numActiveVoices, numFrames);
 
     // Reset the dispatch counter
     dispatchDuration = Duration(0);
@@ -938,7 +938,7 @@ void sfz::Synth::resetAllControllers(int delay) noexcept
 fs::file_time_type sfz::Synth::checkModificationTime()
 {
     auto returnedTime = modificationTime;
-    for (auto file: getIncludedFiles()) {
+    for (const auto& file: getIncludedFiles()) {
         const auto fileTime = fs::last_write_time(file);
         if (returnedTime < fileTime)
             returnedTime = fileTime;

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -82,7 +82,7 @@ void sfz::Voice::startVoice(Region* region, int delay, int number, uint8_t value
 
     pitchBendEnvelope.setFunction([region](float pitchValue){
         const auto normalizedBend = normalizeBend(pitchValue);
-        const auto bendInCents = normalizedBend > 0.0f ? normalizedBend * region->bendUp : -normalizedBend * region->bendDown;
+        const auto bendInCents = normalizedBend > 0.0f ? normalizedBend * static_cast<float>(region->bendUp) : -normalizedBend * static_cast<float>(region->bendDown);
         return centsFactor(bendInCents);
     });
     pitchBendEnvelope.reset(static_cast<float>(resources.midiState.getPitchBend()));
@@ -106,7 +106,7 @@ void sfz::Voice::startVoice(Region* region, int delay, int number, uint8_t value
 
     sourcePosition = region->getOffset();
     triggerDelay = delay;
-    initialDelay = delay + static_cast<uint32_t>(region->getDelay() * sampleRate);
+    initialDelay = delay + static_cast<int>(region->getDelay() * sampleRate);
     baseFrequency = midiNoteFrequency(number);
     bendStepFactor = centsFactor(region->bendStep);
     egEnvelope.reset(*region, resources.midiState, delay, value, sampleRate);

--- a/src/sfizz/effects/Lofi.cpp
+++ b/src/sfizz/effects/Lofi.cpp
@@ -132,7 +132,7 @@ namespace fx {
         for (uint32_t i = 0; i < nframes; ++i) {
             float x = in[i];
 
-            float y = std::copysign((int)(0.5f + std::fabs(x * steps)), x) * invSteps;
+            float y = std::copysign((int)(0.5f + std::fabs(x * steps)), x) * invSteps; // NOLINT
 
             float y2x[2];
             y2x[0] = (y != lastValue) ? (0.5f * (y + lastValue)) : y;
@@ -150,7 +150,7 @@ namespace fx {
     ///
     void Lofi::Decim::init(double sampleRate)
     {
-        fSampleTime = 1.0 / sampleRate;
+        fSampleTime = 1.0f / static_cast<float>(sampleRate);
 
         static constexpr double coefs2x[12] = { 0.036681502163648017, 0.13654762463195794, 0.27463175937945444, 0.42313861743656711, 0.56109869787919531, 0.67754004997416184, 0.76974183386322703, 0.83988962484963892, 0.89226081800387902, 0.9315419599631839, 0.96209454837808417, 0.98781637073289585 };
         fDownsampler2x.set_coefs(coefs2x);
@@ -192,7 +192,7 @@ namespace fx {
 
             phase += dt;
             float y = (phase > 1.0f) ? x : lastValue;
-            phase -= static_cast<int>(phase);
+            phase -= static_cast<float>(static_cast<int>(phase));
 
             float y2x[2];
             y2x[0] = (y != lastValue) ? (0.5f * (y + lastValue)) : y;


### PR DESCRIPTION
If a warning is too aggressive/unneeded, you can deactivate the line by appending `// NOLINT` at the end, or `// NOLINTNEXTLINE` on the line above.