### PR TITLE
Trying to get gcc 4.9 to compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,6 @@ jobs:
 
   - name: "macOS"
     os: osx
-    osx_image: xcode10.1
     env:
     - INSTALL_DIR="sfizz-${TRAVIS_BRANCH}-${TRAVIS_OS_NAME}-${TRAVIS_CPU_ARCH}"
     install: .travis/install_osx.sh

--- a/benchmarks/BM_ADSR.cpp
+++ b/benchmarks/BM_ADSR.cpp
@@ -30,7 +30,7 @@ public:
         output.resize(state.range(0));
     }
 
-    void TearDown(const ::benchmark::State &state[[maybe_unused]])
+    void TearDown(const ::benchmark::State& /* state */)
     {
     }
 

--- a/benchmarks/BM_add.cpp
+++ b/benchmarks/BM_add.cpp
@@ -5,6 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "SIMDHelpers.h"
+#include "Macros.h"
 #include <benchmark/benchmark.h>
 #include <random>
 #include <numeric>
@@ -24,8 +25,8 @@ public:
     std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
-
+  void TearDown(const ::benchmark::State& state) {
+      UNUSED(state);
   }
 
   std::vector<float> input;

--- a/benchmarks/BM_clock.cpp
+++ b/benchmarks/BM_clock.cpp
@@ -9,11 +9,11 @@
 
 class Clock : public benchmark::Fixture {
 public:
-  void SetUp(const ::benchmark::State& state) {
+  void SetUp(const ::benchmark::State& /* state */) {
 
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/benchmarks/BM_copy.cpp
+++ b/benchmarks/BM_copy.cpp
@@ -24,7 +24,7 @@ public:
     std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/benchmarks/BM_cumsum.cpp
+++ b/benchmarks/BM_cumsum.cpp
@@ -23,7 +23,7 @@ public:
     std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/benchmarks/BM_diff.cpp
+++ b/benchmarks/BM_diff.cpp
@@ -25,7 +25,7 @@ public:
     sfz::cumsum<float, false>(input, absl::MakeSpan(input));
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/benchmarks/BM_divide.cpp
+++ b/benchmarks/BM_divide.cpp
@@ -26,7 +26,7 @@ public:
     std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/benchmarks/BM_envelopes.cpp
+++ b/benchmarks/BM_envelopes.cpp
@@ -23,7 +23,7 @@ public:
         sfz::cumsum<float, false>(input, absl::MakeSpan(input));
     }
 
-    void TearDown(const ::benchmark::State& state [[maybe_unused]])
+    void TearDown(const ::benchmark::State& /* state */)
     {
 
     }

--- a/benchmarks/BM_filterModulation.cpp
+++ b/benchmarks/BM_filterModulation.cpp
@@ -32,7 +32,7 @@ public:
         std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
     }
 
-    void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+    void TearDown(const ::benchmark::State& /* state */) {
 
     }
     std::random_device rd { };

--- a/benchmarks/BM_filterStereoMono.cpp
+++ b/benchmarks/BM_filterStereoMono.cpp
@@ -35,7 +35,7 @@ public:
         std::generate(inputRight.begin(), inputRight.end(), [&]() { return dist(gen); });
     }
 
-    void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+    void TearDown(const ::benchmark::State& /* state */) {
 
     }
     std::random_device rd { };

--- a/benchmarks/BM_flacfile.cpp
+++ b/benchmarks/BM_flacfile.cpp
@@ -10,6 +10,7 @@
 #define DR_FLAC_IMPLEMENTATION
 #include "dr_flac.h"
 #include "ghc/filesystem.hpp"
+#include "absl/memory/memory.h"
 #include <memory>
 #ifndef NDEBUG
 #include <iostream>
@@ -60,7 +61,7 @@ BENCHMARK_DEFINE_F(FileFixture, SndFile)(benchmark::State& state) {
     for (auto _ : state)
     {
         SndfileHandle sndfile(filePath1.c_str());
-        buffer = std::make_unique<sfz::Buffer<float>>(sndfile.channels() * sndfile.frames());
+        buffer = absl::make_unique<sfz::Buffer<float>>(sndfile.channels() * sndfile.frames());
         sndfile.readf(buffer->data(), sndfile.frames());
     }
 }
@@ -69,7 +70,7 @@ BENCHMARK_DEFINE_F(FileFixture, DrFlac)(benchmark::State& state) {
     for (auto _ : state)
     {
         auto* flac = drflac_open_file(filePath2.c_str(), nullptr);
-        buffer = std::make_unique<sfz::Buffer<float>>(flac->channels * flac->totalPCMFrameCount);
+        buffer = absl::make_unique<sfz::Buffer<float>>(flac->channels * flac->totalPCMFrameCount);
         drflac_read_pcm_frames_f32(flac, flac->totalPCMFrameCount, buffer->data());
     }
 }

--- a/benchmarks/BM_flacfile.cpp
+++ b/benchmarks/BM_flacfile.cpp
@@ -18,7 +18,7 @@
 
 class FileFixture : public benchmark::Fixture {
 public:
-    void SetUp(const ::benchmark::State& state [[maybe_unused]]) {
+    void SetUp(const ::benchmark::State& state) {
         filePath1 = getPath() / "sample1.flac";
         filePath2 = getPath() / "sample2.flac";
         filePath3 = getPath() / "sample3.flac";
@@ -32,7 +32,7 @@ public:
         }
     }
 
-    void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+    void TearDown(const ::benchmark::State& /* state */) {
     }
 
     ghc::filesystem::path getPath()

--- a/benchmarks/BM_gain.cpp
+++ b/benchmarks/BM_gain.cpp
@@ -24,7 +24,7 @@ public:
     std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 
@@ -46,7 +46,7 @@ public:
     std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/benchmarks/BM_interpolationCast.cpp
+++ b/benchmarks/BM_interpolationCast.cpp
@@ -28,7 +28,7 @@ public:
     absl::c_generate(floatJumps, [&]() { return dist(gen); });
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/benchmarks/BM_logger.cpp
+++ b/benchmarks/BM_logger.cpp
@@ -10,11 +10,11 @@
 
 class Logger : public benchmark::Fixture {
 public:
-  void SetUp(const ::benchmark::State& state) {
+  void SetUp(const ::benchmark::State& /* state */) {
 
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/benchmarks/BM_looping.cpp
+++ b/benchmarks/BM_looping.cpp
@@ -30,7 +30,7 @@ public:
     absl::c_generate(jumps, [&]() { return dist(gen); });
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/benchmarks/BM_maps.cpp
+++ b/benchmarks/BM_maps.cpp
@@ -36,7 +36,7 @@ public:
         });
     }
 
-    void TearDown(const ::benchmark::State& state [[maybe_unused]])
+    void TearDown(const ::benchmark::State& /* state */)
     {
     }
 

--- a/benchmarks/BM_mathfuns.cpp
+++ b/benchmarks/BM_mathfuns.cpp
@@ -26,7 +26,7 @@ public:
         std::generate(source.begin(), source.end(), [&]() { return dist(gen); });
     }
 
-    void TearDown(const ::benchmark::State& state [[maybe_unused]])
+    void TearDown(const ::benchmark::State& /* state */)
     {
     }
 

--- a/benchmarks/BM_mean.cpp
+++ b/benchmarks/BM_mean.cpp
@@ -23,7 +23,7 @@ public:
         std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
     }
 
-    void TearDown(const ::benchmark::State& state [[maybe_unused]])
+    void TearDown(const ::benchmark::State& /* state */)
     {
     }
 

--- a/benchmarks/BM_meanSquared.cpp
+++ b/benchmarks/BM_meanSquared.cpp
@@ -23,7 +23,7 @@ public:
         std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
     }
 
-    void TearDown(const ::benchmark::State& state [[maybe_unused]])
+    void TearDown(const ::benchmark::State& /* state */)
     {
     }
 

--- a/benchmarks/BM_multiplyAdd.cpp
+++ b/benchmarks/BM_multiplyAdd.cpp
@@ -26,7 +26,7 @@ public:
     std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/benchmarks/BM_multiplyAddFixedGain.cpp
+++ b/benchmarks/BM_multiplyAddFixedGain.cpp
@@ -26,7 +26,7 @@ public:
         std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
     }
 
-    void TearDown(const ::benchmark::State& state [[maybe_unused]])
+    void TearDown(const ::benchmark::State& /* state */)
     {
     }
 

--- a/benchmarks/BM_pan.cpp
+++ b/benchmarks/BM_pan.cpp
@@ -33,7 +33,7 @@ public:
     span2 = absl::MakeSpan(temp2);
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/benchmarks/BM_pan.cpp
+++ b/benchmarks/BM_pan.cpp
@@ -69,7 +69,7 @@ BENCHMARK_DEFINE_F(PanArray, BlockOps)(benchmark::State& state) {
     {
         sfz::fill<float>(span2, 1.0f);
         sfz::add<float>(span1, span2);
-        sfz::applyGain<float>(piFour<float>, span2);
+        sfz::applyGain<float>(piFour<float>(), span2);
         sfz::cos<float>(span2, span1);
         sfz::sin<float>(span2, span2);
         sfz::applyGain<float>(span1, absl::MakeSpan(left));

--- a/benchmarks/BM_pointerIterationOrOffsets.cpp
+++ b/benchmarks/BM_pointerIterationOrOffsets.cpp
@@ -14,7 +14,7 @@ constexpr int bigNumber { 2399132 };
 
 class IterOffset : public benchmark::Fixture {
 public:
-  void SetUp(const ::benchmark::State& /* state */) {
+  void SetUp(const ::benchmark::State& state) {
     std::random_device rd { };
     std::mt19937 gen { rd() };
     std::uniform_real_distribution<float> dist { 0.001f, 1.0f };

--- a/benchmarks/BM_pointerIterationOrOffsets.cpp
+++ b/benchmarks/BM_pointerIterationOrOffsets.cpp
@@ -14,7 +14,7 @@ constexpr int bigNumber { 2399132 };
 
 class IterOffset : public benchmark::Fixture {
 public:
-  void SetUp(const ::benchmark::State& state [[maybe_unused]]) {
+  void SetUp(const ::benchmark::State& /* state */) {
     std::random_device rd { };
     std::mt19937 gen { rd() };
     std::uniform_real_distribution<float> dist { 0.001f, 1.0f };
@@ -28,7 +28,7 @@ public:
     sfz::cumsum<int>(jumps, absl::MakeSpan(offsets));
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/benchmarks/BM_readChunk.cpp
+++ b/benchmarks/BM_readChunk.cpp
@@ -33,7 +33,7 @@ public:
         output = std::make_unique<sfz::AudioBuffer<float>>(sndfile.channels(), sndfile.frames());
     }
 
-    void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+    void TearDown(const ::benchmark::State& /* state */) {
     }
 
     ghc::filesystem::path getPath()

--- a/benchmarks/BM_readChunk.cpp
+++ b/benchmarks/BM_readChunk.cpp
@@ -12,7 +12,7 @@
 #define DR_WAV_IMPLEMENTATION
 #include "dr_wav.h"
 #include "AudioBuffer.h"
-#include <memory>
+#include "absl/memory/memory.h"
 #ifndef NDEBUG
 #include <iostream>
 #endif
@@ -30,7 +30,7 @@ public:
 
         sndfile = SndfileHandle(rootPath.c_str());
         numFrames = static_cast<size_t>(sndfile.frames());
-        output = std::make_unique<sfz::AudioBuffer<float>>(sndfile.channels(), sndfile.frames());
+        output = absl::make_unique<sfz::AudioBuffer<float>>(sndfile.channels(), sndfile.frames());
     }
 
     void TearDown(const ::benchmark::State& /* state */) {

--- a/benchmarks/BM_resample.cpp
+++ b/benchmarks/BM_resample.cpp
@@ -206,7 +206,7 @@ public:
         sndfile.readf(interleavedBuffer->data(), sndfile.frames());
     }
 
-    void TearDown(const ::benchmark::State& state [[maybe_unused]])
+    void TearDown(const ::benchmark::State& /* state */)
     {
     }
 

--- a/benchmarks/BM_resample.cpp
+++ b/benchmarks/BM_resample.cpp
@@ -8,7 +8,7 @@
 #include "AudioBuffer.h"
 #include "SIMDHelpers.h"
 #include <benchmark/benchmark.h>
-#include <memory>
+#include "absl/memory/memory.h"
 #include <samplerate.h>
 #include <sndfile.hh>
 #include "ghc/filesystem.hpp"
@@ -151,8 +151,8 @@ void upsample8xStage<true>(absl::Span<const float> input, absl::Span<float> outp
 template <class T, bool SIMD=false>
 std::unique_ptr<sfz::AudioBuffer<T>> upsample2x(const sfz::AudioBuffer<T>& buffer)
 {
-    // auto tempBuffer = std::make_unique<sfz::Buffer<T>>(buffer.getNumFrames() * 2);
-    auto outputBuffer = std::make_unique<sfz::AudioBuffer<T>>(buffer.getNumChannels(), buffer.getNumFrames() * 2);
+    // auto tempBuffer = absl::make_unique<sfz::Buffer<T>>(buffer.getNumFrames() * 2);
+    auto outputBuffer = absl::make_unique<sfz::AudioBuffer<T>>(buffer.getNumChannels(), buffer.getNumFrames() * 2);
     for (size_t channelIdx = 0; channelIdx < buffer.getNumChannels(); channelIdx++) {
         upsample2xStage<SIMD>(buffer.getConstSpan(channelIdx), outputBuffer->getSpan(channelIdx));
     }
@@ -162,8 +162,8 @@ std::unique_ptr<sfz::AudioBuffer<T>> upsample2x(const sfz::AudioBuffer<T>& buffe
 template <class T, bool SIMD=false>
 std::unique_ptr<sfz::AudioBuffer<T>> upsample4x(const sfz::AudioBuffer<T>& buffer)
 {
-    auto tempBuffer = std::make_unique<sfz::Buffer<T>>(buffer.getNumFrames() * 2);
-    auto outputBuffer = std::make_unique<sfz::AudioBuffer<T>>(buffer.getNumChannels(), buffer.getNumFrames() * 4);
+    auto tempBuffer = absl::make_unique<sfz::Buffer<T>>(buffer.getNumFrames() * 2);
+    auto outputBuffer = absl::make_unique<sfz::AudioBuffer<T>>(buffer.getNumChannels(), buffer.getNumFrames() * 4);
     for (size_t channelIdx = 0; channelIdx < buffer.getNumChannels(); channelIdx++) {
         upsample2xStage<SIMD>(buffer.getConstSpan(channelIdx), absl::MakeSpan(*tempBuffer));
         upsample4xStage<SIMD>(absl::MakeConstSpan(*tempBuffer), outputBuffer->getSpan(channelIdx));
@@ -174,9 +174,9 @@ std::unique_ptr<sfz::AudioBuffer<T>> upsample4x(const sfz::AudioBuffer<T>& buffe
 template <class T, bool SIMD=false>
 std::unique_ptr<sfz::AudioBuffer<T>> upsample8x(const sfz::AudioBuffer<T>& buffer)
 {
-    auto tempBuffer2x = std::make_unique<sfz::Buffer<T>>(buffer.getNumFrames() * 2);
-    auto tempBuffer4x = std::make_unique<sfz::Buffer<T>>(buffer.getNumFrames() * 4);
-    auto outputBuffer = std::make_unique<sfz::AudioBuffer<T>>(buffer.getNumChannels(), buffer.getNumFrames() * 8);
+    auto tempBuffer2x = absl::make_unique<sfz::Buffer<T>>(buffer.getNumFrames() * 2);
+    auto tempBuffer4x = absl::make_unique<sfz::Buffer<T>>(buffer.getNumFrames() * 4);
+    auto outputBuffer = absl::make_unique<sfz::AudioBuffer<T>>(buffer.getNumChannels(), buffer.getNumFrames() * 8);
     for (size_t channelIdx = 0; channelIdx < buffer.getNumChannels(); channelIdx++) {
         upsample2xStage<SIMD>(buffer.getConstSpan(channelIdx), absl::MakeSpan(*tempBuffer2x));
         upsample4xStage<SIMD>(absl::MakeConstSpan(*tempBuffer2x), absl::MakeSpan(*tempBuffer4x));
@@ -202,7 +202,7 @@ public:
         SndfileHandle sndfile(rootPath.c_str());
         numFrames = sndfile.frames();
         numChannels = sndfile.channels();
-        interleavedBuffer = std::make_unique<sfz::Buffer<float>>(numChannels * numFrames);
+        interleavedBuffer = absl::make_unique<sfz::Buffer<float>>(numChannels * numFrames);
         sndfile.readf(interleavedBuffer->data(), sndfile.frames());
     }
 
@@ -231,7 +231,7 @@ public:
 BENCHMARK_DEFINE_F(SndFile, HIIR2X_scalar)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto baseBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, numFrames);
+        auto baseBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, numFrames);
         sfz::readInterleaved<float>(*interleavedBuffer, baseBuffer->getSpan(0), baseBuffer->getSpan(1));
         auto outBuffer = upsample2x<float, false>(*baseBuffer);
         benchmark::DoNotOptimize(outBuffer);
@@ -241,7 +241,7 @@ BENCHMARK_DEFINE_F(SndFile, HIIR2X_scalar)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, HIIR4X_scalar)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto baseBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, numFrames);
+        auto baseBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, numFrames);
         sfz::readInterleaved<float>(*interleavedBuffer, baseBuffer->getSpan(0), baseBuffer->getSpan(1));
         auto outBuffer = upsample4x<float, false>(*baseBuffer);
         benchmark::DoNotOptimize(outBuffer);
@@ -251,7 +251,7 @@ BENCHMARK_DEFINE_F(SndFile, HIIR4X_scalar)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, HIIR8X_scalar)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto baseBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, numFrames);
+        auto baseBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, numFrames);
         sfz::readInterleaved<float>(*interleavedBuffer, baseBuffer->getSpan(0), baseBuffer->getSpan(1));
         auto outBuffer = upsample8x<float, false>(*baseBuffer);
         benchmark::DoNotOptimize(outBuffer);
@@ -261,7 +261,7 @@ BENCHMARK_DEFINE_F(SndFile, HIIR8X_scalar)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, HIIR2X_vector)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto baseBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, numFrames);
+        auto baseBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, numFrames);
         sfz::readInterleaved<float>(*interleavedBuffer, baseBuffer->getSpan(0), baseBuffer->getSpan(1));
         auto outBuffer = upsample2x<float, true>(*baseBuffer);
         benchmark::DoNotOptimize(outBuffer);
@@ -271,7 +271,7 @@ BENCHMARK_DEFINE_F(SndFile, HIIR2X_vector)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, HIIR4X_vector)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto baseBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, numFrames);
+        auto baseBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, numFrames);
         sfz::readInterleaved<float>(*interleavedBuffer, baseBuffer->getSpan(0), baseBuffer->getSpan(1));
         auto outBuffer = upsample4x<float, true>(*baseBuffer);
         benchmark::DoNotOptimize(outBuffer);
@@ -281,7 +281,7 @@ BENCHMARK_DEFINE_F(SndFile, HIIR4X_vector)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, HIIR8X_vector)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto baseBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, numFrames);
+        auto baseBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, numFrames);
         sfz::readInterleaved<float>(*interleavedBuffer, baseBuffer->getSpan(0), baseBuffer->getSpan(1));
         auto outBuffer = upsample8x<float, true>(*baseBuffer);
         benchmark::DoNotOptimize(outBuffer);
@@ -291,7 +291,7 @@ BENCHMARK_DEFINE_F(SndFile, HIIR8X_vector)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, SRC2x_BEST)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto intermediateBuffer = std::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
+        auto intermediateBuffer = absl::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
         SRC_DATA srcData;
         srcData.data_in = interleavedBuffer->data();
         srcData.data_out = intermediateBuffer->data();
@@ -299,7 +299,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC2x_BEST)(benchmark::State& state)
         srcData.input_frames = static_cast<long>(numFrames);
         srcData.output_frames = static_cast<long>(2 * numFrames);
         src_simple(&srcData, SRC_SINC_BEST_QUALITY, static_cast<int>(numChannels));
-        auto outBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
+        auto outBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
         sfz::readInterleaved<float>(*intermediateBuffer, outBuffer->getSpan(0), outBuffer->getSpan(1));
         benchmark::DoNotOptimize(outBuffer);
     }
@@ -308,7 +308,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC2x_BEST)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, SRC2x_MEDIUM)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto intermediateBuffer = std::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
+        auto intermediateBuffer = absl::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
         SRC_DATA srcData;
         srcData.data_in = interleavedBuffer->data();
         srcData.data_out = intermediateBuffer->data();
@@ -316,7 +316,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC2x_MEDIUM)(benchmark::State& state)
         srcData.input_frames = static_cast<long>(numFrames);
         srcData.output_frames = static_cast<long>(2 * numFrames);
         src_simple(&srcData, SRC_SINC_MEDIUM_QUALITY, static_cast<int>(numChannels));
-        auto outBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
+        auto outBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
         sfz::readInterleaved<float>(*intermediateBuffer, outBuffer->getSpan(0), outBuffer->getSpan(1));
         benchmark::DoNotOptimize(outBuffer);
     }
@@ -325,7 +325,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC2x_MEDIUM)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, SRC2x_FASTEST)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto intermediateBuffer = std::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
+        auto intermediateBuffer = absl::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
         SRC_DATA srcData;
         srcData.data_in = interleavedBuffer->data();
         srcData.data_out = intermediateBuffer->data();
@@ -333,7 +333,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC2x_FASTEST)(benchmark::State& state)
         srcData.input_frames = static_cast<long>(numFrames);
         srcData.output_frames = static_cast<long>(2 * numFrames);
         src_simple(&srcData, SRC_SINC_FASTEST, static_cast<int>(numChannels));
-        auto outBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
+        auto outBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
         sfz::readInterleaved<float>(*intermediateBuffer, outBuffer->getSpan(0), outBuffer->getSpan(1));
         benchmark::DoNotOptimize(outBuffer);
     }
@@ -343,7 +343,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC2x_FASTEST)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, SRC4x_BEST)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto intermediateBuffer = std::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
+        auto intermediateBuffer = absl::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
         SRC_DATA srcData;
         srcData.data_in = interleavedBuffer->data();
         srcData.data_out = intermediateBuffer->data();
@@ -351,7 +351,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC4x_BEST)(benchmark::State& state)
         srcData.input_frames = static_cast<long>(numFrames);
         srcData.output_frames = static_cast<long>(2 * numFrames);
         src_simple(&srcData, SRC_SINC_BEST_QUALITY, static_cast<int>(numChannels));
-        auto outBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
+        auto outBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
         sfz::readInterleaved<float>(*intermediateBuffer, outBuffer->getSpan(0), outBuffer->getSpan(1));
         benchmark::DoNotOptimize(outBuffer);
     }
@@ -360,7 +360,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC4x_BEST)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, SRC4x_MEDIUM)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto intermediateBuffer = std::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
+        auto intermediateBuffer = absl::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
         SRC_DATA srcData;
         srcData.data_in = interleavedBuffer->data();
         srcData.data_out = intermediateBuffer->data();
@@ -368,7 +368,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC4x_MEDIUM)(benchmark::State& state)
         srcData.input_frames = static_cast<long>(numFrames);
         srcData.output_frames = static_cast<long>(2 * numFrames);
         src_simple(&srcData, SRC_SINC_MEDIUM_QUALITY, static_cast<int>(numChannels));
-        auto outBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
+        auto outBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
         sfz::readInterleaved<float>(*intermediateBuffer, outBuffer->getSpan(0), outBuffer->getSpan(1));
         benchmark::DoNotOptimize(outBuffer);
     }
@@ -377,7 +377,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC4x_MEDIUM)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, SRC4x_FASTEST)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto intermediateBuffer = std::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
+        auto intermediateBuffer = absl::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
         SRC_DATA srcData;
         srcData.data_in = interleavedBuffer->data();
         srcData.data_out = intermediateBuffer->data();
@@ -385,7 +385,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC4x_FASTEST)(benchmark::State& state)
         srcData.input_frames = static_cast<long>(numFrames);
         srcData.output_frames = static_cast<long>(2 * numFrames);
         src_simple(&srcData, SRC_SINC_FASTEST, static_cast<int>(numChannels));
-        auto outBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
+        auto outBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
         sfz::readInterleaved<float>(*intermediateBuffer, outBuffer->getSpan(0), outBuffer->getSpan(1));
         benchmark::DoNotOptimize(outBuffer);
     }
@@ -394,7 +394,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC4x_FASTEST)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, SRC8x_BEST)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto intermediateBuffer = std::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
+        auto intermediateBuffer = absl::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
         SRC_DATA srcData;
         srcData.data_in = interleavedBuffer->data();
         srcData.data_out = intermediateBuffer->data();
@@ -402,7 +402,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC8x_BEST)(benchmark::State& state)
         srcData.input_frames = static_cast<long>(numFrames);
         srcData.output_frames = static_cast<long>(2 * numFrames);
         src_simple(&srcData, SRC_SINC_BEST_QUALITY, static_cast<int>(numChannels));
-        auto outBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
+        auto outBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
         sfz::readInterleaved<float>(*intermediateBuffer, outBuffer->getSpan(0), outBuffer->getSpan(1));
         benchmark::DoNotOptimize(outBuffer);
     }
@@ -411,7 +411,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC8x_BEST)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, SRC8x_MEDIUM)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto intermediateBuffer = std::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
+        auto intermediateBuffer = absl::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
         SRC_DATA srcData;
         srcData.data_in = interleavedBuffer->data();
         srcData.data_out = intermediateBuffer->data();
@@ -419,7 +419,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC8x_MEDIUM)(benchmark::State& state)
         srcData.input_frames = static_cast<long>(numFrames);
         srcData.output_frames = static_cast<long>(2 * numFrames);
         src_simple(&srcData, SRC_SINC_MEDIUM_QUALITY, static_cast<int>(numChannels));
-        auto outBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
+        auto outBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
         sfz::readInterleaved<float>(*intermediateBuffer, outBuffer->getSpan(0), outBuffer->getSpan(1));
         benchmark::DoNotOptimize(outBuffer);
     }
@@ -428,7 +428,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC8x_MEDIUM)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, SRC8x_FASTEST)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto intermediateBuffer = std::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
+        auto intermediateBuffer = absl::make_unique<sfz::Buffer<float>>(2 * numChannels * numFrames);
         SRC_DATA srcData;
         srcData.data_in = interleavedBuffer->data();
         srcData.data_out = intermediateBuffer->data();
@@ -436,7 +436,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC8x_FASTEST)(benchmark::State& state)
         srcData.input_frames = static_cast<long>(numFrames);
         srcData.output_frames = static_cast<long>(2 * numFrames);
         src_simple(&srcData, SRC_SINC_FASTEST, static_cast<int>(numChannels));
-        auto outBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
+        auto outBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, 2 * numFrames);
         sfz::readInterleaved<float>(*intermediateBuffer, outBuffer->getSpan(0), outBuffer->getSpan(1));
         benchmark::DoNotOptimize(outBuffer);
     }
@@ -445,7 +445,7 @@ BENCHMARK_DEFINE_F(SndFile, SRC8x_FASTEST)(benchmark::State& state)
 BENCHMARK_DEFINE_F(SndFile, HIIR8X_default)(benchmark::State& state)
 {
     for (auto _ : state) {
-        auto baseBuffer = std::make_unique<sfz::AudioBuffer<float>>(numChannels, numFrames);
+        auto baseBuffer = absl::make_unique<sfz::AudioBuffer<float>>(numChannels, numFrames);
         sfz::readInterleaved<float>(*interleavedBuffer, baseBuffer->getSpan(0), baseBuffer->getSpan(1));
         auto outBuffer = upsample8x<float>(*baseBuffer);
         benchmark::DoNotOptimize(outBuffer);

--- a/benchmarks/BM_resampleChunk.cpp
+++ b/benchmarks/BM_resampleChunk.cpp
@@ -78,7 +78,7 @@ public:
         output = std::make_unique<sfz::AudioBuffer<float>>(sndfile.channels(), numFrames * 4);
     }
 
-    void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+    void TearDown(const ::benchmark::State& /* state */) {
     }
 
     ghc::filesystem::path getPath()

--- a/benchmarks/BM_resampleChunk.cpp
+++ b/benchmarks/BM_resampleChunk.cpp
@@ -11,7 +11,7 @@
 #include "ghc/filesystem.hpp"
 #include "Oversampler.h"
 #include "AudioBuffer.h"
-#include <memory>
+#include "absl/memory/memory.h"
 #include <iostream>
 
 
@@ -75,7 +75,7 @@ public:
 
         sndfile = SndfileHandle(rootPath.c_str());
         numFrames = static_cast<size_t>(sndfile.frames());
-        output = std::make_unique<sfz::AudioBuffer<float>>(sndfile.channels(), numFrames * 4);
+        output = absl::make_unique<sfz::AudioBuffer<float>>(sndfile.channels(), numFrames * 4);
     }
 
     void TearDown(const ::benchmark::State& /* state */) {

--- a/benchmarks/BM_saturating.cpp
+++ b/benchmarks/BM_saturating.cpp
@@ -29,7 +29,7 @@ public:
     absl::c_generate(jumps, [&]() { return dist(gen); });
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/benchmarks/BM_subtract.cpp
+++ b/benchmarks/BM_subtract.cpp
@@ -24,7 +24,7 @@ public:
     std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/benchmarks/BM_wavfile.cpp
+++ b/benchmarks/BM_wavfile.cpp
@@ -17,7 +17,7 @@
 
 class FileFixture : public benchmark::Fixture {
 public:
-    void SetUp(const ::benchmark::State& state [[maybe_unused]]) {
+    void SetUp(const ::benchmark::State& state) {
         filePath1 = getPath() / "sample1.wav";
         filePath2 = getPath() / "sample2.wav";
         filePath3 = getPath() / "sample3.wav";
@@ -31,7 +31,7 @@ public:
         }
     }
 
-    void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+    void TearDown(const ::benchmark::State& /* state */) {
     }
 
     ghc::filesystem::path getPath()

--- a/benchmarks/BM_wavfile.cpp
+++ b/benchmarks/BM_wavfile.cpp
@@ -9,7 +9,7 @@
 #define DR_WAV_IMPLEMENTATION
 #include "dr_wav.h"
 #include "ghc/filesystem.hpp"
-#include <memory>
+#include "absl/memory/memory.h"
 #ifndef NDEBUG
 #include <iostream>
 #endif
@@ -17,7 +17,7 @@
 
 class FileFixture : public benchmark::Fixture {
 public:
-    void SetUp(const ::benchmark::State& state) {
+    void SetUp(const ::benchmark::State& /* state */) {
         filePath1 = getPath() / "sample1.wav";
         filePath2 = getPath() / "sample2.wav";
         filePath3 = getPath() / "sample3.wav";
@@ -59,7 +59,7 @@ BENCHMARK_DEFINE_F(FileFixture, SndFile)(benchmark::State& state) {
     for (auto _ : state)
     {
         SndfileHandle sndfile(filePath1.c_str());
-        buffer = std::make_unique<sfz::Buffer<float>>(sndfile.channels() * sndfile.frames());
+        buffer = absl::make_unique<sfz::Buffer<float>>(sndfile.channels() * sndfile.frames());
         sndfile.readf(buffer->data(), sndfile.frames());
     }
 }
@@ -74,7 +74,7 @@ BENCHMARK_DEFINE_F(FileFixture, DrWav)(benchmark::State& state) {
             #endif
             std::terminate();
         }
-        buffer = std::make_unique<sfz::Buffer<float>>(wav.channels * wav.totalPCMFrameCount);
+        buffer = absl::make_unique<sfz::Buffer<float>>(wav.channels * wav.totalPCMFrameCount);
         drwav_read_pcm_frames_f32(&wav, wav.totalPCMFrameCount, buffer->data());
     }
 }

--- a/benchmarks/BM_widthPos.cpp
+++ b/benchmarks/BM_widthPos.cpp
@@ -37,7 +37,7 @@ public:
     span3 = absl::MakeSpan(temp3);
   }
 
-  void TearDown(const ::benchmark::State& state [[maybe_unused]]) {
+  void TearDown(const ::benchmark::State& /* state */) {
 
   }
 

--- a/clients/jack_client.cpp
+++ b/clients/jack_client.cpp
@@ -37,7 +37,6 @@
 #include <string_view>
 #include <chrono>
 #include <thread>
-using namespace std::literals;
 
 static jack_port_t* midiInputPort;
 static jack_port_t* outputPort1;
@@ -290,7 +289,7 @@ int main(int argc, char** argv)
         std::cout << "Allocated buffers: " << synth.getAllocatedBuffers() << '\n';
         std::cout << "Total size: " << synth.getAllocatedBytes()  << '\n';
 #endif
-        std::this_thread::sleep_for(2s);
+        std::this_thread::sleep_for(std::chrono::seconds(2));
     }
 
     std::cout << "Closing..." << '\n';

--- a/clients/jack_client.cpp
+++ b/clients/jack_client.cpp
@@ -22,6 +22,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "sfizz/Synth.h"
+#include "sfizz/Macros.h"
 #include <absl/flags/parse.h>
 #include <absl/flags/flag.h>
 #include <absl/types/span.h>
@@ -70,9 +71,9 @@ constexpr int buildAndCenterPitch(uint8_t firstByte, uint8_t secondByte)
 }
 }
 
-static std::atomic<bool> keepRunning [[maybe_unused]] { true };
+static std::atomic<bool> keepRunning { true };
 
-int process(jack_nframes_t numFrames, void* arg [[maybe_unused]])
+int process(jack_nframes_t numFrames, void* arg)
 {
     auto synth = reinterpret_cast<sfz::Synth*>(arg);
 
@@ -129,7 +130,7 @@ int process(jack_nframes_t numFrames, void* arg [[maybe_unused]])
     return 0;
 }
 
-int sampleBlockChanged(jack_nframes_t nframes, void* arg [[maybe_unused]])
+int sampleBlockChanged(jack_nframes_t nframes, void* arg)
 {
     if (arg == nullptr)
         return 0;
@@ -140,7 +141,7 @@ int sampleBlockChanged(jack_nframes_t nframes, void* arg [[maybe_unused]])
     return 0;
 }
 
-int sampleRateChanged(jack_nframes_t nframes, void* arg [[maybe_unused]])
+int sampleRateChanged(jack_nframes_t nframes, void* arg)
 {
     if (arg == nullptr)
         return 0;
@@ -153,10 +154,11 @@ int sampleRateChanged(jack_nframes_t nframes, void* arg [[maybe_unused]])
 
 static bool shouldClose { false };
 
-static void done(int sig [[maybe_unused]])
+static void done(int sig)
 {
     std::cout << "Signal received" << '\n';
     shouldClose = true;
+    UNUSED(sig);
     // if (client != nullptr)
 
     // exit(0);

--- a/clients/jack_client.cpp
+++ b/clients/jack_client.cpp
@@ -71,8 +71,6 @@ constexpr int buildAndCenterPitch(uint8_t firstByte, uint8_t secondByte)
 }
 }
 
-static std::atomic<bool> keepRunning { true };
-
 int process(jack_nframes_t numFrames, void* arg)
 {
     auto synth = reinterpret_cast<sfz::Synth*>(arg);

--- a/cmake/SfizzConfig.cmake
+++ b/cmake/SfizzConfig.cmake
@@ -1,3 +1,10 @@
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND (CMAKE_CXX_STANDARD LESS 14 OR NOT CMAKE_CXX_STANDARD))
+    # There is a strange segfault in clang in c++11 when instantiating the
+    # envelopes in FloatEnvelopes.cpp.
+    message("Forcing C++14 to bypass a clang segfault")
+    set(CMAKE_CXX_STANDARD 14)
+endif()
+
 # Do not override the C++ standard if set to more than 11
 if (NOT CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 11)
     set(CMAKE_CXX_STANDARD 11)

--- a/cmake/SfizzConfig.cmake
+++ b/cmake/SfizzConfig.cmake
@@ -1,4 +1,4 @@
-# Do not override the C++ standard if set to more than 14
+# Do not override the C++ standard if set to more than 11
 if (NOT CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 11)
     set(CMAKE_CXX_STANDARD 11)
 endif()

--- a/cmake/SfizzConfig.cmake
+++ b/cmake/SfizzConfig.cmake
@@ -1,6 +1,6 @@
 # Do not override the C++ standard if set to more than 14
-if (NOT CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 14)
-    set(CMAKE_CXX_STANDARD 14)
+if (NOT CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 11)
+    set(CMAKE_CXX_STANDARD 11)
 endif()
 
 # Export the compile_commands.json file

--- a/cmake/SfizzConfig.cmake
+++ b/cmake/SfizzConfig.cmake
@@ -1,7 +1,5 @@
-# Do not override the C++ standard if set to more than 11
-if (NOT CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 11)
-    set(CMAKE_CXX_STANDARD 11)
-endif()
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_C_STANDARD 99)
 
 # Export the compile_commands.json file
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/cmake/SfizzConfig.cmake
+++ b/cmake/SfizzConfig.cmake
@@ -1,10 +1,3 @@
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND (CMAKE_CXX_STANDARD LESS 14 OR NOT CMAKE_CXX_STANDARD))
-    # There is a strange segfault in clang in c++11 when instantiating the
-    # envelopes in FloatEnvelopes.cpp.
-    message("Forcing C++14 to bypass a clang segfault")
-    set(CMAKE_CXX_STANDARD 14)
-endif()
-
 # Do not override the C++ standard if set to more than 11
 if (NOT CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 11)
     set(CMAKE_CXX_STANDARD 11)

--- a/lv2/CMakeLists.txt
+++ b/lv2/CMakeLists.txt
@@ -3,6 +3,9 @@ set (LV2PLUGIN_PRJ_NAME "${PROJECT_NAME}_lv2")
 # Set the build directory as <build_dir>/lv2/<plugin_name>.lv2/
 set (PROJECT_BINARY_DIR "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.lv2")
 
+# C99 or higher is needed
+set(CMAKE_C_STANDARD 99)
+
 # LV2 plugin specific settings
 include (LV2Config)
 

--- a/lv2/CMakeLists.txt
+++ b/lv2/CMakeLists.txt
@@ -3,9 +3,6 @@ set (LV2PLUGIN_PRJ_NAME "${PROJECT_NAME}_lv2")
 # Set the build directory as <build_dir>/lv2/<plugin_name>.lv2/
 set (PROJECT_BINARY_DIR "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.lv2")
 
-# C99 or higher is needed
-set(CMAKE_C_STANDARD 99)
-
 # LV2 plugin specific settings
 include (LV2Config)
 

--- a/src/external/atomic_queue/atomic_queue.h
+++ b/src/external/atomic_queue/atomic_queue.h
@@ -95,27 +95,24 @@ constexpr T& map(T* elements, unsigned index) noexcept {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+template<class T>
+constexpr T decrement(T x) { return x - 1; }
+template<class T>
+constexpr T increment(T x) { return x + 1; }
+template<class T>
+constexpr T or_equal(T x, unsigned u) { return (x | x >> u); }
+template<class T, class... Args>
+constexpr T or_equal(T x, unsigned u, Args... rest)
+{
+    return or_equal(or_equal(x, u), rest...);
+}
+
 constexpr uint32_t round_up_to_power_of_2(uint32_t a) noexcept {
-    --a;
-    a |= a >> 1;
-    a |= a >> 2;
-    a |= a >> 4;
-    a |= a >> 8;
-    a |= a >> 16;
-    ++a;
-    return a;
+    return increment(or_equal(decrement(a), 1, 2, 4, 8, 16));
 }
 
 constexpr uint64_t round_up_to_power_of_2(uint64_t a) noexcept {
-    --a;
-    a |= a >> 1;
-    a |= a >> 2;
-    a |= a >> 4;
-    a |= a >> 8;
-    a |= a >> 16;
-    a |= a >> 32;
-    ++a;
-    return a;
+    return increment(or_equal(decrement(a), 1, 2, 4, 8, 16, 32));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -304,7 +301,7 @@ public:
         static_cast<Derived&>(*this).do_push(std::forward<T>(element), head);
     }
 
-    auto pop() noexcept {
+    Derived& pop() noexcept {
         unsigned tail;
         if(Derived::spsc_) {
             tail = tail_.load(X);

--- a/src/external/atomic_queue/atomic_queue.h
+++ b/src/external/atomic_queue/atomic_queue.h
@@ -95,15 +95,35 @@ constexpr T& map(T* elements, unsigned index) noexcept {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// Implement a "bit-twiddling hack" for finding the next power of 2
+// in either 32 bits or 64 bits in C++11 compatible constexpr functions
+
+// "Runtime" version for 32 bits
+// --a;
+// a |= a >> 1;
+// a |= a >> 2;
+// a |= a >> 4;
+// a |= a >> 8;
+// a |= a >> 16;
+// ++a;
+
 template<class T>
-constexpr T decrement(T x) { return x - 1; }
+constexpr T decrement(T x) {
+    return x - 1;
+}
+
 template<class T>
-constexpr T increment(T x) { return x + 1; }
+constexpr T increment(T x) {
+    return x + 1;
+}
+
 template<class T>
-constexpr T or_equal(T x, unsigned u) { return (x | x >> u); }
+constexpr T or_equal(T x, unsigned u) {
+    return (x | x >> u);
+}
+
 template<class T, class... Args>
-constexpr T or_equal(T x, unsigned u, Args... rest)
-{
+constexpr T or_equal(T x, unsigned u, Args... rest) {
     return or_equal(or_equal(x, u), rest...);
 }
 

--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -12,18 +12,9 @@
 #pragma once
 #include <stddef.h>
 #include <stdbool.h>
+#include "sfizz/Macros.h"
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#if defined SFIZZ_EXPORT_SYMBOLS
-  #if defined _WIN32
-    #define SFIZZ_EXPORTED_API __declspec(dllexport)
-  #else
-    #define SFIZZ_EXPORTED_API __attribute__ ((visibility ("default")))
-  #endif
-#else
-  #define SFIZZ_EXPORTED_API
 #endif
 
 typedef struct sfizz_synth_t sfizz_synth_t;

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -7,16 +7,7 @@
 #include <string>
 #include <vector>
 #include <memory>
-
-#if defined SFIZZ_EXPORT_SYMBOLS
-  #if defined _WIN32
-    #define SFIZZ_EXPORTED_API __declspec(dllexport)
-  #else
-    #define SFIZZ_EXPORTED_API __attribute__ ((visibility ("default")))
-  #endif
-#else
-  #define SFIZZ_EXPORTED_API
-#endif
+#include "sfizz/Macros.h"
 
 namespace sfz
 {

--- a/src/sfizz/ADSREnvelope.cpp
+++ b/src/sfizz/ADSREnvelope.cpp
@@ -14,7 +14,7 @@ namespace sfz {
 template <class Type>
 void ADSREnvelope<Type>::reset(const Region& region, const MidiState& state, int delay, uint8_t velocity, float sampleRate) noexcept
 {
-    auto secondsToSamples = [sampleRate](auto timeInSeconds) {
+    auto secondsToSamples = [sampleRate](Type timeInSeconds) {
         return static_cast<int>(timeInSeconds * sampleRate);
     };
 

--- a/src/sfizz/ADSREnvelope.cpp
+++ b/src/sfizz/ADSREnvelope.cpp
@@ -54,7 +54,7 @@ Type ADSREnvelope<Type>::getNextValue() noexcept
 
         currentState = State::Attack;
         step = (peak - currentValue) / (attack > 0 ? attack : 1);
-        [[fallthrough]];
+        // fallthrough
     case State::Attack:
         if (attack-- > 0) {
             currentValue += step;
@@ -63,14 +63,14 @@ Type ADSREnvelope<Type>::getNextValue() noexcept
 
         currentState = State::Hold;
         currentValue = peak;
-        [[fallthrough]];
+        // fallthrough
     case State::Hold:
         if (hold-- > 0)
             return currentValue;
 
         step = std::exp(std::log(sustain + config::virtuallyZero) / (decay > 0 ? decay : 1));
         currentState = State::Decay;
-        [[fallthrough]];
+        // fallthrough
     case State::Decay:
         if (decay-- > 0) {
             currentValue *= step;
@@ -79,7 +79,7 @@ Type ADSREnvelope<Type>::getNextValue() noexcept
 
         currentState = State::Sustain;
         currentValue = sustain;
-        [[fallthrough]];
+        // fallthrough
     case State::Sustain:
         if (freeRunning)
             shouldRelease = true;
@@ -92,7 +92,7 @@ Type ADSREnvelope<Type>::getNextValue() noexcept
 
         currentState = State::Done;
         currentValue = 0.0;
-        [[fallthrough]];
+        // fallthrough
     default:
         return 0.0;
     }
@@ -116,7 +116,7 @@ void ADSREnvelope<Type>::getBlock(absl::Span<Type> output) noexcept
 
         currentState = State::Attack;
         step = (peak - start) / (attack > 0 ? attack : 1);
-        [[fallthrough]];
+        // fallthrough
     case State::Attack:
         length = min(remainingSamples, attack);
         currentValue = linearRamp<Type>(output, currentValue, step);
@@ -128,7 +128,7 @@ void ADSREnvelope<Type>::getBlock(absl::Span<Type> output) noexcept
 
         currentValue = peak;
         currentState = State::Hold;
-        [[fallthrough]];
+        // fallthrough
     case State::Hold:
         length = min(remainingSamples, hold);
         fill<Type>(output, currentValue);
@@ -140,7 +140,7 @@ void ADSREnvelope<Type>::getBlock(absl::Span<Type> output) noexcept
 
         step = std::exp(std::log(sustain + config::virtuallyZero) / (decay > 0 ? decay : 1));
         currentState = State::Decay;
-        [[fallthrough]];
+        // fallthrough
     case State::Decay:
         length = min(remainingSamples, decay);
         currentValue = multiplicativeRamp<Type>(output, currentValue, step);
@@ -152,7 +152,7 @@ void ADSREnvelope<Type>::getBlock(absl::Span<Type> output) noexcept
 
         currentValue = sustain;
         currentState = State::Sustain;
-        [[fallthrough]];
+        // fallthrough
     case State::Sustain:
         if (freeRunning)
             shouldRelease = true;
@@ -168,9 +168,9 @@ void ADSREnvelope<Type>::getBlock(absl::Span<Type> output) noexcept
 
         currentValue = 0.0;
         currentState = State::Done;
-        [[fallthrough]];
+        // fallthrough
     case State::Done:
-        [[fallthrough]];
+        // fallthrough
     default:
         break;
     }

--- a/src/sfizz/AudioBuffer.h
+++ b/src/sfizz/AudioBuffer.h
@@ -28,7 +28,7 @@ namespace sfz
 template <class Type, size_t MaxChannels = sfz::config::numChannels, unsigned int Alignment = SIMDConfig::defaultAlignment>
 class AudioBuffer {
 public:
-    using value_type = std::remove_cv_t<Type>;
+    using value_type = typename std::remove_cv<Type>::type;
     using pointer = value_type*;
     using const_pointer = const value_type*;
     using iterator = pointer;

--- a/src/sfizz/AudioBuffer.h
+++ b/src/sfizz/AudioBuffer.h
@@ -10,7 +10,7 @@
 #include "Debug.h"
 #include "LeakDetector.h"
 #include "absl/types/span.h"
-#include <memory>
+#include "absl/memory/memory.h"
 #include <array>
 
 namespace sfz
@@ -54,7 +54,7 @@ public:
         , numFrames(numFrames)
     {
         for (size_t i = 0; i < numChannels; ++i)
-            buffers[i] = std::make_unique<buffer_type>(numFrames);
+            buffers[i] = absl::make_unique<buffer_type>(numFrames);
     }
 
     /**
@@ -170,7 +170,7 @@ public:
     void addChannel()
     {
         if (numChannels < MaxChannels)
-            buffers[numChannels++] = std::make_unique<buffer_type>(numFrames);
+            buffers[numChannels++] = absl::make_unique<buffer_type>(numFrames);
     }
 
     /**

--- a/src/sfizz/AudioSpan.h
+++ b/src/sfizz/AudioSpan.h
@@ -148,7 +148,7 @@ public:
      * @tparam Alignment the alignment block size for the platform
      * @param audioBuffer the source AudioBuffer.
      */
-    template <class U, size_t N, unsigned int Alignment, typename = std::enable_if<N <= MaxChannels>, typename = std::enable_if_t<std::is_const<U>::value, int>>
+    template <class U, size_t N, unsigned int Alignment, typename = typename std::enable_if<N <= MaxChannels>::type, typename = typename std::enable_if<std::is_const<U>::value, int>::type>
     AudioSpan(AudioBuffer<U, N, Alignment>& audioBuffer)
         : numFrames(audioBuffer.getNumFrames())
         , numChannels(audioBuffer.getNumChannels())

--- a/src/sfizz/Buffer.h
+++ b/src/sfizz/Buffer.h
@@ -260,9 +260,9 @@ public:
     constexpr pointer data() const noexcept { return normalData; }
     constexpr size_type size() const noexcept { return alignedSize; }
     constexpr bool empty() const noexcept { return alignedSize == 0; }
-    constexpr iterator begin() noexcept { return data(); }
-    constexpr iterator end() noexcept { return normalEnd; }
-    constexpr pointer alignedEnd() noexcept { return _alignedEnd; }
+    constexpr iterator begin() const noexcept  { return data(); }
+    constexpr iterator end() const noexcept { return normalEnd; }
+    constexpr pointer alignedEnd() const noexcept { return _alignedEnd; }
 
 
     /**

--- a/src/sfizz/EGDescription.h
+++ b/src/sfizz/EGDescription.h
@@ -26,6 +26,7 @@
 #pragma once
 #include "Config.h"
 #include "Defaults.h"
+#include "Macros.h"
 #include "LeakDetector.h"
 #include "SfzHelpers.h"
 #include <absl/types/optional.h>
@@ -134,8 +135,9 @@ struct EGDescription
      * @param velocity
      * @return float
      */
-    float getStart(const SfzCCArray &ccValues, uint8_t velocity [[maybe_unused]]) const noexcept
+    float getStart(const SfzCCArray &ccValues, uint8_t velocity) const noexcept
     {
+        UNUSED(velocity);
         return Default::egPercentRange.clamp(ccSwitchedValue(ccValues, ccStart, start));
     }
     /**

--- a/src/sfizz/EQPool.cpp
+++ b/src/sfizz/EQPool.cpp
@@ -3,7 +3,6 @@
 #include <thread>
 #include "absl/algorithm/container.h"
 #include "SIMDHelpers.h"
-using namespace std::chrono_literals;
 
 sfz::EQHolder::EQHolder(const MidiState& state)
 :midiState(state)
@@ -114,7 +113,7 @@ size_t sfz::EQPool::setnumEQs(size_t numEQs)
     AtomicDisabler disabler { canGiveOutEQs };
 
     while(givingOutEQs)
-        std::this_thread::sleep_for(1ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
     auto eqIterator = eqs.begin();
     auto eqSentinel = eqs.rbegin();

--- a/src/sfizz/Effects.cpp
+++ b/src/sfizz/Effects.cpp
@@ -44,21 +44,21 @@ std::unique_ptr<Effect> EffectFactory::makeEffect(absl::Span<const Opcode> membe
 
     if (!opcode) {
         DBG("The effect does not specify a type");
-        return std::make_unique<sfz::fx::Nothing>();
+        return absl::make_unique<sfz::fx::Nothing>();
     }
 
     const absl::string_view type = opcode->value;
 
-    const auto it = absl::c_find_if(_entries, [&](auto&& entry) { return entry.name == type; });
+    const auto it = absl::c_find_if(_entries, [&](const FactoryEntry& entry) { return entry.name == type; });
     if (it == _entries.end()) {
         DBG("Unsupported effect type: " << type);
-        return std::make_unique<sfz::fx::Nothing>();
+        return absl::make_unique<sfz::fx::Nothing>();
     }
 
     auto fx = it->make(members);
     if (!fx) {
         DBG("Could not instantiate effect of type: " << type);
-        return std::make_unique<sfz::fx::Nothing>();
+        return absl::make_unique<sfz::fx::Nothing>();
     }
 
     return fx;

--- a/src/sfizz/EventEnvelopes.cpp
+++ b/src/sfizz/EventEnvelopes.cpp
@@ -53,7 +53,7 @@ void EventEnvelope<Type>::prepareEvents(int blockLength)
     if (resetEvents)
         clear();
 
-    absl::c_stable_sort(events, [](const auto& lhs, const auto& rhs) {
+    absl::c_stable_sort(events, [](const std::pair<int, Type>& lhs, const std::pair<int, Type>& rhs) {
         return lhs.first < rhs.first;
     });
 

--- a/src/sfizz/EventEnvelopes.h
+++ b/src/sfizz/EventEnvelopes.h
@@ -94,7 +94,7 @@ protected:
     Type currentValue { 0.0 };
 private:
     static_assert(std::is_arithmetic<Type>::value, "Type should be arithmetic");
-    std::function<Type(Type)> function { [](Type input) { return input; } };
+    std::function<Type(Type)> function { [](Type input) -> Type { return input; } };
     int maxCapacity { config::defaultSamplesPerBlock };
     void prepareEvents(int blockLength);
     bool resetEvents { false };

--- a/src/sfizz/FilePool.cpp
+++ b/src/sfizz/FilePool.cpp
@@ -411,7 +411,7 @@ void sfz::FilePool::emptyFileLoadingQueues() noexcept
 {
     emptyQueue = true;
     while (emptyQueue)
-        std::this_thread::sleep_for(std::chrono::microseconds(100));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
 }
 
 void sfz::FilePool::waitForBackgroundLoading() noexcept

--- a/src/sfizz/FilePool.h
+++ b/src/sfizz/FilePool.h
@@ -44,10 +44,11 @@ namespace sfz {
 using AudioBufferPtr = std::shared_ptr<AudioBuffer<float>>;
 
 
+// Strict C++11 disallows member initialization if aggregate initialization is to be used...
 struct PreloadedFileHandle
 {
-    std::shared_ptr<AudioBuffer<float>> preloadedData {};
-    float sampleRate { config::defaultSampleRate };
+    std::shared_ptr<AudioBuffer<float>> preloadedData;
+    float sampleRate;
 };
 
 struct FilePromise
@@ -78,7 +79,7 @@ struct FilePromise
     AudioBuffer<float> fileData {};
     float sampleRate { config::defaultSampleRate };
     Oversampling oversamplingFactor { config::defaultOversamplingFactor };
-    std::atomic_size_t availableFrames { 0 };
+    std::atomic<size_t> availableFrames { 0 };
     std::atomic<bool> dataReady { false };
     std::chrono::time_point<std::chrono::high_resolution_clock> creationTime;
 

--- a/src/sfizz/FilePool.h
+++ b/src/sfizz/FilePool.h
@@ -52,7 +52,7 @@ struct PreloadedFileHandle
 
 struct FilePromise
 {
-    auto getData()
+    AudioSpan<const float> getData()
     {
         if (dataReady)
             return AudioSpan<const float>(fileData);

--- a/src/sfizz/FilterPool.cpp
+++ b/src/sfizz/FilterPool.cpp
@@ -4,7 +4,6 @@
 #include "AtomicGuard.h"
 #include <thread>
 #include <chrono>
-using namespace std::chrono_literals;
 
 sfz::FilterHolder::FilterHolder(const MidiState& midiState)
 : midiState(midiState)
@@ -113,7 +112,7 @@ size_t sfz::FilterPool::setNumFilters(size_t numFilters)
     AtomicDisabler disabler { canGiveOutFilters };
 
     while(givingOutFilters)
-        std::this_thread::sleep_for(1ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
     auto filterIterator = filters.begin();
     auto filterSentinel = filters.rbegin();

--- a/src/sfizz/Logger.cpp
+++ b/src/sfizz/Logger.cpp
@@ -13,8 +13,6 @@
 #include <sstream>
 #include <cmath>
 
-using namespace std::chrono_literals;
-
 template<class T>
 void printStatistics(std::vector<T>& data)
 {
@@ -141,7 +139,7 @@ void sfz::Logger::moveEvents() noexcept
             callbackTimes.clear();
         }
 
-        std::this_thread::sleep_for(10ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 }
 

--- a/src/sfizz/Logger.h
+++ b/src/sfizz/Logger.h
@@ -47,6 +47,13 @@ struct ScopedTiming
 
 struct FileTime
 {
+    FileTime() = default;
+    FileTime(Duration waitDuration, Duration loadDuration, uint32_t fileSize, absl::string_view filename)
+    : waitDuration(waitDuration), loadDuration(loadDuration), fileSize(fileSize), filename(filename) { }
+    FileTime(const FileTime&) = default;
+    FileTime& operator=(const FileTime&) = default;
+    FileTime(FileTime&&) = default;
+    FileTime& operator=(FileTime&&) = default;
     Duration waitDuration { 0 };
     Duration loadDuration { 0 };
     uint32_t fileSize { 0 };
@@ -66,6 +73,13 @@ struct CallbackBreakdown
 
 struct CallbackTime
 {
+    CallbackTime() = default;
+    CallbackTime(const CallbackBreakdown& breakdown, int numVoices, size_t numSamples)
+    : breakdown(breakdown), numVoices(numVoices), numSamples(numSamples) { }
+    CallbackTime(const CallbackTime&) = default;
+    CallbackTime& operator=(const CallbackTime&) = default;
+    CallbackTime(CallbackTime&&) = default;
+    CallbackTime& operator=(CallbackTime&&) = default;
     CallbackBreakdown breakdown {};
     int numVoices { 0 };
     size_t numSamples { 0 };

--- a/src/sfizz/Logger.h
+++ b/src/sfizz/Logger.h
@@ -6,6 +6,7 @@
 
 #pragma once
 #include "Config.h"
+#include "LeakDetector.h"
 #include "atomic_queue/atomic_queue.h"
 #include <vector>
 #include <string>
@@ -58,6 +59,7 @@ struct FileTime
     Duration loadDuration { 0 };
     uint32_t fileSize { 0 };
     absl::string_view filename {};
+    LEAK_DETECTOR(FileTime);
 };
 
 struct CallbackBreakdown
@@ -69,6 +71,7 @@ struct CallbackBreakdown
     Duration filters { 0 };
     Duration panning { 0 };
     Duration effects { 0 };
+    LEAK_DETECTOR(CallbackBreakdown);
 };
 
 struct CallbackTime
@@ -83,6 +86,7 @@ struct CallbackTime
     CallbackBreakdown breakdown {};
     int numVoices { 0 };
     size_t numSamples { 0 };
+    LEAK_DETECTOR(CallbackTime);
 };
 
 class Logger
@@ -149,6 +153,7 @@ private:
     std::atomic_flag keepRunning;
     std::atomic_flag clearFlag;
     std::thread loggingThread;
+    LEAK_DETECTOR(Logger);
 };
 
 }

--- a/src/sfizz/Logger.h
+++ b/src/sfizz/Logger.h
@@ -47,10 +47,10 @@ struct ScopedTiming
 
 struct FileTime
 {
-    Duration waitDuration;
-    Duration loadDuration;
-    uint32_t fileSize;
-    absl::string_view filename;
+    Duration waitDuration { 0 };
+    Duration loadDuration { 0 };
+    uint32_t fileSize { 0 };
+    absl::string_view filename {};
 };
 
 struct CallbackBreakdown
@@ -66,9 +66,9 @@ struct CallbackBreakdown
 
 struct CallbackTime
 {
-    CallbackBreakdown breakdown;
-    int numVoices;
-    size_t numSamples;
+    CallbackBreakdown breakdown {};
+    int numVoices { 0 };
+    size_t numSamples { 0 };
 };
 
 class Logger

--- a/src/sfizz/Macros.h
+++ b/src/sfizz/Macros.h
@@ -17,3 +17,9 @@
 #else
   #define SFIZZ_EXPORTED_API
 #endif
+
+#if __cplusplus > 201103L
+#define CONSTEXPR_OR_INLINE constexpr
+#else
+#define CONSTEXPR_OR_INLINE inline
+#endif

--- a/src/sfizz/Macros.h
+++ b/src/sfizz/Macros.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+
+#define UNUSED(x) (void)(x)

--- a/src/sfizz/Macros.h
+++ b/src/sfizz/Macros.h
@@ -7,3 +7,13 @@
 #pragma once
 
 #define UNUSED(x) (void)(x)
+
+#if defined SFIZZ_EXPORT_SYMBOLS
+  #if defined _WIN32
+    #define SFIZZ_EXPORTED_API __declspec(dllexport)
+  #else
+    #define SFIZZ_EXPORTED_API __attribute__ ((visibility ("default")))
+  #endif
+#else
+  #define SFIZZ_EXPORTED_API
+#endif

--- a/src/sfizz/Macros.h
+++ b/src/sfizz/Macros.h
@@ -19,7 +19,7 @@
 #endif
 
 #if __cplusplus > 201103L
-#define CONSTEXPR_OR_INLINE constexpr
+#define CXX14_CONSTEXPR constexpr
 #else
-#define CONSTEXPR_OR_INLINE inline
+#define CXX14_CONSTEXPR
 #endif

--- a/src/sfizz/MathHelpers.h
+++ b/src/sfizz/MathHelpers.h
@@ -124,9 +124,7 @@ inline float midiNoteFrequency(const int noteNumber)
 template<class T>
 constexpr T clamp( T v, T lo, T hi )
 {
-    v = min(v, hi);
-    v = max(v, lo);
-    return v;
+    return max(min(v, hi), lo);
 }
 
 template<int Increment = 1, class T>
@@ -148,19 +146,18 @@ constexpr ValueType linearInterpolation(ValueType left, ValueType right, ValueTy
     return left * leftCoeff + right * rightCoeff;
 }
 
-constexpr double dPi { 3.141592653589793238462643383279502884};
-constexpr double dTwoPi { dPi * 2 };
-constexpr double dPiTwo { dPi / 2 };
-constexpr double dPiFour { dPi / 4 };
-constexpr double dSqrtTwo { 1.414213562373095048801688724209698078569671875376948073176 };
-constexpr double dSqrtTwoInv { 0.707106781186547524400844362104849039284835937688474036588 };
-
-constexpr float fPi { 3.141592653589793238462643383279502884};
-constexpr float fTwoPi { fPi * 2 };
-constexpr float fPiTwo { fPi / 2 };
-constexpr float fPiFour { fPi / 4 };
-constexpr float fSqrtTwo { 1.414213562373095048801688724209698078569671875376948073176 };
-constexpr float fSqrtTwoInv { 0.707106781186547524400844362104849039284835937688474036588 };
+template<class Type>
+constexpr Type pi() { return static_cast<Type>(3.141592653589793238462643383279502884); };
+template<class Type>
+constexpr Type twoPi() { return pi<Type>() * 2; };
+template<class Type>
+constexpr Type piTwo() { return pi<Type>() / 2; };
+template<class Type>
+constexpr Type piFour() { return pi<Type>() / 4; };
+template<class Type>
+constexpr Type sqrtTwo() { return static_cast<Type>(1.414213562373095048801688724209698078569671875376948073176); };
+template<class Type>
+constexpr Type sqrtTwoInv() { return static_cast<Type>(0.707106781186547524400844362104849039284835937688474036588); };
 
 /**
    @brief A fraction which is parameterized by integer type

--- a/src/sfizz/MathHelpers.h
+++ b/src/sfizz/MathHelpers.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include "Config.h"
+#include "Macros.h"
 #include <algorithm>
 #include <cmath>
 #include <random>
@@ -128,13 +129,13 @@ constexpr T clamp( T v, T lo, T hi )
 }
 
 template<int Increment = 1, class T>
-constexpr void incrementAll(T& only)
+CONSTEXPR_OR_INLINE void incrementAll(T& only)
 {
     only += Increment;
 }
 
 template<int Increment = 1, class T, class... Args>
-constexpr void incrementAll(T& first, Args&... rest)
+CONSTEXPR_OR_INLINE void incrementAll(T& first, Args&... rest)
 {
     first += Increment;
     incrementAll<Increment>(rest...);

--- a/src/sfizz/MathHelpers.h
+++ b/src/sfizz/MathHelpers.h
@@ -17,25 +17,25 @@
 template<class T>
 constexpr T max(T op1, T op2)
 {
-    return std::max(op1, op2);
+    return op1 > op2 ? op1 : op2;
 }
 
 template<class T, class... Args>
 constexpr T max(T op1, Args... rest)
 {
-    return std::max(op1, max(rest...));
+    return max(op1, max(rest...));
 }
 
 template<class T>
 constexpr T min(T op1, T op2)
 {
-    return std::min(op1, op2);
+    return op1 > op2 ? op2 : op1;
 }
 
 template<class T, class... Args>
 constexpr T min(T op1, Args... rest)
 {
-    return std::min(op1, min(rest...));
+    return min(op1, min(rest...));
 }
 
 /**

--- a/src/sfizz/MathHelpers.h
+++ b/src/sfizz/MathHelpers.h
@@ -129,13 +129,13 @@ constexpr T clamp( T v, T lo, T hi )
 }
 
 template<int Increment = 1, class T>
-CONSTEXPR_OR_INLINE void incrementAll(T& only)
+inline CXX14_CONSTEXPR void incrementAll(T& only)
 {
     only += Increment;
 }
 
 template<int Increment = 1, class T, class... Args>
-CONSTEXPR_OR_INLINE void incrementAll(T& first, Args&... rest)
+inline CXX14_CONSTEXPR void incrementAll(T& first, Args&... rest)
 {
     first += Increment;
     incrementAll<Increment>(rest...);

--- a/src/sfizz/MathHelpers.h
+++ b/src/sfizz/MathHelpers.h
@@ -124,8 +124,8 @@ inline float midiNoteFrequency(const int noteNumber)
 template<class T>
 constexpr T clamp( T v, T lo, T hi )
 {
-    v = std::min(v, hi);
-    v = std::max(v, lo);
+    v = min(v, hi);
+    v = max(v, lo);
     return v;
 }
 
@@ -148,18 +148,19 @@ constexpr ValueType linearInterpolation(ValueType left, ValueType right, ValueTy
     return left * leftCoeff + right * rightCoeff;
 }
 
-template <class Type>
-constexpr Type pi { static_cast<Type>(3.141592653589793238462643383279502884) };
-template <class Type>
-constexpr Type twoPi { static_cast<Type>(2) * pi<Type> };
-template <class Type>
-constexpr Type piTwo { pi<Type> / static_cast<Type>(2) };
-template <class Type>
-constexpr Type piFour { pi<Type> / static_cast<Type>(4) };
-template <class Type>
-constexpr Type sqrtTwo { static_cast<Type>(1.414213562373095048801688724209698078569671875376948073176) };
-template <class Type>
-constexpr Type sqrtTwoInv { static_cast<Type>(0.707106781186547524400844362104849039284835937688474036588) };
+constexpr double dPi { 3.141592653589793238462643383279502884};
+constexpr double dTwoPi { dPi * 2 };
+constexpr double dPiTwo { dPi / 2 };
+constexpr double dPiFour { dPi / 4 };
+constexpr double dSqrtTwo { 1.414213562373095048801688724209698078569671875376948073176 };
+constexpr double dSqrtTwoInv { 0.707106781186547524400844362104849039284835937688474036588 };
+
+constexpr float fPi { 3.141592653589793238462643383279502884};
+constexpr float fTwoPi { fPi * 2 };
+constexpr float fPiTwo { fPi / 2 };
+constexpr float fPiFour { fPi / 4 };
+constexpr float fSqrtTwo { 1.414213562373095048801688724209698078569671875376948073176 };
+constexpr float fSqrtTwoInv { 0.707106781186547524400844362104849039284835937688474036588 };
 
 /**
    @brief A fraction which is parameterized by integer type

--- a/src/sfizz/MidiState.cpp
+++ b/src/sfizz/MidiState.cpp
@@ -5,6 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "MidiState.h"
+#include "Macros.h"
 #include "Debug.h"
 
 sfz::MidiState::MidiState()
@@ -25,11 +26,11 @@ void sfz::MidiState::noteOnEvent(int delay, int noteNumber, uint8_t velocity) no
 
 }
 
-void sfz::MidiState::noteOffEvent(int delay, int noteNumber, uint8_t velocity [[maybe_unused]]) noexcept
+void sfz::MidiState::noteOffEvent(int delay, int noteNumber, uint8_t velocity) noexcept
 {
     ASSERT(noteNumber >= 0 && noteNumber <= 127);
     ASSERT(velocity >= 0 && velocity <= 127);
-
+    UNUSED(velocity);
     if (noteNumber >= 0 && noteNumber < 128) {
         if (activeNotes > 0)
             activeNotes--;

--- a/src/sfizz/MidiState.h
+++ b/src/sfizz/MidiState.h
@@ -134,13 +134,13 @@ private:
      * @brief Stores the note on times.
      *
      */
-	MidiNoteArray<NoteOnTime> noteOnTimes { };
+	MidiNoteArray<NoteOnTime> noteOnTimes;
     /**
      * @brief Stores the velocity of the note ons for currently
      * depressed notes.
      *
      */
-	MidiNoteArray<uint8_t> lastNoteVelocities { };
+	MidiNoteArray<uint8_t> lastNoteVelocities;
     /**
      * @brief Current known values for the CCs.
      *

--- a/src/sfizz/OnePoleFilter.h
+++ b/src/sfizz/OnePoleFilter.h
@@ -26,7 +26,7 @@ public:
     template <class C>
     static Type normalizedGain(Type cutoff, C sampleRate)
     {
-        return std::tan(cutoff / static_cast<Type>(sampleRate) * fPi);
+        return std::tan(cutoff / static_cast<Type>(sampleRate) * pi<float>());
     }
 
     OnePoleFilter(Type gain)

--- a/src/sfizz/OnePoleFilter.h
+++ b/src/sfizz/OnePoleFilter.h
@@ -26,7 +26,7 @@ public:
     template <class C>
     static Type normalizedGain(Type cutoff, C sampleRate)
     {
-        return std::tan(cutoff / static_cast<Type>(sampleRate) * pi<float>);
+        return std::tan(cutoff / static_cast<Type>(sampleRate) * fPi);
     }
 
     OnePoleFilter(Type gain)

--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -45,7 +45,7 @@ struct Opcode {
  * @param validRange the range of admitted values
  * @return absl::optional<ValueType> the cast value, or null
  */
-template <typename ValueType, std::enable_if_t<std::is_integral<ValueType>::value, int> = 0>
+template <typename ValueType, typename std::enable_if<std::is_integral<ValueType>::value, int>::type = 0>
 inline absl::optional<ValueType> readOpcode(absl::string_view value, const Range<ValueType>& validRange)
 {
         int64_t returnedValue;
@@ -74,7 +74,7 @@ inline absl::optional<ValueType> readOpcode(absl::string_view value, const Range
  * @param validRange the range of admitted values
  * @return absl::optional<ValueType> the cast value, or null
  */
-template <typename ValueType, std::enable_if_t<std::is_floating_point<ValueType>::value, int> = 0>
+template <typename ValueType, typename std::enable_if<std::is_floating_point<ValueType>::value, int>::type = 0>
 inline absl::optional<ValueType> readOpcode(absl::string_view value, const Range<ValueType>& validRange)
 {
     float returnedValue;

--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -11,6 +11,7 @@
 #include "SfzHelpers.h"
 #include "StringViewHelpers.h"
 #include <absl/types/optional.h>
+#include "absl/meta/type_traits.h"
 #include <string_view>
 #include <vector>
 #include <type_traits>
@@ -45,7 +46,7 @@ struct Opcode {
  * @param validRange the range of admitted values
  * @return absl::optional<ValueType> the cast value, or null
  */
-template <typename ValueType, typename std::enable_if<std::is_integral<ValueType>::value, int>::type = 0>
+template <typename ValueType, absl::enable_if_t<std::is_integral<ValueType>::value, int> = 0>
 inline absl::optional<ValueType> readOpcode(absl::string_view value, const Range<ValueType>& validRange)
 {
         int64_t returnedValue;
@@ -74,7 +75,7 @@ inline absl::optional<ValueType> readOpcode(absl::string_view value, const Range
  * @param validRange the range of admitted values
  * @return absl::optional<ValueType> the cast value, or null
  */
-template <typename ValueType, typename std::enable_if<std::is_floating_point<ValueType>::value, int>::type = 0>
+template <typename ValueType, absl::enable_if_t<std::is_floating_point<ValueType>::value, int> = 0>
 inline absl::optional<ValueType> readOpcode(absl::string_view value, const Range<ValueType>& validRange)
 {
     float returnedValue;

--- a/src/sfizz/Oversampler.cpp
+++ b/src/sfizz/Oversampler.cpp
@@ -105,7 +105,7 @@ void sfz::Oversampler::stream(const sfz::AudioBuffer<float>& input, sfz::AudioBu
     {
         // std::cout << "Input frames: " << inputFrameCounter << "/" << numFrames << '\n';
         const auto thisChunkSize = std::min(chunkSize, numFrames - inputFrameCounter);
-        const auto outputChunkSize { thisChunkSize * static_cast<int>(factor) };
+        const auto outputChunkSize = thisChunkSize * static_cast<int>(factor);
         for (size_t chanIdx = 0; chanIdx < numChannels; chanIdx++) {
             const auto inputChunk = input.getSpan(chanIdx).subspan(inputFrameCounter, thisChunkSize);
             const auto outputChunk = output.getSpan(chanIdx).subspan(outputFrameCounter, outputChunkSize);

--- a/src/sfizz/Oversampler.cpp
+++ b/src/sfizz/Oversampler.cpp
@@ -78,11 +78,11 @@ void sfz::Oversampler::stream(const sfz::AudioBuffer<float>& input, sfz::AudioBu
     case Oversampling::x8:
         for (auto& upsampler: upsampler8x)
             upsampler.set_coefs(coeffsStage8x.data());
-        [[fallthrough]];
+        // fallthrough
     case Oversampling::x4:
         for (auto& upsampler: upsampler4x)
             upsampler.set_coefs(coeffsStage4x.data());
-        [[fallthrough]];
+        // fallthrough
     case Oversampling::x2:
         for (auto& upsampler: upsampler2x)
             upsampler.set_coefs(coeffsStage2x.data());

--- a/src/sfizz/Range.h
+++ b/src/sfizz/Range.h
@@ -24,7 +24,7 @@ public:
     constexpr Range() = default;
     constexpr Range(Type start, Type end) noexcept
         : _start(start)
-        , _end(std::max(start, end))
+        , _end(max(start, end))
     {
 
     }

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -7,6 +7,7 @@
 #include "Region.h"
 #include "Defaults.h"
 #include "MathHelpers.h"
+#include "Macros.h"
 #include "Debug.h"
 #include "Opcode.h"
 #include "StringViewHelpers.h"
@@ -817,7 +818,7 @@ bool sfz::Region::registerNoteOn(int noteNumber, uint8_t velocity, float randVal
     return keyOk && velOk && randOk && (attackTrigger || firstLegatoNote || notFirstLegatoNote);
 }
 
-bool sfz::Region::registerNoteOff(int noteNumber, uint8_t velocity [[maybe_unused]], float randValue) noexcept
+bool sfz::Region::registerNoteOff(int noteNumber, uint8_t velocity, float randValue) noexcept
 {
     if (keyswitchRange.containsWithEnd(noteNumber)) {
         if (keyswitchDown && *keyswitchDown == noteNumber)

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -1011,7 +1011,7 @@ float sfz::Region::velocityCurve(uint8_t velocity) const noexcept
     float gain { 1.0f };
 
     if (velocityPoints.size() > 0) { // Custom velocity curve
-        auto after = std::find_if(velocityPoints.begin(), velocityPoints.end(), [velocity](auto& val) { return val.first >= velocity; });
+        auto after = std::find_if(velocityPoints.begin(), velocityPoints.end(), [velocity](const std::pair<int, float>& val) { return val.first >= velocity; });
         auto before = after == velocityPoints.begin() ? velocityPoints.begin() : after - 1;
         // Linear interpolation
         float relativePositionInSegment {

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -66,7 +66,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
     case hash("count"):
         setValueFromOpcode(opcode, sampleCount, Default::sampleCountRange);
         break;
-    case hash("loopmode"): [[fallthrough]];
+    case hash("loopmode"): // fallthrough
     case hash("loop_mode"):
         switch (hash(opcode.value)) {
         case hash("no_loop"):
@@ -85,21 +85,21 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             DBG("Unkown loop mode:" << std::string(opcode.value));
         }
         break;
-    case hash("loopend"): [[fallthrough]];
+    case hash("loopend"): // fallthrough
     case hash("loop_end"):
         setRangeEndFromOpcode(opcode, loopRange, Default::loopRange);
         break;
-    case hash("loopstart"): [[fallthrough]];
+    case hash("loopstart"): // fallthrough
     case hash("loop_start"):
         setRangeStartFromOpcode(opcode, loopRange, Default::loopRange);
         break;
 
     // Instrument settings: voice lifecycle
-    case hash("group"): [[fallthrough]];
+    case hash("group"): // fallthrough
     case hash("polyphony_group"):
         setValueFromOpcode(opcode, group, Default::groupRange);
         break;
-    case hash("offby"): [[fallthrough]];
+    case hash("offby"): // fallthrough
     case hash("off_by"):
         setValueFromOpcode(opcode, offBy, Default::groupRange);
         break;
@@ -237,11 +237,11 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             DBG("Unknown trigger mode: " << std::string(opcode.value));
         }
         break;
-    case hash("on_locc&"): [[fallthrough]];
+    case hash("on_locc&"): // fallthrough
     case hash("start_locc&"):
         setRangeStartFromOpcode(opcode, ccTriggers[opcode.parameters.back()], Default::ccTriggerValueRange);
         break;
-    case hash("on_hicc&"): [[fallthrough]];
+    case hash("on_hicc&"): // fallthrough
     case hash("start_hicc&"):
         setRangeEndFromOpcode(opcode, ccTriggers[opcode.parameters.back()], Default::ccTriggerValueRange);
         break;
@@ -251,14 +251,14 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         setValueFromOpcode(opcode, volume, Default::volumeRange);
         break;
     case hash("gain_cc&"):
-    case hash("gain_oncc&"): [[fallthrough]];
+    case hash("gain_oncc&"): // fallthrough
     case hash("volume_oncc&"):
         setCCPairFromOpcode(opcode, volumeCC, Default::volumeCCRange);
         break;
     case hash("amplitude"):
         setValueFromOpcode(opcode, amplitude, Default::amplitudeRange);
         break;
-    case hash("amplitude_cc&"): [[fallthrough]];
+    case hash("amplitude_cc&"): // fallthrough
     case hash("amplitude_oncc&"):
         setCCPairFromOpcode(opcode, amplitudeCC, Default::amplitudeRange);
         break;
@@ -377,7 +377,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         break;
 
     // Performance parameters: filters
-    case hash("cutoff"): [[fallthrough]];
+    case hash("cutoff"): // fallthrough
     case hash("cutoff&"):
         {
             const auto filterIndex = opcode.parameters.empty() ? 0 : (opcode.parameters.back() - 1);
@@ -386,7 +386,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             setValueFromOpcode(opcode, filters[filterIndex].cutoff, Default::filterCutoffRange);
         }
         break;
-    case hash("resonance"): [[fallthrough]];
+    case hash("resonance"): // fallthrough
     case hash("resonance&"):
         {
             const auto filterIndex = opcode.parameters.empty() ? 0 : (opcode.parameters.back() - 1);
@@ -397,7 +397,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         break;
     case hash("cutoff_oncc&"):
     case hash("cutoff_cc&"):
-    case hash("cutoff&_oncc&"): [[fallthrough]];
+    case hash("cutoff&_oncc&"): // fallthrough
     case hash("cutoff&_cc&"):
         {
             const auto filterIndex = opcode.parameters.size() == 1 ? 0 : (opcode.parameters.front() - 1);
@@ -413,7 +413,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
         break;
     case hash("resonance&_oncc&"):
     case hash("resonance&_cc&"):
-    case hash("resonance_oncc&"): [[fallthrough]];
+    case hash("resonance_oncc&"): // fallthrough
     case hash("resonance_cc&"):
         {
             const auto filterIndex = opcode.parameters.size() == 1 ? 0 : (opcode.parameters.front() - 1);
@@ -427,7 +427,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             );
         }
         break;
-    case hash("fil_keytrack"): [[fallthrough]];
+    case hash("fil_keytrack"): // fallthrough
     case hash("fil&_keytrack"):
         {
             const auto filterIndex = opcode.parameters.empty() ? 0 : (opcode.parameters.front() - 1);
@@ -437,7 +437,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             setValueFromOpcode(opcode, filters[filterIndex].keytrack, Default::filterKeytrackRange);
         }
         break;
-    case hash("fil_keycenter"): [[fallthrough]];
+    case hash("fil_keycenter"): // fallthrough
     case hash("fil&_keycenter"):
         {
             const auto filterIndex = opcode.parameters.empty() ? 0 : (opcode.parameters.front() - 1);
@@ -447,7 +447,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             setValueFromOpcode(opcode, filters[filterIndex].keycenter, Default::keyRange);
         }
         break;
-    case hash("fil_veltrack"): [[fallthrough]];
+    case hash("fil_veltrack"): // fallthrough
     case hash("fil&_veltrack"):
         {
             const auto filterIndex = opcode.parameters.empty() ? 0 : (opcode.parameters.front() - 1);
@@ -457,7 +457,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             setValueFromOpcode(opcode, filters[filterIndex].veltrack, Default::filterVeltrackRange);
         }
         break;
-    case hash("fil_random"): [[fallthrough]];
+    case hash("fil_random"): // fallthrough
     case hash("fil&_random"):
         {
             const auto filterIndex = opcode.parameters.empty() ? 0 : (opcode.parameters.front() - 1);
@@ -467,7 +467,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             setValueFromOpcode(opcode, filters[filterIndex].random, Default::filterRandomRange);
         }
         break;
-    case hash("fil_gain"): [[fallthrough]];
+    case hash("fil_gain"): // fallthrough
     case hash("fil&_gain"):
         {
             const auto filterIndex = opcode.parameters.empty() ? 0 : (opcode.parameters.front() - 1);
@@ -477,7 +477,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             setValueFromOpcode(opcode, filters[filterIndex].gain, Default::filterGainRange);
         }
         break;
-    case hash("fil_gaincc&"): [[fallthrough]];
+    case hash("fil_gaincc&"): // fallthrough
     case hash("fil&_gaincc&"):
         {
             const auto filterIndex = opcode.parameters.size() == 1 ? 0 : (opcode.parameters.front() - 1);
@@ -491,7 +491,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             );
         }
         break;
-    case hash("fil_type"): [[fallthrough]];
+    case hash("fil_type"): // fallthrough
     case hash("fil&_type"):
         {
             const auto filterIndex = opcode.parameters.empty() ? 0 : (opcode.parameters.front() - 1);
@@ -520,7 +520,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             setValueFromOpcode(opcode, equalizers[eqNumber - 1].bandwidth, Default::eqBandwidthRange);
         }
         break;
-    case hash("eq&_bw_oncc&"): [[fallthrough]];
+    case hash("eq&_bw_oncc&"): // fallthrough
     case hash("eq&_bwcc&"):
         {
             const auto eqNumber = opcode.parameters.front();
@@ -542,7 +542,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             setValueFromOpcode(opcode, equalizers[eqNumber - 1].frequency, Default::eqFrequencyRange);
         }
         break;
-    case hash("eq&_freq_oncc&"): [[fallthrough]];
+    case hash("eq&_freq_oncc&"): // fallthrough
     case hash("eq&_freqcc&"):
         {
             const auto eqNumber = opcode.parameters.front();
@@ -577,7 +577,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             setValueFromOpcode(opcode, equalizers[eqNumber - 1].gain, Default::eqGainRange);
         }
         break;
-    case hash("eq&_gain_oncc&"): [[fallthrough]];
+    case hash("eq&_gain_oncc&"): // fallthrough
     case hash("eq&_gaincc&"):
         {
             const auto eqNumber = opcode.parameters.front();
@@ -638,7 +638,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
     case hash("transpose"):
         setValueFromOpcode(opcode, transpose, Default::transposeRange);
         break;
-    case hash("tune"): [[fallthrough]];
+    case hash("tune"): // fallthrough
     case hash("pitch"):
         setValueFromOpcode(opcode, tune, Default::tuneRange);
         break;
@@ -704,31 +704,31 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
             return false; // Was not vel2...
         setValueFromOpcode(opcode, amplitudeEG.vel2sustain, Default::egOnCCPercentRange);
         break;
-    case hash("ampeg_attackcc&"): [[fallthrough]];
+    case hash("ampeg_attackcc&"): // fallthrough
     case hash("ampeg_attack_oncc&"):
         setCCPairFromOpcode(opcode, amplitudeEG.ccAttack, Default::egOnCCTimeRange);
         break;
-    case hash("ampeg_decaycc&"): [[fallthrough]];
+    case hash("ampeg_decaycc&"): // fallthrough
     case hash("ampeg_decay_oncc&"):
         setCCPairFromOpcode(opcode, amplitudeEG.ccDecay, Default::egOnCCTimeRange);
         break;
-    case hash("ampeg_delaycc&"): [[fallthrough]];
+    case hash("ampeg_delaycc&"): // fallthrough
     case hash("ampeg_delay_oncc&"):
         setCCPairFromOpcode(opcode, amplitudeEG.ccDelay, Default::egOnCCTimeRange);
         break;
-    case hash("ampeg_holdcc&"): [[fallthrough]];
+    case hash("ampeg_holdcc&"): // fallthrough
     case hash("ampeg_hold_oncc&"):
         setCCPairFromOpcode(opcode, amplitudeEG.ccHold, Default::egOnCCTimeRange);
         break;
-    case hash("ampeg_releasecc&"): [[fallthrough]];
+    case hash("ampeg_releasecc&"): // fallthrough
     case hash("ampeg_release_oncc&"):
         setCCPairFromOpcode(opcode, amplitudeEG.ccRelease, Default::egOnCCTimeRange);
         break;
-    case hash("ampeg_startcc&"): [[fallthrough]];
+    case hash("ampeg_startcc&"): // fallthrough
     case hash("ampeg_start_oncc&"):
         setCCPairFromOpcode(opcode, amplitudeEG.ccStart, Default::egOnCCPercentRange);
         break;
-    case hash("ampeg_sustaincc&"): [[fallthrough]];
+    case hash("ampeg_sustaincc&"): // fallthrough
     case hash("ampeg_sustain_oncc&"):
         setCCPairFromOpcode(opcode, amplitudeEG.ccSustain, Default::egOnCCPercentRange);
         break;

--- a/src/sfizz/SIMDHelpers.h
+++ b/src/sfizz/SIMDHelpers.h
@@ -748,7 +748,7 @@ namespace _internals {
         int i = 0;
 
         for (; i < panSize; ++i)
-            pan[i] = std::cos(i * (dPiTwo / (panSize - 1)));
+            pan[i] = std::cos(i * (twoPi<double>() / (panSize - 1)));
 
         for (; i < static_cast<int>(pan.size()); ++i)
             pan[i] = pan[panSize - 1];

--- a/src/sfizz/SIMDHelpers.h
+++ b/src/sfizz/SIMDHelpers.h
@@ -748,7 +748,7 @@ namespace _internals {
         int i = 0;
 
         for (; i < panSize; ++i)
-            pan[i] = std::cos(i * (twoPi<double>() / (panSize - 1)));
+            pan[i] = std::cos(i * (piTwo<double>() / (panSize - 1)));
 
         for (; i < static_cast<int>(pan.size()); ++i)
             pan[i] = pan[panSize - 1];

--- a/src/sfizz/SIMDHelpers.h
+++ b/src/sfizz/SIMDHelpers.h
@@ -748,7 +748,7 @@ namespace _internals {
         int i = 0;
 
         for (; i < panSize; ++i)
-            pan[i] = std::cos(i * (piTwo<double> / (panSize - 1)));
+            pan[i] = std::cos(i * (dPiTwo / (panSize - 1)));
 
         for (; i < static_cast<int>(pan.size()); ++i)
             pan[i] = pan[panSize - 1];

--- a/src/sfizz/SIMDNEON.cpp
+++ b/src/sfizz/SIMDNEON.cpp
@@ -29,10 +29,10 @@
 #include <arm_neon.h>
 
 using Type = float;
-[[maybe_unused]] constexpr uintptr_t TypeAlignment { 4 };
-[[maybe_unused]] constexpr uintptr_t TypeAlignmentMask { TypeAlignment - 1 };
-[[maybe_unused]] constexpr uintptr_t ByteAlignment { TypeAlignment * sizeof(Type) };
-[[maybe_unused]] constexpr uintptr_t ByteAlignmentMask { ByteAlignment - 1 };
+constexpr uintptr_t TypeAlignment { 4 };
+constexpr uintptr_t TypeAlignmentMask { TypeAlignment - 1 };
+constexpr uintptr_t ByteAlignment { TypeAlignment * sizeof(Type) };
+constexpr uintptr_t ByteAlignmentMask { ByteAlignment - 1 };
 
 float* nextAligned(const float* ptr)
 {

--- a/src/sfizz/SIMDNEON.cpp
+++ b/src/sfizz/SIMDNEON.cpp
@@ -30,7 +30,6 @@
 
 using Type = float;
 constexpr uintptr_t TypeAlignment { 4 };
-constexpr uintptr_t TypeAlignmentMask { TypeAlignment - 1 };
 constexpr uintptr_t ByteAlignment { TypeAlignment * sizeof(Type) };
 constexpr uintptr_t ByteAlignmentMask { ByteAlignment - 1 };
 

--- a/src/sfizz/SIMDSSE.cpp
+++ b/src/sfizz/SIMDSSE.cpp
@@ -16,10 +16,10 @@
 #include "mathfuns/sse_mathfun.h"
 
 using Type = float;
-[[maybe_unused]] constexpr uintptr_t TypeAlignment { 4 };
-[[maybe_unused]] constexpr uintptr_t TypeAlignmentMask { TypeAlignment - 1 };
-[[maybe_unused]] constexpr uintptr_t ByteAlignment { TypeAlignment * sizeof(Type) };
-[[maybe_unused]] constexpr uintptr_t ByteAlignmentMask { ByteAlignment - 1 };
+constexpr uintptr_t TypeAlignment { 4 };
+constexpr uintptr_t TypeAlignmentMask { TypeAlignment - 1 };
+constexpr uintptr_t ByteAlignment { TypeAlignment * sizeof(Type) };
+constexpr uintptr_t ByteAlignmentMask { ByteAlignment - 1 };
 
 struct AlignmentSentinels {
     float* nextAligned;

--- a/src/sfizz/SIMDSSE.cpp
+++ b/src/sfizz/SIMDSSE.cpp
@@ -623,7 +623,7 @@ void sfz::pan<float, true>(absl::Span<const float> panEnvelope, absl::Span<float
     }
 
     const auto mmOne = _mm_set_ps1(1.0f);
-    const auto mmPiFour = _mm_set_ps1(piFour<float>);
+    const auto mmPiFour = _mm_set_ps1(piFour<float>());
     __m128 mmCos;
     __m128 mmSin;
     while (pan < lastAligned) {
@@ -660,7 +660,7 @@ void sfz::width<float, true>(absl::Span<const float> widthEnvelope, absl::Span<f
         incrementAll(width, left, right);
     }
 
-    const auto mmPiFour = _mm_set_ps1(piFour<float>);
+    const auto mmPiFour = _mm_set_ps1(piFour<float>());
     __m128 mmCos;
     __m128 mmSin;
     while (width < lastAligned) {

--- a/src/sfizz/SIMDSSE.cpp
+++ b/src/sfizz/SIMDSSE.cpp
@@ -17,7 +17,6 @@
 
 using Type = float;
 constexpr uintptr_t TypeAlignment { 4 };
-constexpr uintptr_t TypeAlignmentMask { TypeAlignment - 1 };
 constexpr uintptr_t ByteAlignment { TypeAlignment * sizeof(Type) };
 constexpr uintptr_t ByteAlignmentMask { ByteAlignment - 1 };
 

--- a/src/sfizz/SfzHelpers.h
+++ b/src/sfizz/SfzHelpers.h
@@ -241,7 +241,7 @@ constexpr void addToBase(T& base, T modifier)
  * @param base
  * @param modifier
  */
-constexpr void multiplyByCents(float& base, int modifier)
+void multiplyByCents(float& base, int modifier)
 {
     base *= centsFactor(modifier);
 }

--- a/src/sfizz/SfzHelpers.h
+++ b/src/sfizz/SfzHelpers.h
@@ -241,7 +241,7 @@ constexpr void addToBase(T& base, T modifier)
  * @param base
  * @param modifier
  */
-void multiplyByCents(float& base, int modifier)
+inline void multiplyByCents(float& base, int modifier)
 {
     base *= centsFactor(modifier);
 }

--- a/src/sfizz/SfzHelpers.h
+++ b/src/sfizz/SfzHelpers.h
@@ -11,6 +11,7 @@
 #include <array>
 #include <cmath>
 #include "Config.h"
+#include "MathHelpers.h"
 
 namespace sfz
 {
@@ -85,7 +86,7 @@ template<class T>
 constexpr float normalizeCC(T ccValue)
 {
     static_assert(std::is_integral<T>::value, "Requires an integral T");
-    return static_cast<float>(std::min(std::max(ccValue, static_cast<T>(0)), static_cast<T>(127))) / 127.0f;
+    return static_cast<float>(min(max(ccValue, static_cast<T>(0)), static_cast<T>(127))) / 127.0f;
 }
 
 /**
@@ -124,7 +125,7 @@ constexpr float normalizePercents(T percentValue)
  */
 constexpr float normalizeBend(float bendValue)
 {
-    return std::min(std::max(bendValue, -8191.0f), 8191.0f) / 8191.0f;
+    return min(max(bendValue, -8191.0f), 8191.0f) / 8191.0f;
 }
 
 /**

--- a/src/sfizz/SfzHelpers.h
+++ b/src/sfizz/SfzHelpers.h
@@ -10,6 +10,7 @@
 //#include <string>
 #include <array>
 #include <cmath>
+#include "Macros.h"
 #include "Config.h"
 #include "MathHelpers.h"
 
@@ -230,7 +231,7 @@ using modFunction = std::function<void(T&, U)>;
  * @param modifier the modifier value
  */
 template<class T>
-constexpr void addToBase(T& base, T modifier)
+CONSTEXPR_OR_INLINE void addToBase(T& base, T modifier)
 {
     base += modifier;
 }
@@ -241,7 +242,7 @@ constexpr void addToBase(T& base, T modifier)
  * @param base
  * @param modifier
  */
-inline void multiplyByCents(float& base, int modifier)
+CONSTEXPR_OR_INLINE void multiplyByCents(float& base, int modifier)
 {
     base *= centsFactor(modifier);
 }

--- a/src/sfizz/SfzHelpers.h
+++ b/src/sfizz/SfzHelpers.h
@@ -231,7 +231,7 @@ using modFunction = std::function<void(T&, U)>;
  * @param modifier the modifier value
  */
 template<class T>
-CONSTEXPR_OR_INLINE void addToBase(T& base, T modifier)
+inline CXX14_CONSTEXPR void addToBase(T& base, T modifier)
 {
     base += modifier;
 }
@@ -242,7 +242,7 @@ CONSTEXPR_OR_INLINE void addToBase(T& base, T modifier)
  * @param base
  * @param modifier
  */
-CONSTEXPR_OR_INLINE void multiplyByCents(float& base, int modifier)
+inline CXX14_CONSTEXPR void multiplyByCents(float& base, int modifier)
 {
     base *= centsFactor(modifier);
 }

--- a/src/sfizz/StringViewHelpers.h
+++ b/src/sfizz/StringViewHelpers.h
@@ -56,10 +56,7 @@ constexpr uint64_t Fnv1aPrime = 0x01000193;
  */
 constexpr uint64_t hash(absl::string_view s, uint64_t h = Fnv1aBasis)
 {
-    if (s.length() > 0)
-        return hash( { s.data() + 1, s.length() - 1 }, (h ^ s.front()) * Fnv1aPrime );
-
-    return h;
+    return (s.length() == 0) ? h : hash( { s.data() + 1, s.length() - 1 }, (h ^ s.front()) * Fnv1aPrime );
 }
 
 /**
@@ -73,12 +70,9 @@ constexpr uint64_t hash(absl::string_view s, uint64_t h = Fnv1aBasis)
  */
 constexpr uint64_t hashNoAmpersand(absl::string_view s, uint64_t h = Fnv1aBasis)
 {
-    if (s.length() > 0) {
-        if (s.front() == '&')
-            return hashNoAmpersand( { s.data() + 1, s.length() - 1 }, h );
-        else
-            return hashNoAmpersand( { s.data() + 1, s.length() - 1 }, (h ^ s.front()) * Fnv1aPrime );
-    }
-
-    return h;
+    return (s.length() == 0) ? h : (
+        (s.front() == '&')
+            ? hashNoAmpersand( { s.data() + 1, s.length() - 1 }, h )
+            : hashNoAmpersand( { s.data() + 1, s.length() - 1 }, (h ^ s.front()) * Fnv1aPrime )
+    );
 }

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -163,20 +163,20 @@ void sfz::Synth::handleControlOpcodes(const std::vector<Opcode>& members)
 {
     for (auto& member : members) {
         switch (member.lettersOnlyHash) {
-        case hash("Set_cc&"): [[fallthrough]];
+        case hash("Set_cc&"): // fallthrough
         case hash("set_cc&"):
             if (Default::ccNumberRange.containsWithEnd(member.parameters.back())) {
                 const auto ccValue = readOpcode(member.value, Default::ccValueRange).value_or(0);
                 resources.midiState.ccEvent(0, member.parameters.back(), ccValue);
             }
             break;
-        case hash("Label_cc&"): [[fallthrough]];
+        case hash("Label_cc&"): // fallthrough
         case hash("label_cc&"):
             if (Default::ccNumberRange.containsWithEnd(member.parameters.back()))
                 ccNames.emplace_back(member.parameters.back(), std::string(member.value));
             break;
         case hash("Default_path"):
-            [[fallthrough]];
+            // fallthrough
         case hash("default_path"):
             defaultPath = absl::StrReplaceAll(trim(member.value), { { "\\", "/" } });
             DBG("Changing default sample path to " << defaultPath);

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -260,7 +260,7 @@ void sfz::Synth::handleEffectOpcodes(const std::vector<Opcode>& members)
 void addEndpointsToVelocityCurve(sfz::Region& region)
 {
     if (region.velocityPoints.size() > 0) {
-        absl::c_sort(region.velocityPoints, [](auto& lhs, auto& rhs) { return lhs.first < rhs.first; });
+        absl::c_sort(region.velocityPoints, [](const std::pair<int, float>& lhs, const std::pair<int, float>& rhs) { return lhs.first < rhs.first; });
         if (region.ampVeltrack > 0) {
             if (region.velocityPoints.back().first != sfz::Default::velocityRange.getEnd())
                 region.velocityPoints.push_back(std::make_pair<int, float>(127, 1.0f));
@@ -409,7 +409,7 @@ bool sfz::Synth::loadSfzFile(const fs::path& file)
 
 sfz::Voice* sfz::Synth::findFreeVoice() noexcept
 {
-    auto freeVoice = absl::c_find_if(voices, [](const auto& voice) { return voice->isFree(); });
+    auto freeVoice = absl::c_find_if(voices, [](const std::unique_ptr<Voice>& voice) { return voice->isFree(); });
     if (freeVoice != voices.end())
         return freeVoice->get();
 
@@ -418,7 +418,7 @@ sfz::Voice* sfz::Synth::findFreeVoice() noexcept
     for (auto& voice : voices)
         if (voice->canBeStolen())
             voiceViewArray.push_back(voice.get());
-    absl::c_sort(voiceViewArray, [](const auto& lhs, const auto& rhs) { return lhs->getSourcePosition() > rhs->getSourcePosition(); });
+    absl::c_sort(voiceViewArray, [](Voice* lhs, Voice* rhs) { return lhs->getSourcePosition() > rhs->getSourcePosition(); });
 
     for (auto* voice : voiceViewArray) {
         if (voice->getMeanSquaredAverage() < config::voiceStealingThreshold) {

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -8,6 +8,7 @@
 #include "AtomicGuard.h"
 #include "Config.h"
 #include "Debug.h"
+#include "Macros.h"
 #include "MidiState.h"
 #include "ScopedFTZ.h"
 #include "StringViewHelpers.h"
@@ -589,10 +590,11 @@ void sfz::Synth::noteOn(int delay, int noteNumber, uint8_t velocity) noexcept
     noteOnDispatch(delay, noteNumber, velocity);
 }
 
-void sfz::Synth::noteOff(int delay, int noteNumber, uint8_t velocity [[maybe_unused]]) noexcept
+void sfz::Synth::noteOff(int delay, int noteNumber, uint8_t velocity) noexcept
 {
     ASSERT(noteNumber < 128);
     ASSERT(noteNumber >= 0);
+    UNUSED(velocity);
 
     ScopedTiming logger { dispatchDuration, ScopedTiming::Operation::addToDuration };
     resources.midiState.noteOffEvent(delay, noteNumber, velocity);

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -342,7 +342,7 @@ bool sfz::Synth::loadSfzFile(const fs::path& file)
                 region->isStereo = true;
 
             // TODO: adjust with LFO targets
-            const auto maxOffset { region->offset + region->offsetRandom };
+            const auto maxOffset = region->offset + region->offsetRandom;
             if (!resources.filePool.preloadFile(region->sample, maxOffset))
                 removeCurrentRegion();
         }
@@ -432,7 +432,7 @@ sfz::Voice* sfz::Synth::findFreeVoice() noexcept
 
 int sfz::Synth::getNumActiveVoices() const noexcept
 {
-    auto activeVoices { 0 };
+    auto activeVoices = 0;
     for (const auto& voice : voices) {
         if (!voice->isFree())
             activeVoices++;

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -13,12 +13,12 @@
 #include "StringViewHelpers.h"
 #include "pugixml.hpp"
 #include "absl/algorithm/container.h"
+#include "absl/memory/memory.h"
 #include "absl/strings/str_replace.h"
 #include <algorithm>
 #include <chrono>
 #include <iostream>
 #include <utility>
-using namespace std::literals;
 
 sfz::Synth::Synth()
     : Synth(config::numVoices)
@@ -38,7 +38,7 @@ sfz::Synth::~Synth()
 {
     AtomicDisabler callbackDisabler { canEnterCallback };
     while (inCallback) {
-        std::this_thread::sleep_for(1ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     for (auto& voice: voices)
@@ -83,9 +83,9 @@ void sfz::Synth::callback(absl::string_view header, const std::vector<Opcode>& m
 
 void sfz::Synth::buildRegion(const std::vector<Opcode>& regionOpcodes)
 {
-    auto lastRegion = std::make_unique<Region>(resources.midiState, defaultPath);
+    auto lastRegion = absl::make_unique<Region>(resources.midiState, defaultPath);
 
-    auto parseOpcodes = [&](const auto& opcodes) {
+    auto parseOpcodes = [&](const std::vector<Opcode>& opcodes) {
         for (auto& opcode : opcodes) {
             const auto unknown = absl::c_find_if(unknownOpcodes, [&](absl::string_view sv) { return sv.compare(opcode.opcode) == 0; });
             if (unknown != unknownOpcodes.end()) {
@@ -112,7 +112,7 @@ void sfz::Synth::clear()
 {
     AtomicDisabler callbackDisabler { canEnterCallback };
     while (inCallback) {
-        std::this_thread::sleep_for(1ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     for (auto &voice: voices)
@@ -279,7 +279,7 @@ bool sfz::Synth::loadSfzFile(const fs::path& file)
 {
     AtomicDisabler callbackDisabler { canEnterCallback };
     while (inCallback) {
-        std::this_thread::sleep_for(1ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     clear();
@@ -452,7 +452,7 @@ void sfz::Synth::setSamplesPerBlock(int samplesPerBlock) noexcept
     AtomicDisabler callbackDisabler { canEnterCallback };
 
     while (inCallback) {
-        std::this_thread::sleep_for(1ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     this->samplesPerBlock = samplesPerBlock;
@@ -471,7 +471,7 @@ void sfz::Synth::setSampleRate(float sampleRate) noexcept
 {
     AtomicDisabler callbackDisabler { canEnterCallback };
     while (inCallback) {
-        std::this_thread::sleep_for(1ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     this->sampleRate = sampleRate;
@@ -851,12 +851,12 @@ void sfz::Synth::resetVoices(int numVoices)
 {
     AtomicDisabler callbackDisabler{ canEnterCallback };
     while (inCallback) {
-        std::this_thread::sleep_for(1ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     voices.clear();
     for (int i = 0; i < numVoices; ++i)
-        voices.push_back(std::make_unique<Voice>(resources));
+        voices.push_back(absl::make_unique<Voice>(resources));
 
     for (auto& voice: voices) {
         voice->setSampleRate(this->sampleRate);
@@ -871,7 +871,7 @@ void sfz::Synth::setOversamplingFactor(sfz::Oversampling factor) noexcept
 {
     AtomicDisabler callbackDisabler{ canEnterCallback };
     while (inCallback) {
-        std::this_thread::sleep_for(1ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     for (auto& voice: voices)
@@ -891,7 +891,7 @@ void sfz::Synth::setPreloadSize(uint32_t preloadSize) noexcept
 {
     AtomicDisabler callbackDisabler{ canEnterCallback };
     while (inCallback) {
-        std::this_thread::sleep_for(1ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     resources.filePool.setPreloadSize(preloadSize);

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -4,6 +4,7 @@
 // license. You should have receive a LICENSE.md file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
+#include "Macros.h"
 #include "Voice.h"
 #include "AudioSpan.h"
 #include "Config.h"
@@ -129,8 +130,9 @@ void sfz::Voice::release(int delay, bool fastRelease) noexcept
     }
 }
 
-void sfz::Voice::registerNoteOff(int delay, int noteNumber, uint8_t velocity [[maybe_unused]]) noexcept
+void sfz::Voice::registerNoteOff(int delay, int noteNumber, uint8_t velocity) noexcept
 {
+    UNUSED(velocity);
     if (region == nullptr)
         return;
 
@@ -207,14 +209,18 @@ void sfz::Voice::registerPitchWheel(int delay, int pitch) noexcept
     pitchBendEnvelope.registerEvent(delay, static_cast<float>(pitch));
 }
 
-void sfz::Voice::registerAftertouch(int delay [[maybe_unused]], uint8_t aftertouch [[maybe_unused]]) noexcept
+void sfz::Voice::registerAftertouch(int delay, uint8_t aftertouch) noexcept
 {
     // TODO
+    UNUSED(delay);
+    UNUSED(aftertouch);
 }
 
-void sfz::Voice::registerTempo(int delay [[maybe_unused]], float secondsPerQuarter [[maybe_unused]]) noexcept
+void sfz::Voice::registerTempo(int delay, float secondsPerQuarter) noexcept
 {
     // TODO
+    UNUSED(delay);
+    UNUSED(secondsPerQuarter);
 }
 
 void sfz::Voice::setSampleRate(float sampleRate) noexcept

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -479,7 +479,7 @@ void sfz::Voice::fillWithGenerator(AudioSpan<float> buffer) noexcept
         auto bends = tempSpan2.first(buffer.getNumFrames());
         auto phases = tempSpan2.first(buffer.getNumFrames());
 
-        const float step = baseFrequency * fTwoPi / sampleRate;
+        const float step = baseFrequency * twoPi<float>() / sampleRate;
         fill<float>(jumps, step);
 
         if (region->bendStep > 1)
@@ -496,8 +496,8 @@ void sfz::Voice::fillWithGenerator(AudioSpan<float> buffer) noexcept
         copy<float>(leftSpan, rightSpan);
 
         // Wrap the phase so we don't loose too much precision on longer notes
-        const auto numTwoPiWraps = static_cast<int>(phase / fTwoPi);
-        phase -= fTwoPi * static_cast<float>(numTwoPiWraps);
+        const auto numTwoPiWraps = static_cast<int>(phase / twoPi<float>());
+        phase -= twoPi<float>() * static_cast<float>(numTwoPiWraps);
     }
 }
 

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -479,7 +479,7 @@ void sfz::Voice::fillWithGenerator(AudioSpan<float> buffer) noexcept
         auto bends = tempSpan2.first(buffer.getNumFrames());
         auto phases = tempSpan2.first(buffer.getNumFrames());
 
-        const float step = baseFrequency * twoPi<float> / sampleRate;
+        const float step = baseFrequency * fTwoPi / sampleRate;
         fill<float>(jumps, step);
 
         if (region->bendStep > 1)
@@ -496,8 +496,8 @@ void sfz::Voice::fillWithGenerator(AudioSpan<float> buffer) noexcept
         copy<float>(leftSpan, rightSpan);
 
         // Wrap the phase so we don't loose too much precision on longer notes
-        const auto numTwoPiWraps = static_cast<int>(phase / twoPi<float>);
-        phase -= twoPi<float> * static_cast<float>(numTwoPiWraps);
+        const auto numTwoPiWraps = static_cast<int>(phase / fTwoPi);
+        phase -= fTwoPi * static_cast<float>(numTwoPiWraps);
     }
 }
 

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -45,7 +45,7 @@ void sfz::Voice::startVoice(Region* region, int delay, int number, uint8_t value
     pitchRatio = region->getBasePitchVariation(number, value);
 
     baseVolumedB = region->getBaseVolumedB(number);
-    auto volumedB { baseVolumedB };
+    auto volumedB = baseVolumedB;
     if (region->volumeCC)
         volumedB += normalizeCC(resources.midiState.getCCValue(region->volumeCC->cc)) * region->volumeCC->value;
     volumeEnvelope.reset(db2mag(Default::volumeRange.clamp(volumedB)));
@@ -63,19 +63,19 @@ void sfz::Voice::startVoice(Region* region, int delay, int number, uint8_t value
     crossfadeEnvelope.reset(Default::normalizedRange.clamp(crossfadeGain));
 
     basePan = normalizePercents(region->pan);
-    auto pan { basePan };
+    auto pan = basePan;
     if (region->panCC)
         pan += normalizeCC(resources.midiState.getCCValue(region->panCC->cc)) * normalizePercents(region->panCC->value);
     panEnvelope.reset(Default::symmetricNormalizedRange.clamp(pan));
 
     basePosition = normalizePercents(region->position);
-    auto position { basePosition };
+    auto position = basePosition;
     if (region->positionCC)
         position += normalizeCC(resources.midiState.getCCValue(region->positionCC->cc)) * normalizePercents(region->positionCC->value);
     positionEnvelope.reset(Default::symmetricNormalizedRange.clamp(position));
 
     baseWidth = normalizePercents(region->width);
-    auto width { baseWidth };
+    auto width = baseWidth;
     if (region->widthCC)
         width += normalizeCC(resources.midiState.getCCValue(region->widthCC->cc)) * normalizePercents(region->widthCC->value);
     widthEnvelope.reset(Default::symmetricNormalizedRange.clamp(width));

--- a/src/sfizz/effects/Lofi.cpp
+++ b/src/sfizz/effects/Lofi.cpp
@@ -37,7 +37,7 @@
 
 #include "Lofi.h"
 #include "Opcode.h"
-#include <memory>
+#include "absl/memory/memory.h"
 #include <algorithm>
 #include <cstring>
 #include <cmath>
@@ -79,7 +79,7 @@ namespace fx {
 
     std::unique_ptr<Effect> Lofi::makeInstance(absl::Span<const Opcode> members)
     {
-        auto fx = std::make_unique<Lofi>();
+        auto fx = absl::make_unique<Lofi>();
 
         for (const Opcode& opcode : members) {
             switch (opcode.lettersOnlyHash) {
@@ -92,7 +92,7 @@ namespace fx {
             }
         }
 
-        return fx;
+        return std::move(fx);
     }
 
     ///

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -6,10 +6,11 @@
 
 #include "Synth.h"
 #include "sfizz.hpp"
+#include "absl/memory/memory.h"
 
 sfz::Sfizz::Sfizz()
 {
-    synth = std::make_unique<sfz::Synth>();
+    synth = absl::make_unique<sfz::Synth>();
 }
 
 sfz::Sfizz::~Sfizz()

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -5,10 +5,10 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "Config.h"
+#include "Macros.h"
 #include "Synth.h"
 #include "sfizz.h"
 
-#define UNUSED(x) (void)(x)
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/tests/AudioBufferT.cpp
+++ b/tests/AudioBufferT.cpp
@@ -64,8 +64,8 @@ TEST_CASE("[AudioBuffer] Iterators")
     std::fill(buffer.channelWriter(0), buffer.channelWriterEnd(0), fillValue);
     std::fill(buffer.channelWriter(1), buffer.channelWriterEnd(1), fillValue);
 
-    REQUIRE(std::all_of(buffer.channelReader(0), buffer.channelReaderEnd(0), [fillValue](auto value) { return value == fillValue; }));
-    REQUIRE(std::all_of(buffer.channelReader(1), buffer.channelReaderEnd(1), [fillValue](auto value) { return value == fillValue; }));
+    REQUIRE(std::all_of(buffer.channelReader(0), buffer.channelReaderEnd(0), [fillValue](float value) { return value == fillValue; }));
+    REQUIRE(std::all_of(buffer.channelReader(1), buffer.channelReaderEnd(1), [fillValue](float value) { return value == fillValue; }));
 }
 
 TEST_CASE("[AudioSpan] Constructions")

--- a/tests/BufferT.cpp
+++ b/tests/BufferT.cpp
@@ -73,7 +73,7 @@ TEST_CASE("[Buffer] Resize 10 floats ")
     REQUIRE(buffer.resize(smallSize));
     checkBoundaries(buffer, smallSize);
 
-    REQUIRE(std::all_of(buffer.begin(), buffer.end(), [](auto value) { return value == 1.0f; }));
+    REQUIRE(std::all_of(buffer.begin(), buffer.end(), [](float value) { return value == 1.0f; }));
 
     REQUIRE(buffer.resize(bigSize));
     checkBoundaries(buffer, bigSize);
@@ -95,7 +95,7 @@ TEST_CASE("[Buffer] Resize 4096 floats ")
     REQUIRE(buffer.resize(smallSize));
     checkBoundaries(buffer, smallSize);
 
-    REQUIRE(std::all_of(buffer.begin(), buffer.end(), [](auto value) { return value == 1.0f; }));
+    REQUIRE(std::all_of(buffer.begin(), buffer.end(), [](float value) { return value == 1.0f; }));
 
     REQUIRE(buffer.resize(bigSize));
     checkBoundaries(buffer, bigSize);
@@ -117,7 +117,7 @@ TEST_CASE("[Buffer] Resize 65536 floats ")
     REQUIRE(buffer.resize(smallSize));
     checkBoundaries(buffer, smallSize);
 
-    REQUIRE(std::all_of(buffer.begin(), buffer.end(), [](auto value) { return value == 1.0f; }));
+    REQUIRE(std::all_of(buffer.begin(), buffer.end(), [](float value) { return value == 1.0f; }));
 
     REQUIRE(buffer.resize(bigSize));
     checkBoundaries(buffer, bigSize);
@@ -134,11 +134,11 @@ TEST_CASE("[Buffer] Copy and move")
     std::fill(copied.begin(), copied.end(), 2.0f);
     copied = buffer;
     checkBoundaries(copied, baseSize);
-    REQUIRE(std::all_of(copied.begin(), copied.end(), [](auto value) { return value == 1.0f; }));
+    REQUIRE(std::all_of(copied.begin(), copied.end(), [](float value) { return value == 1.0f; }));
 
     sfz::Buffer<float> copyConstructed { buffer };
     checkBoundaries(copyConstructed, baseSize);
-    REQUIRE(std::all_of(copyConstructed.begin(), copyConstructed.end(), [](auto value) { return value == 1.0f; }));
+    REQUIRE(std::all_of(copyConstructed.begin(), copyConstructed.end(), [](float value) { return value == 1.0f; }));
 
     // sfz::Buffer<float> moveConstructed { std::move(buffer) };
     // REQUIRE(buffer.empty());

--- a/tests/EventEnvelopesT.cpp
+++ b/tests/EventEnvelopesT.cpp
@@ -134,7 +134,7 @@ TEST_CASE("[LinearEnvelope] 2 events, with another block call")
 TEST_CASE("[LinearEnvelope] 2 events, function")
 {
     sfz::LinearEnvelope<float> envelope;
-    envelope.setFunction([](auto x) { return 2 * x; });
+    envelope.setFunction([](float x) { return 2 * x; });
     envelope.registerEvent(2, 1.0f);
     envelope.registerEvent(6, 2.0f);
     std::array<float, 8> output;

--- a/vst/cmake/Vst3.cmake
+++ b/vst/cmake/Vst3.cmake
@@ -36,6 +36,7 @@ function(plugin_add_vst3sdk NAME)
             "${VST3SDK_BASEDIR}/public.sdk/source/common/threadchecker_win32.cpp"
             "${VST3SDK_BASEDIR}/public.sdk/source/vst/vstgui_win32_bundle_support.cpp"
             "${VST3SDK_BASEDIR}/public.sdk/source/main/dllmain.cpp")
+        set_property(TARGET "${NAME}" PROPERTY CXX_STANDARD 14)
     elseif(APPLE)
         target_sources("${NAME}" PRIVATE
             "${VST3SDK_BASEDIR}/public.sdk/source/main/macmain.cpp")


### PR DESCRIPTION
For now it's more C++11 compatibility. For reference from #110 here is @falkTX patch with some of the `[[fallthrough]]` and `[[maybe_unused]]` things to remove too!

```patch
diff --git a/src/sfizz/Buffer.h b/src/sfizz/Buffer.h
index 757fe9c..e37b634 100644
--- a/src/sfizz/Buffer.h
+++ b/src/sfizz/Buffer.h
@@ -274,9 +274,9 @@ public:
         return counter;
     }
 private:
-    static constexpr auto AlignmentMask { Alignment - 1 };
-    static constexpr auto TypeAlignment { Alignment / sizeof(value_type) };
-    static constexpr auto TypeAlignmentMask { TypeAlignment - 1 };
+    static constexpr auto AlignmentMask = Alignment - 1U;
+    static constexpr auto TypeAlignment = Alignment / sizeof(value_type);
+    static constexpr auto TypeAlignmentMask = TypeAlignment - 1U;
     static_assert(std::is_arithmetic<value_type>::value, "Type should be arithmetic");
     static_assert(Alignment == 0 || Alignment == 4 || Alignment == 8 || Alignment == 16, "Bad alignment value");
     static_assert(TypeAlignment * sizeof(value_type) == Alignment, "The alignment does not appear to be divided by the size of the Type");
diff --git a/src/sfizz/EGDescription.h b/src/sfizz/EGDescription.h
index cc65551..ceba155 100644
--- a/src/sfizz/EGDescription.h
+++ b/src/sfizz/EGDescription.h
@@ -134,9 +134,12 @@ struct EGDescription
      * @param velocity
      * @return float
      */
-    float getStart(const SfzCCArray &ccValues, uint8_t velocity [[maybe_unused]]) const noexcept
+    float getStart(const SfzCCArray &ccValues, uint8_t velocity) const noexcept
     {
         return Default::egPercentRange.clamp(ccSwitchedValue(ccValues, ccStart, start));
+
+        // unused
+        (void)velocity;
     }
     /**
      * @brief Get the sustain level with possibly a CC modifier and a velocity modifier
diff --git a/src/sfizz/MathHelpers.h b/src/sfizz/MathHelpers.h
index aa99bec..60aec45 100644
--- a/src/sfizz/MathHelpers.h
+++ b/src/sfizz/MathHelpers.h
@@ -127,9 +127,7 @@ inline float midiNoteFrequency(const int noteNumber)
 template<class T>
 constexpr T clamp( T v, T lo, T hi )
 {
-    v = std::min(v, hi);
-    v = std::max(v, lo);
-    return v;
+    return std::max(std::min(v, hi), lo);
 }
 
 template<int Increment = 1, class T>
@@ -152,17 +150,17 @@ constexpr ValueType linearInterpolation(ValueType left, ValueType right, ValueTy
 }
 
 template <class Type>
-constexpr Type pi { static_cast<Type>(3.141592653589793238462643383279502884) };
+constexpr Type pi() { return static_cast<Type>(3.141592653589793238462643383279502884); };
 template <class Type>
-constexpr Type twoPi { static_cast<Type>(2) * pi<Type> };
+constexpr Type twoPi() { return static_cast<Type>(2) * pi<Type>(); };
 template <class Type>
-constexpr Type piTwo { pi<Type> / static_cast<Type>(2) };
+constexpr Type piTwo() { return pi<Type>() / static_cast<Type>(2); };
 template <class Type>
-constexpr Type piFour { pi<Type> / static_cast<Type>(4) };
+constexpr Type piFour() { return pi<Type>() / static_cast<Type>(4); };
 template <class Type>
-constexpr Type sqrtTwo { static_cast<Type>(1.414213562373095048801688724209698078569671875376948073176) };
+constexpr Type sqrtTwo() { return static_cast<Type>(1.414213562373095048801688724209698078569671875376948073176); };
 template <class Type>
-constexpr Type sqrtTwoInv { static_cast<Type>(0.707106781186547524400844362104849039284835937688474036588) };
+constexpr Type sqrtTwoInv() { return static_cast<Type>(0.707106781186547524400844362104849039284835937688474036588); };
 
 /**
    @brief A fraction which is parameterized by integer type
diff --git a/src/sfizz/MidiState.h b/src/sfizz/MidiState.h
index afba37c..e48e776 100644
--- a/src/sfizz/MidiState.h
+++ b/src/sfizz/MidiState.h
@@ -134,13 +134,13 @@ private:
      * @brief Stores the note on times.
      *
      */
-	MidiNoteArray<NoteOnTime> noteOnTimes { };
+	MidiNoteArray<NoteOnTime> noteOnTimes;
     /**
      * @brief Stores the velocity of the note ons for currently
      * depressed notes.
      *
      */
-	MidiNoteArray<uint8_t> lastNoteVelocities { };
+	MidiNoteArray<uint8_t> lastNoteVelocities;
     /**
      * @brief Current known values for the CCs.
      *
diff --git a/src/sfizz/Range.h b/src/sfizz/Range.h
index acb88c6..27fec5d 100644
--- a/src/sfizz/Range.h
+++ b/src/sfizz/Range.h
@@ -39,7 +39,7 @@ public:
     // }
     constexpr Range(Type start, Type end) noexcept
         : _start(start)
-        , _end(std::max(start, end))
+        , _end(start > end ? start : end)
     {
     }
     ~Range() = default;
diff --git a/src/sfizz/SIMDHelpers.h b/src/sfizz/SIMDHelpers.h
index f4c5a2d..678a985 100644
--- a/src/sfizz/SIMDHelpers.h
+++ b/src/sfizz/SIMDHelpers.h
@@ -734,7 +734,7 @@ namespace _internals {
         int i = 0;
 
         for (; i < panSize; ++i)
-            pan[i] = std::cos(i * (piTwo<double> / (panSize - 1)));
+            pan[i] = std::cos(i * (piTwo<double>() / (panSize - 1)));
 
         for (; i < static_cast<int>(pan.size()); ++i)
             pan[i] = pan[panSize - 1];
diff --git a/src/sfizz/SfzHelpers.h b/src/sfizz/SfzHelpers.h
index 1e590d1..fb8ce05 100644
--- a/src/sfizz/SfzHelpers.h
+++ b/src/sfizz/SfzHelpers.h
@@ -81,7 +81,7 @@ constexpr float normalizePercents(T percentValue)
  * @param bendValue
  * @return constexpr float
  */
-constexpr float normalizeBend(float bendValue)
+inline float normalizeBend(float bendValue)
 {
     return std::min(std::max(bendValue, -8191.0f), 8191.0f) / 8191.0f;
 }
@@ -199,7 +199,7 @@ constexpr void addToBase(T& base, T modifier)
  * @param base
  * @param modifier
  */
-constexpr void multiplyByCents(float& base, int modifier)
+inline void multiplyByCents(float& base, int modifier)
 {
     base *= centsFactor(modifier);
 }
diff --git a/src/sfizz/StringViewHelpers.h b/src/sfizz/StringViewHelpers.h
index 0cc49d3..7e198e8 100644
--- a/src/sfizz/StringViewHelpers.h
+++ b/src/sfizz/StringViewHelpers.h
@@ -61,8 +61,5 @@ constexpr uint64_t Fnv1aPrime = 0x01000193;
  */
 constexpr uint64_t hash(absl::string_view s, uint64_t h = Fnv1aBasis)
 {
-    if (s.length() > 0)
-        return hash( { s.data() + 1, s.length() - 1 }, (h ^ s.front()) * Fnv1aPrime );
-
-    return h;
+    return s.empty() ? h : hash( { s.data() + 1, s.length() - 1 }, (h ^ s.front()) * Fnv1aPrime );
 }
diff --git a/src/sfizz/Synth.cpp b/src/sfizz/Synth.cpp
index 0c3b3f8..cf024a5 100644
--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -156,7 +156,7 @@ void sfz::Synth::handleControlOpcodes(const std::vector<Opcode>& members)
         const auto backParameter = member.backParameter();
         switch (member.lettersOnlyHash) {
         case hash("Set_cc"):
-            [[fallthrough]];
+            // fall-through
         case hash("set_cc"):
             if (backParameter && Default::ccNumberRange.containsWithEnd(*backParameter)) {
                 const auto ccValue = readOpcode(member.value, Default::ccValueRange).value_or(0);
@@ -164,13 +164,13 @@ void sfz::Synth::handleControlOpcodes(const std::vector<Opcode>& members)
             }
             break;
         case hash("Label_cc"):
-            [[fallthrough]];
+            // fall-through
         case hash("label_cc"):
             if (backParameter && Default::ccNumberRange.containsWithEnd(*backParameter))
                 ccNames.emplace_back(*backParameter, std::string(member.value));
             break;
         case hash("Default_path"):
-            [[fallthrough]];
+            // fall-through
         case hash("default_path"):
             defaultPath = absl::StrReplaceAll(trim(member.value), { { "\\", "/" } });
             DBG("Changing default sample path to " << defaultPath);
@@ -273,7 +273,7 @@ bool sfz::Synth::loadSfzFile(const fs::path& file)
                 region->isStereo = true;
 
             // TODO: adjust with LFO targets
-            const auto maxOffset { region->offset + region->offsetRandom };
+            const uint maxOffset { region->offset + region->offsetRandom };
             if (!resources.filePool.preloadFile(region->sample, maxOffset))
                 removeCurrentRegion();
         }
@@ -363,7 +363,7 @@ sfz::Voice* sfz::Synth::findFreeVoice() noexcept
 
 int sfz::Synth::getNumActiveVoices() const noexcept
 {
-    auto activeVoices { 0 };
+    int activeVoices { 0 };
     for (const auto& voice : voices) {
         if (!voice->isFree())
             activeVoices++;
@@ -465,7 +465,7 @@ void sfz::Synth::noteOn(int delay, int noteNumber, uint8_t velocity) noexcept
     noteOnDispatch(delay, noteNumber, velocity);
 }
 
-void sfz::Synth::noteOff(int delay, int noteNumber, uint8_t velocity [[maybe_unused]]) noexcept
+void sfz::Synth::noteOff(int delay, int noteNumber, uint8_t velocity) noexcept
 {
     ASSERT(noteNumber < 128);
     ASSERT(noteNumber >= 0);
@@ -485,7 +485,10 @@ void sfz::Synth::noteOff(int delay, int noteNumber, uint8_t velocity [[maybe_unu
     for (auto& voice : voices)
         voice->registerNoteOff(delay, noteNumber, replacedVelocity);
 
-    noteOffDispatch(delay, noteNumber, replacedVelocity);
+    return noteOffDispatch(delay, noteNumber, replacedVelocity);
+
+    // unused
+    (void)velocity;
 }
 
 void sfz::Synth::noteOffDispatch(int delay, int noteNumber, uint8_t velocity) noexcept
```