### PR TITLE
Fix travis buildenv in prepare_tarball

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     stage: "Build"
     env:
     - CROSS_COMPILE=mingw32
-    - CONTAINER=cross
+    - CONTAINER=archlinux
     - INSTALL_DIR="sfizz-${TRAVIS_BRANCH}-mingw32"
     before_install: .travis/before_install_mingw.sh
     install: .travis/install_mingw.sh
@@ -48,7 +48,7 @@ jobs:
   - name: "Windows mingw64"
     env:
     - CROSS_COMPILE=mingw64
-    - CONTAINER=cross
+    - CONTAINER=archlinux
     - INSTALL_DIR="sfizz-${TRAVIS_BRANCH}-mingw64"
     before_install: .travis/before_install_mingw.sh
     install: .travis/install_mingw.sh

--- a/.travis/before_install_mingw.sh
+++ b/.travis/before_install_mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-. .travis/mingw_container.sh
+. .travis/docker_container.sh
 
 buildenv bash -c "echo Hello from container" # ensure to start the container
 docker cp "$container":/etc/pacman.conf pacman.conf

--- a/.travis/docker_container.sh
+++ b/.travis/docker_container.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 buildenv() {
-  setup_container archlinux
+  setup_container "$CONTAINER"
   docker exec -w "$(pwd)" -i -t "$container" "$@"
 }
 

--- a/.travis/install_mingw.sh
+++ b/.travis/install_mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-. .travis/mingw_container.sh
+. .travis/docker_container.sh
 
 buildenv pacman -Sqy --noconfirm
 buildenv pacman -Sq --noconfirm base-devel wget mingw-w64-cmake mingw-w64-gcc mingw-w64-pkg-config mingw-w64-libsndfile

--- a/.travis/no_container.sh
+++ b/.travis/no_container.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+buildenv() {
+  "$@"
+}

--- a/.travis/prepare_tarball.sh
+++ b/.travis/prepare_tarball.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 set -ex
-. .travis/mingw_container.sh
+
+if ! [ -z "$CONTAINER" ]; then
+  . .travis/docker_container.sh
+else
+  . .travis/no_container.sh
+fi
 
 # Do not prepare a tarball without a tag
 if [[ ${TRAVIS_TAG} == "" ]]; then

--- a/.travis/script_mingw.sh
+++ b/.travis/script_mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -ex
-. .travis/mingw_container.sh
+. .travis/docker_container.sh
 
 mkdir -p build/${INSTALL_DIR} && cd build
 if [[ ${CROSS_COMPILE} == "mingw32" ]]; then


### PR DESCRIPTION
The goal of this PR is to fix a problem in CI, which is bound to arrive at the moment of deployment.
It's sure to conflict with #112, but I'll fix it later

There exists the function `buildenv` which can prefix a command in order to run it in the container.

When `prepare_tarball.sh` is invoked, and a tag is present, `buildenv` will be called to prefix `make install`. But `buildenv` is only defined when it's docker (mingw).

- I make the docker process more generic to accept the image name by environment (`$CONTAINER`).
- if `$CONTAINER` is set, we can know this target uses docker
- use this information in `prepare_tarball` in order to call it under appropriate `buildenv` (a dummy in case of Linux or Mac)