### PR TITLE
Add Travis builds for VST

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: cpp
 os: linux
 dist: bionic
 
+cache:
+  directories:
+  - vst/download/
+
 jobs:
   include:
   - name: "clang-tidy checks"
@@ -81,10 +85,11 @@ jobs:
     script: .travis/script_library.sh
     after_success: .travis/prepare_tarball.sh
 
-  - name: "Linux arm64 static LV2"
+  - name: "Linux arm64 static plugins"
     arch: arm64
     env:
-    - INSTALL_DIR="sfizz-lv2-${TRAVIS_BRANCH}-${TRAVIS_OS_NAME}-${TRAVIS_CPU_ARCH}"
+    - INSTALL_DIR="sfizz-plugins-${TRAVIS_BRANCH}-${TRAVIS_OS_NAME}-${TRAVIS_CPU_ARCH}"
+    - ENABLE_VST_PLUGIN=OFF
     addons:
       apt:
         packages:
@@ -93,21 +98,31 @@ jobs:
     install:
     - .travis/download_cmake.sh
     - .travis/download_static_libs.sh
-    script: .travis/script_lv2.sh
+    script: .travis/script_plugins.sh
     after_success: .travis/prepare_tarball.sh
 
-  - name: "Linux amd64 static LV2"
+  - name: "Linux amd64 static plugins"
     env:
-    - INSTALL_DIR="sfizz-lv2-${TRAVIS_BRANCH}-${TRAVIS_OS_NAME}-${TRAVIS_CPU_ARCH}"
+    - INSTALL_DIR="sfizz-plugins-${TRAVIS_BRANCH}-${TRAVIS_OS_NAME}-${TRAVIS_CPU_ARCH}"
+    - ENABLE_VST_PLUGIN=ON
     addons:
       apt:
         packages:
         - libjack-jackd2-dev
         - libsndfile1-dev
+        - libcairo2-dev
+        - libfontconfig1-dev
+        - libx11-xcb-dev
+        - libxcb-util-dev
+        - libxcb-cursor-dev
+        - libxcb-xkb-dev
+        - libxkbcommon-dev
+        - libxkbcommon-x11-dev
+        - libxcb-keysyms1-dev
     install:
     - .travis/download_cmake.sh
     - .travis/download_static_libs.sh
-    script: .travis/script_lv2.sh
+    script: .travis/script_plugins.sh
     after_success: .travis/prepare_tarball.sh
 
   - name: "macOS"

--- a/.travis/patches/vstsdk-3.6.14-mingw-atomic-add.diff
+++ b/.travis/patches/vstsdk-3.6.14-mingw-atomic-add.diff
@@ -1,0 +1,12 @@
+diff -Nru VST_SDK.orig/VST3_SDK/pluginterfaces/base/funknown.cpp VST_SDK/VST3_SDK/pluginterfaces/base/funknown.cpp
+--- VST_SDK.orig/VST3_SDK/pluginterfaces/base/funknown.cpp	2019-12-02 13:58:41.000000000 +0100
++++ VST_SDK/VST3_SDK/pluginterfaces/base/funknown.cpp	2020-03-10 22:02:26.220911670 +0100
+@@ -84,7 +84,7 @@
+ int32 PLUGIN_API atomicAdd (int32& var, int32 d)
+ {
+ #if SMTG_OS_WINDOWS
+-	return InterlockedExchangeAdd (&var, d) + d;
++	return InterlockedExchangeAdd ((LONG*)&var, d) + d;
+ #elif SMTG_OS_MACOS
+ #if SMTG_MACOS_USE_STDATOMIC
+ 	return atomic_fetch_add (reinterpret_cast<atomic_int_least32_t*> (&var), d) + d;

--- a/.travis/script_library.sh
+++ b/.travis/script_library.sh
@@ -2,5 +2,5 @@
 set -ex
 
 mkdir -p build/${INSTALL_DIR} && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release -DSFIZZ_LV2=OFF -DSFIZZ_TESTS=OFF ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release -DSFIZZ_LV2=OFF -DSFIZZ_VST=OFF -DSFIZZ_TESTS=OFF ..
 make -j$(nproc)

--- a/.travis/script_lv2.sh
+++ b/.travis/script_lv2.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -ex
-
-mkdir -p build/${INSTALL_DIR} && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DSFIZZ_JACK=OFF -DSFIZZ_TESTS=OFF -DSFIZZ_SHARED=OFF -DSFIZZ_STATIC_LIBSNDFILE=ON ..
-make -j$(nproc)

--- a/.travis/script_mingw.sh
+++ b/.travis/script_mingw.sh
@@ -5,9 +5,11 @@ set -ex
 
 mkdir -p build/${INSTALL_DIR} && cd build
 if [[ ${CROSS_COMPILE} == "mingw32" ]]; then
-  buildenv i686-w64-mingw32-cmake -DCMAKE_BUILD_TYPE=Release -DSFIZZ_JACK=OFF -DSFIZZ_STATIC_LIBSNDFILE=ON ..
+  buildenv i686-w64-mingw32-cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LTO=OFF -DSFIZZ_JACK=OFF -DSFIZZ_VST=ON -DSFIZZ_STATIC_LIBSNDFILE=ON ..
+  buildenv patch -p1 -i "$(pwd)"/../.travis/patches/vstsdk-3.6.14-mingw-atomic-add.diff -d ../vst/external/VST_SDK
   buildenv make -j
 elif [[ ${CROSS_COMPILE} == "mingw64" ]]; then
-  buildenv x86_64-w64-mingw32-cmake -DCMAKE_BUILD_TYPE=Release -DSFIZZ_JACK=OFF -DSFIZZ_STATIC_LIBSNDFILE=ON ..
+  buildenv x86_64-w64-mingw32-cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LTO=OFF -DSFIZZ_JACK=OFF -DSFIZZ_VST=ON -DSFIZZ_STATIC_LIBSNDFILE=ON ..
+  buildenv patch -p1 -i "$(pwd)"/../.travis/patches/vstsdk-3.6.14-mingw-atomic-add.diff -d ../vst/external/VST_SDK
   buildenv make -j
 fi

--- a/.travis/script_mingw.sh
+++ b/.travis/script_mingw.sh
@@ -7,9 +7,9 @@ mkdir -p build/${INSTALL_DIR} && cd build
 if [[ ${CROSS_COMPILE} == "mingw32" ]]; then
   buildenv i686-w64-mingw32-cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LTO=OFF -DSFIZZ_JACK=OFF -DSFIZZ_VST=ON -DSFIZZ_STATIC_LIBSNDFILE=ON ..
   buildenv patch -p1 -i "$(pwd)"/../.travis/patches/vstsdk-3.6.14-mingw-atomic-add.diff -d ../vst/external/VST_SDK
-  buildenv make -j
+  buildenv make -j$(nproc)
 elif [[ ${CROSS_COMPILE} == "mingw64" ]]; then
   buildenv x86_64-w64-mingw32-cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LTO=OFF -DSFIZZ_JACK=OFF -DSFIZZ_VST=ON -DSFIZZ_STATIC_LIBSNDFILE=ON ..
   buildenv patch -p1 -i "$(pwd)"/../.travis/patches/vstsdk-3.6.14-mingw-atomic-add.diff -d ../vst/external/VST_SDK
-  buildenv make -j
+  buildenv make -j$(nproc)
 fi

--- a/.travis/script_osx.sh
+++ b/.travis/script_osx.sh
@@ -2,7 +2,7 @@
 set -ex
 
 mkdir -p build/${INSTALL_DIR} && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DSFIZZ_TESTS=OFF ..
+cmake -DCMAKE_BUILD_TYPE=Release -DSFIZZ_VST=ON -DSFIZZ_TESTS=OFF ..
 make -j$(sysctl -n hw.ncpu)
 # Xcode not currently supported, see https://gitlab.kitware.com/cmake/cmake/issues/18088
 # xcodebuild -project sfizz.xcodeproj -alltargets -configuration Debug build

--- a/.travis/script_plugins.sh
+++ b/.travis/script_plugins.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ex
+
+mkdir -p build/${INSTALL_DIR} && cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DSFIZZ_JACK=OFF -DSFIZZ_VST="$ENABLE_VST_PLUGIN" -DSFIZZ_TESTS=OFF -DSFIZZ_SHARED=OFF -DSFIZZ_STATIC_LIBSNDFILE=ON ..
+make -j$(nproc)

--- a/cmake/VSTConfig.cmake
+++ b/cmake/VSTConfig.cmake
@@ -3,6 +3,14 @@ set (VSTPLUGIN_VENDOR          "Paul Ferrand")
 set (VSTPLUGIN_URL             "http://sfztools.github.io/sfizz")
 set (VSTPLUGIN_EMAIL           "paul@ferrand.cc")
 
+if (MSVC)
+    set (VSTPLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/vst3" CACHE STRING
+    "Install destination for VST bundle [default: ${CMAKE_INSTALL_PREFIX}/vst3}]")
+else()
+    set (VSTPLUGIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/vst3" CACHE STRING
+    "Install destination for VST bundle [default: ${CMAKE_INSTALL_PREFIX}/lib/vst3}]")
+endif()
+
 # The variable CMAKE_SYSTEM_PROCESSOR is incorrect on Visual studio...
 # see https://gitlab.kitware.com/cmake/cmake/issues/15170
 

--- a/vst/CMakeLists.txt
+++ b/vst/CMakeLists.txt
@@ -120,3 +120,9 @@ endif()
 if (FALSE)
     target_link_options(${VSTPLUGIN_PRJ_NAME} PRIVATE "-Wl,-no-undefined")
 endif()
+
+# Installation
+if (NOT MSVC)
+    install (DIRECTORY "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}"
+        DESTINATION "${VSTPLUGIN_INSTALL_DIR}")
+endif()


### PR DESCRIPTION
This builds the VST plugins in Travis.
A patch is added which fixes VSTSDK for MinGW.

Also, I disable LTO on MinGW because it fails the builds.
It fails to link because of some duplicate symbols in namespace Steinberg.

(side note: it's not the only problem that LTO causes.
I was also forced to disable it in some Fedora RPM builds)
