### PR TITLE
Update clang-tidy with VST and filters additions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,10 @@ jobs:
       apt:
         packages:
         - clang-tidy
+        - wget
+        - unzip
         - libsndfile-dev
-    install: skip
+    install: .travis/download_vst_sdk.sh
     script: scripts/run_clang_tidy.sh
 
   - name: "Linux amd64 tests"

--- a/.travis/download_vst_sdk.sh
+++ b/.travis/download_vst_sdk.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ex
+
+vst_sdk_archive="vst-sdk_3.6.14_build-24_2019-11-29.zip"
+wget "https://download.steinberg.net/sdk_downloads/${vst_sdk_archive}"
+mkdir -p vst/external
+unzip -ouq ${vst_sdk_archive} -d vst/external

--- a/.travis/download_vst_sdk.sh
+++ b/.travis/download_vst_sdk.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -ex
 
+vst_download_prefix="vst/download"
 vst_sdk_archive="vst-sdk_3.6.14_build-24_2019-11-29.zip"
-wget "https://download.steinberg.net/sdk_downloads/${vst_sdk_archive}"
+mkdir -p ${vst_download_prefix}
+if ! [[ -f "${vst_download_prefix}/${vst_sdk_archive}" ]]; then
+  wget -P ${vst_download_prefix} "https://download.steinberg.net/sdk_downloads/${vst_sdk_archive}"
+fi
 mkdir -p vst/external
-unzip -ouq ${vst_sdk_archive} -d vst/external
+unzip -ouq "${vst_download_prefix}/${vst_sdk_archive}" -d "vst/external"

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -19,6 +19,14 @@ clang-tidy \
   src/sfizz/SIMDSSE.cpp \
   src/sfizz/Synth.cpp \
   src/sfizz/Voice.cpp \
+  src/sfizz/effects/Eq.cpp \
+  src/sfizz/effects/Filter.cpp \
   src/sfizz/effects/Lofi.cpp \
   src/sfizz/effects/Nothing.cpp \
-  -- -Iexternal/abseil-cpp -Isrc/external -Isrc/external/pugixml/src -Isrc/sfizz -Isrc
+  vst/SfizzVstController.cpp \
+  vst/SfizzVstProcessor.cpp \
+  vst/SfizzVstEditor.cpp \
+  vst/SfizzVstState.cpp \
+  -- -Iexternal/abseil-cpp -Isrc/external -Isrc/external/pugixml/src \
+      -Isrc/sfizz -Isrc \
+      -Ivst -Ivst/external/VST_SDK/VST3_SDK -Ivst/external/VST_SDK/VST3_SDK/vstgui4 -DNDEBUG

--- a/vst/SfizzVstController.cpp
+++ b/vst/SfizzVstController.cpp
@@ -84,7 +84,7 @@ tresult PLUGIN_API SfizzVstControllerNoUi::getParamStringByValue(Vst::ParamID ta
     switch (tag) {
     case kPidOversampling:
         {
-            int factorLog2 = kParamOversamplingRange.denormalize(valueNormalized);
+            auto factorLog2 = static_cast<int>(kParamOversamplingRange.denormalize(valueNormalized));
             Steinberg::String buf;
             buf.printf("%dX", 1 << factorLog2);
             buf.copyTo(string);

--- a/vst/SfizzVstProcessor.cpp
+++ b/vst/SfizzVstProcessor.cpp
@@ -256,7 +256,7 @@ void SfizzVstProcessor::processControllerChanges(Vst::IParameterChanges& pc)
         switch (id) {
         default:
             if (id >= kPidMidiCC0 && id <= kPidMidiCCLast) {
-                int ccNumber = id - kPidMidiCC0;
+                auto ccNumber = static_cast<int>(id - kPidMidiCC0);
                 for (uint32 pointIndex = 0; pointIndex < pointCount; ++pointIndex) {
                     if (vq->getPoint(pointIndex, sampleOffset, value) == kResultTrue)
                         synth.cc(sampleOffset, ccNumber, fastRound(value * 127.0));

--- a/vst/SfizzVstProcessor.cpp
+++ b/vst/SfizzVstProcessor.cpp
@@ -196,7 +196,7 @@ void SfizzVstProcessor::processParameterChanges(Vst::IParameterChanges& pc)
                     break;
                 msg->setMessageID("SetNumVoices");
                 Vst::IAttributeList* attr = msg->getAttributes();
-                attr->setInt("NumVoices", kParamNumVoicesRange.denormalize(value));
+                attr->setInt("NumVoices", static_cast<Steinberg::int64>(kParamNumVoicesRange.denormalize(value)));
                 if (!_fifoToWorker.push(msg)) {
                     msg->release();
                     break;
@@ -211,7 +211,7 @@ void SfizzVstProcessor::processParameterChanges(Vst::IParameterChanges& pc)
                     break;
                 msg->setMessageID("SetOversampling");
                 Vst::IAttributeList* attr = msg->getAttributes();
-                attr->setInt("Oversampling", kParamOversamplingRange.denormalize(value));
+                attr->setInt("Oversampling", static_cast<Steinberg::int64>(kParamOversamplingRange.denormalize(value)));
                 if (!_fifoToWorker.push(msg)) {
                     msg->release();
                     break;
@@ -226,7 +226,7 @@ void SfizzVstProcessor::processParameterChanges(Vst::IParameterChanges& pc)
                     break;
                 msg->setMessageID("SetPreloadSize");
                 Vst::IAttributeList* attr = msg->getAttributes();
-                attr->setInt("PreloadSize", kParamPreloadSizeRange.denormalize(value));
+                attr->setInt("PreloadSize", static_cast<Steinberg::int64>(kParamPreloadSizeRange.denormalize(value)));
                 if (!_fifoToWorker.push(msg)) {
                     msg->release();
                     break;


### PR DESCRIPTION
And remove some linting error along the way. The most would probably be the `~SfizzVstProcessor`. I don't call `setEnable` but only stop the background thread, and within a `try` block to avoid excepting in the destructor. Apparently you cannot call virtual functions in destructors.

I'll rebase on the filter additions when done.