### PR TITLE
Make the macOS build universal binary

### DIFF
--- a/.travis/script_osx.sh
+++ b/.travis/script_osx.sh
@@ -2,7 +2,7 @@
 set -ex
 
 mkdir -p build/${INSTALL_DIR} && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DSFIZZ_VST=ON -DSFIZZ_TESTS=OFF ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="i386;x86_64" -DSFIZZ_VST=ON -DSFIZZ_TESTS=OFF ..
 make -j$(sysctl -n hw.ncpu)
 # Xcode not currently supported, see https://gitlab.kitware.com/cmake/cmake/issues/18088
 # xcodebuild -project sfizz.xcodeproj -alltargets -configuration Debug build


### PR DESCRIPTION
Let's check if i386 builds passes on Mac.