### PR TITLE
Avoid purging and recreating the synth in Reaper

### DIFF
--- a/lv2/sfizz.c
+++ b/lv2/sfizz.c
@@ -416,7 +416,8 @@ activate(LV2_Handle instance)
 static void
 deactivate(LV2_Handle instance)
 {
-    UNUSED(instance);
+    sfizz_plugin_t *self = (sfizz_plugin_t *)instance;
+    sfizz_all_sound_off(self->synth);
 }
 
 static void

--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -369,6 +369,13 @@ SFIZZ_EXPORTED_API void sfizz_enable_logging(sfizz_synth_t* synth);
  */
 SFIZZ_EXPORTED_API void sfizz_disable_logging(sfizz_synth_t* synth);
 
+/**
+ * @brief Shuts down the current processing, clear buffers and reset the voices.
+ *
+ * @param synth
+ */
+SFIZZ_EXPORTED_API void sfizz_all_sound_off(sfizz_synth_t* synth);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -256,6 +256,11 @@ public:
      *
      */
     void disableLogging() noexcept;
+    /**
+     * @brief Shuts down the current processing, clear buffers and reset the voices.
+     *
+     */
+    void allSoundOff() noexcept;
 private:
     std::unique_ptr<sfz::Synth> synth;
 };

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -579,6 +579,8 @@ void sfz::Synth::noteOn(int delay, int noteNumber, uint8_t velocity) noexcept
     ASSERT(noteNumber < 128);
     ASSERT(noteNumber >= 0);
 
+    DBG("Note on at " << noteNumber << " (" << +velocity << ")");
+
     ScopedTiming logger { dispatchDuration, ScopedTiming::Operation::addToDuration };
     resources.midiState.noteOnEvent(delay, noteNumber, velocity);
 
@@ -594,6 +596,8 @@ void sfz::Synth::noteOff(int delay, int noteNumber, uint8_t velocity) noexcept
     ASSERT(noteNumber < 128);
     ASSERT(noteNumber >= 0);
     UNUSED(velocity);
+
+    DBG("Note off at " << noteNumber << " (" << +velocity << ")");
 
     ScopedTiming logger { dispatchDuration, ScopedTiming::Operation::addToDuration };
     resources.midiState.noteOffEvent(delay, noteNumber, velocity);
@@ -961,4 +965,12 @@ void sfz::Synth::enableLogging() noexcept
 void sfz::Synth::disableLogging() noexcept
 {
     resources.logger.disableLogging();
+}
+
+void sfz::Synth::allSoundOff() noexcept
+{
+    for (auto &voice: voices)
+        voice->reset();
+    for (auto& effectBus: effectBuses)
+        effectBus->clear();
 }

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -965,6 +965,11 @@ void sfz::Synth::disableLogging() noexcept
 
 void sfz::Synth::allSoundOff() noexcept
 {
+    AtomicDisabler callbackDisabler{ canEnterCallback };
+    while (inCallback) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
     for (auto &voice: voices)
         voice->reset();
     for (auto& effectBus: effectBuses)

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -579,8 +579,6 @@ void sfz::Synth::noteOn(int delay, int noteNumber, uint8_t velocity) noexcept
     ASSERT(noteNumber < 128);
     ASSERT(noteNumber >= 0);
 
-    DBG("Note on at " << noteNumber << " (" << +velocity << ")");
-
     ScopedTiming logger { dispatchDuration, ScopedTiming::Operation::addToDuration };
     resources.midiState.noteOnEvent(delay, noteNumber, velocity);
 
@@ -596,8 +594,6 @@ void sfz::Synth::noteOff(int delay, int noteNumber, uint8_t velocity) noexcept
     ASSERT(noteNumber < 128);
     ASSERT(noteNumber >= 0);
     UNUSED(velocity);
-
-    DBG("Note off at " << noteNumber << " (" << +velocity << ")");
 
     ScopedTiming logger { dispatchDuration, ScopedTiming::Operation::addToDuration };
     resources.midiState.noteOffEvent(delay, noteNumber, velocity);

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -361,6 +361,12 @@ public:
      *
      */
     void disableLogging() noexcept;
+
+    /**
+     * @brief Shuts down the current processing, clear buffers and reset the voices.
+     *
+     */
+    void allSoundOff() noexcept;
 protected:
     /**
      * @brief The parser callback; this is called by the parent object each time

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -195,3 +195,8 @@ void sfz::Sfizz::disableLogging() noexcept
 {
     synth->disableLogging();
 }
+
+void sfz::Sfizz::allSoundOff() noexcept
+{
+    synth->allSoundOff();
+}

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -237,10 +237,17 @@ void sfizz_enable_logging(sfizz_synth_t* synth)
     auto self = reinterpret_cast<sfz::Synth*>(synth);
     return self->enableLogging();
 }
+
 void sfizz_disable_logging(sfizz_synth_t* synth)
 {
     auto self = reinterpret_cast<sfz::Synth*>(synth);
     return self->disableLogging();
+}
+
+void sfizz_all_sound_off(sfizz_synth_t* synth)
+{
+    auto self = reinterpret_cast<sfz::Synth*>(synth);
+    return self->allSoundOff();
 }
 
 #ifdef __cplusplus

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -26,6 +26,17 @@ TEST_CASE("[Synth] Play and check active voices")
     REQUIRE(synth.getNumActiveVoices() == 0);
 }
 
+TEST_CASE("[Synth] All sound off")
+{
+    sfz::Synth synth;
+    synth.loadSfzFile(fs::current_path() / "tests/TestFiles/groups_avl.sfz");
+    synth.noteOn(0, 36, 24);
+    synth.noteOn(0, 36, 89);
+    REQUIRE(synth.getNumActiveVoices() == 2);
+    synth.allSoundOff();
+    REQUIRE(synth.getNumActiveVoices() == 0);
+}
+
 TEST_CASE("[Synth] Change the number of voice while playing")
 {
     sfz::Synth synth;

--- a/vst/SfizzVstProcessor.cpp
+++ b/vst/SfizzVstProcessor.cpp
@@ -48,10 +48,6 @@ tresult PLUGIN_API SfizzVstProcessor::initialize(FUnknown* context)
 
     fprintf(stderr, "[sfizz] new synth\n");
     _synth.reset(new sfz::Sfizz);
-    if (!_synth) {
-        fprintf(stderr, "[sfizz] Could not create synth!\n");
-        return kResultFalse;
-    }
 
     return result;
 }
@@ -114,16 +110,8 @@ tresult PLUGIN_API SfizzVstProcessor::setActive(TBool state)
 {
     sfz::Sfizz* synth = _synth.get();
 
-    if (!synth) {
-        fprintf(stderr, "[sfizz] Synth was destroyed? Trying to recreate...\n");
-        synth = new sfz::Sfizz;
-        if (!synth) {
-            fprintf(stderr, "[sfizz] Something is very wrong\n");
-            return kResultFalse;
-        }
-        _synth.reset(synth);
-        syncStateToSynth();
-    }
+    if (!synth)
+        return kResultFalse;
 
     if (state) {
         _synth->setSampleRate(processSetup.sampleRate);

--- a/vst/SfizzVstProcessor.cpp
+++ b/vst/SfizzVstProcessor.cpp
@@ -114,12 +114,13 @@ tresult PLUGIN_API SfizzVstProcessor::setActive(TBool state)
         return kResultFalse;
 
     if (state) {
-        _synth->setSampleRate(processSetup.sampleRate);
-        _synth->setSamplesPerBlock(processSetup.maxSamplesPerBlock);
+        synth->setSampleRate(processSetup.sampleRate);
+        synth->setSamplesPerBlock(processSetup.maxSamplesPerBlock);
 
         _workRunning = true;
         _worker = std::thread([this]() { doBackgroundWork(); });
     } else {
+        synth->allSoundOff();
         stopBackgroundWork();
     }
 


### PR DESCRIPTION
It's less clear in Bitwig because I did not attach the console, but Reaper calls `setEnable(false)` when transport stops, and `setEnable(true)` when it starts. This triggers a destruction and recreation/reloading of the sample files in the current state. I changed it to only adapt the sample rate if needed and start/stop the background worker.