### PR TITLE
Proper tuning of wavetable generators

### DIFF
--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -177,7 +177,7 @@ namespace Default
 	constexpr int transpose { 0 };
 	constexpr Range<int> transposeRange { -127, 127 };
 	constexpr int tune { 0 };
-	constexpr Range<int> tuneRange { -100, 100 };
+	constexpr Range<int> tuneRange { -9600, 9600 }; // ±100 in SFZv1, more in ARIA
     constexpr Range<int> bendBoundRange { -9600, 9600 };
     constexpr Range<int> bendStepRange { 1, 1200 };
     constexpr int bendUp { 200 }; // No range here because the bounds can be inverted

--- a/src/sfizz/MathHelpers.h
+++ b/src/sfizz/MathHelpers.h
@@ -110,7 +110,7 @@ namespace Random {
  */
 inline float midiNoteFrequency(const int noteNumber)
 {
-    return 440.0f * std::pow(2.0f, (noteNumber - 69) / 12.0f);
+    return 440.0f * std::pow(2.0f, (noteNumber - 69) * (1.0f / 12.0f));
 }
 
 /**

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -506,7 +506,8 @@ void sfz::Voice::fillWithGenerator(AudioSpan<float> buffer) noexcept
         auto frequencies = tempSpan1.first(buffer.getNumFrames());
         auto bends = tempSpan2.first(buffer.getNumFrames());
 
-        fill<float>(frequencies, baseFrequency);
+        float keycenterFrequency = midiNoteFrequency(region->pitchKeycenter);
+        fill<float>(frequencies, pitchRatio * keycenterFrequency);
 
         if (region->bendStep > 1)
             pitchBendEnvelope.getQuantizedBlock(bends, bendStepFactor);

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -792,10 +792,10 @@ TEST_CASE("[Region] Parsing opcodes")
         REQUIRE(region.tune == 40);
         region.parseOpcode({ "tune", "-1" });
         REQUIRE(region.tune == -1);
-        region.parseOpcode({ "tune", "154" });
-        REQUIRE(region.tune == 100);
-        region.parseOpcode({ "tune", "-154" });
-        REQUIRE(region.tune == -100);
+        region.parseOpcode({ "tune", "15432" });
+        REQUIRE(region.tune == 9600);
+        region.parseOpcode({ "tune", "-15432" });
+        REQUIRE(region.tune == -9600);
     }
 
     SECTION("bend_up, bend_down, bend_step")


### PR DESCRIPTION
The changes allows to take in consideration the pitch ratio.
It fixes the use of `tune`/`pitch` and oscillators together.