### PR TITLE
Add oscillator=on and wavetables from file

### DIFF
--- a/src/sfizz/FilePool.cpp
+++ b/src/sfizz/FilePool.cpp
@@ -90,6 +90,10 @@ void streamFromFile(SndfileHandle& sndFile, uint32_t numFrames, sfz::Oversamplin
 sfz::FilePool::FilePool(sfz::Logger& logger)
 : logger(logger)
 {
+    FilePromise promise;
+    if (!promise.dataStatus.is_lock_free())
+        DBG("atomic<DataStatus> is not lock-free; could cause issues with locking");
+
     for (int i = 0; i < config::numBackgroundThreads; ++i)
         threadPool.emplace_back( &FilePool::loadingThread, this );
 

--- a/src/sfizz/FilePool.h
+++ b/src/sfizz/FilePool.h
@@ -38,7 +38,6 @@
 #include "Logger.h"
 #include <chrono>
 #include <thread>
-#include <sndfile.hh>
 
 namespace sfz {
 using AudioBufferPtr = std::shared_ptr<AudioBuffer<float>>;

--- a/src/sfizz/FilePool.h
+++ b/src/sfizz/FilePool.h
@@ -43,11 +43,19 @@ namespace sfz {
 using AudioBufferPtr = std::shared_ptr<AudioBuffer<float>>;
 
 
+struct FileInformation {
+    uint32_t end { Default::sampleEndRange.getEnd() };
+    uint32_t loopBegin { Default::loopRange.getStart() };
+    uint32_t loopEnd { Default::loopRange.getEnd() };
+    double sampleRate { config::defaultSampleRate };
+    int numChannels { 0 };
+};
+
 // Strict C++11 disallows member initialization if aggregate initialization is to be used...
-struct PreloadedFileHandle
+struct FileDataHandle
 {
     std::shared_ptr<AudioBuffer<float>> preloadedData;
-    float sampleRate;
+    FileInformation information;
 };
 
 struct FilePromise
@@ -142,14 +150,6 @@ public:
      */
     size_t getNumPreloadedSamples() const noexcept { return preloadedFiles.size(); }
 
-    struct FileInformation {
-        uint32_t end { Default::sampleEndRange.getEnd() };
-        uint32_t loopBegin { Default::loopRange.getStart() };
-        uint32_t loopEnd { Default::loopRange.getEnd() };
-        double sampleRate { config::defaultSampleRate };
-        int numChannels { 0 };
-    };
-
     /**
      * @brief Get metadata information about a file.
      *
@@ -159,7 +159,7 @@ public:
     absl::optional<FileInformation> getFileInformation(const std::string& filename) noexcept;
 
     /**
-     * @brief Check that a file is preloaded with the proper offset bounds
+     * @brief Preload a file with the proper offset bounds
      *
      * @param filename
      * @param offset the maximum offset to consider for preloading. The total preloaded
@@ -168,6 +168,15 @@ public:
      * @return false if something went wrong ()
      */
     bool preloadFile(const std::string& filename, uint32_t maxOffset) noexcept;
+
+    /**
+     * @brief Load a file and return its information. The file pool will store this
+     * data for future requests so use this function responsibly.
+     *
+     * @param filename
+     * @return A handle on the file data
+     */
+    absl::optional<sfz::FileDataHandle> loadFile(const std::string& filename) noexcept;
 
     /**
      * @brief Check that the sample exists. If not, try to find it in a case insensitive way.
@@ -258,7 +267,9 @@ private:
     std::atomic<bool> addingPromisesToClear { false };
     std::atomic<bool> canAddPromisesToClear { true };
 
-    absl::flat_hash_map<absl::string_view, PreloadedFileHandle> preloadedFiles;
+    // Preloaded data
+    absl::flat_hash_map<absl::string_view, FileDataHandle> preloadedFiles;
+    absl::flat_hash_map<absl::string_view, FileDataHandle> loadedFiles;
     std::vector<std::thread> threadPool { };
     LEAK_DETECTOR(FilePool);
 };

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -98,6 +98,7 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
     // Wavetable oscillator
     case hash("oscillator_phase"):
         setValueFromOpcode(opcode, oscillatorPhase, Default::oscillatorPhaseRange);
+        break;
     case hash("oscillator"):
         if (auto value = readBooleanFromOpcode(opcode))
             oscillator = *value;

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -917,6 +917,19 @@ float sfz::Region::getBaseGain() noexcept
     return normalizePercents(amplitude);
 }
 
+float sfz::Region::getPhase() noexcept
+{
+    float phase;
+    if (oscillatorPhase >= 0) {
+        phase = oscillatorPhase * (1.0f / 360.0f);
+        phase -= static_cast<int>(phase);
+    } else {
+        std::uniform_real_distribution<float> phaseDist { 0.0001f, 0.9999f };
+        phase = phaseDist(Random::randomGenerator);
+    }
+    return phase;
+}
+
 uint32_t sfz::Region::getOffset(Oversampling factor) noexcept
 {
     return (offset + offsetDistribution(Random::randomGenerator)) * static_cast<uint32_t>(factor);

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -98,6 +98,9 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
     // Wavetable oscillator
     case hash("oscillator_phase"):
         setValueFromOpcode(opcode, oscillatorPhase, Default::oscillatorPhaseRange);
+    case hash("oscillator"):
+        if (auto value = readBooleanFromOpcode(opcode))
+            oscillator = *value;
         break;
 
     // Instrument settings: voice lifecycle

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -168,6 +168,12 @@ struct Region {
      */
     float getBaseGain() noexcept;
     /**
+     * @brief Get the base gain of the region.
+     *
+     * @return float
+     */
+    float getPhase() noexcept;
+    /**
      * @brief Computes the gain value related to the velocity of the note
      *
      * @return float

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -228,6 +228,7 @@ struct Region {
 
     // Wavetable oscillator
     float oscillatorPhase { Default::oscillatorPhase };
+    bool oscillator = false;
 
     // Instrument settings: voice lifecycle
     uint32_t group { Default::group }; // group

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -135,7 +135,7 @@ struct Region {
      * @param velocity
      * @return float
      */
-    float getBasePitchVariation(int noteNumber, uint8_t velocity) noexcept;
+    float getBasePitchVariation(int noteNumber, uint8_t velocity) const noexcept;
     /**
      * @brief Get the note-related gain of the region depending on which note has been
      * pressed and at which velocity.
@@ -144,7 +144,7 @@ struct Region {
      * @param velocity
      * @return float
      */
-    float getNoteGain(int noteNumber, uint8_t velocity) noexcept;
+    float getNoteGain(int noteNumber, uint8_t velocity) const noexcept;
     /**
      * @brief Get the additional crossfade gain of the region depending on the
      * CC values
@@ -152,7 +152,7 @@ struct Region {
      * @param ccState
      * @return float
      */
-    float getCrossfadeGain(const SfzCCArray& ccState) noexcept;
+    float getCrossfadeGain(const SfzCCArray& ccState) const noexcept;
     /**
      * @brief Get the base volume of the region depending on which note has been
      * pressed to trigger the region.
@@ -160,19 +160,19 @@ struct Region {
      * @param noteNumber
      * @return float
      */
-    float getBaseVolumedB(int noteNumber) noexcept;
+    float getBaseVolumedB(int noteNumber) const noexcept;
     /**
      * @brief Get the base gain of the region.
      *
      * @return float
      */
-    float getBaseGain() noexcept;
+    float getBaseGain() const noexcept;
     /**
      * @brief Get the base gain of the region.
      *
      * @return float
      */
-    float getPhase() noexcept;
+    float getPhase() const noexcept;
     /**
      * @brief Computes the gain value related to the velocity of the note
      *
@@ -184,13 +184,13 @@ struct Region {
      *
      * @return uint32_t
      */
-    uint32_t getOffset(Oversampling factor = Oversampling::x1) noexcept;
+    uint32_t getOffset(Oversampling factor = Oversampling::x1) const noexcept;
     /**
      * @brief Get the region delay in seconds
      *
      * @return float
      */
-    float getDelay() noexcept;
+    float getDelay() const noexcept;
     /**
      * @brief Get the index of the sample end, either natural end or forced
      * loop.
@@ -333,11 +333,6 @@ private:
     absl::string_view defaultPath { "" };
 
     int sequenceCounter { 0 };
-
-    std::uniform_real_distribution<float> volumeDistribution { -sfz::Default::ampRandom, sfz::Default::ampRandom };
-    std::uniform_real_distribution<float> delayDistribution { 0, sfz::Default::delayRandom };
-    std::uniform_int_distribution<uint32_t> offsetDistribution { 0, sfz::Default::offsetRandom };
-    std::uniform_int_distribution<int> pitchDistribution { -sfz::Default::pitchRandom, sfz::Default::pitchRandom };
     LEAK_DETECTOR(Region);
 };
 

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -367,8 +367,7 @@ bool sfz::Synth::loadSfzFile(const fs::path& file)
                 continue;
             }
 
-            const auto fileWave = resources.wavePool.createFileWave(resources.filePool, region->sample);
-            if (!fileWave) {
+            if (!resources.wavePool.createFileWave(resources.filePool, region->sample)) {
                 removeCurrentRegion();
                 continue;
             }

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -362,7 +362,16 @@ bool sfz::Synth::loadSfzFile(const fs::path& file)
                 removeCurrentRegion();
         }
         else if (region->oscillator && !region->isGenerator()) {
-            resources.wavePool.createFileWave(resources.filePool, region->sample);
+            if (!resources.filePool.checkSample(region->sample)) {
+                removeCurrentRegion();
+                continue;
+            }
+
+            const auto fileWave = resources.wavePool.createFileWave(resources.filePool, region->sample);
+            if (!fileWave) {
+                removeCurrentRegion();
+                continue;
+            }
         }
 
         for (auto note = 0; note < 128; note++) {

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -306,6 +306,7 @@ bool sfz::Synth::loadSfzFile(const fs::path& file)
         return false;
 
     resources.filePool.setRootDirectory(parser.originalDirectory());
+    resources.wavePool.clearFileWaves();
 
     auto currentRegion = regions.begin();
     auto lastRegion = regions.rbegin();
@@ -324,7 +325,7 @@ bool sfz::Synth::loadSfzFile(const fs::path& file)
     while (currentRegion < lastRegion.base()) {
         auto region = currentRegion->get();
 
-        if (!region->isGenerator()) {
+        if (!region->oscillator && !region->isGenerator()) {
             if (!resources.filePool.checkSample(region->sample)) {
                 removeCurrentRegion();
                 continue;
@@ -359,6 +360,9 @@ bool sfz::Synth::loadSfzFile(const fs::path& file)
             const auto maxOffset = region->offset + region->offsetRandom;
             if (!resources.filePool.preloadFile(region->sample, maxOffset))
                 removeCurrentRegion();
+        }
+        else if (region->oscillator && !region->isGenerator()) {
+            resources.wavePool.createFileWave(resources.filePool, region->sample);
         }
 
         for (auto note = 0; note < 128; note++) {

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -143,6 +143,7 @@ void sfz::Synth::clear()
     effectBuses[0]->setSampleRate(sampleRate);
     curves = CurveSet::createPredefined();
     resources.filePool.clear();
+    resources.wavePool.clearFileWaves();
     resources.logger.clear();
     numGroups = 0;
     numMasters = 0;
@@ -306,7 +307,6 @@ bool sfz::Synth::loadSfzFile(const fs::path& file)
         return false;
 
     resources.filePool.setRootDirectory(parser.originalDirectory());
-    resources.wavePool.clearFileWaves();
 
     auto currentRegion = regions.begin();
     auto lastRegion = regions.rbegin();

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -58,9 +58,11 @@ void sfz::Voice::startVoice(Region* region, int delay, int number, uint8_t value
             break;
         }
         waveOscillator.setWavetable(wave);
+        waveOscillator.setPhase(region->getPhase());
     } else if (region->oscillator) {
         const WavetableMulti* wave = resources.wavePool.getFileWave(region->sample);
         waveOscillator.setWavetable(wave);
+        waveOscillator.setPhase(region->getPhase());
     } else {
         currentPromise = resources.filePool.getFilePromise(region->sample);
         if (currentPromise == nullptr) {
@@ -68,19 +70,6 @@ void sfz::Voice::startVoice(Region* region, int delay, int number, uint8_t value
             return;
         }
         speedRatio = static_cast<float>(currentPromise->sampleRate / this->sampleRate);
-    }
-
-    if (region->oscillator || region->isGenerator()) {
-        float phase;
-        const float phaseParam = region->oscillatorPhase;
-        if (phaseParam >= 0) {
-            phase = phaseParam * (1.0f / 360.0f);
-            phase -= static_cast<int>(phase);
-        } else {
-            std::uniform_real_distribution<float> phaseDist { 0.0001f, 0.9999f };
-            phase = phaseDist(Random::randomGenerator);
-        }
-        waveOscillator.setPhase(phase);
     }
 
     pitchRatio = region->getBasePitchVariation(number, value);

--- a/src/sfizz/Wavetables.cpp
+++ b/src/sfizz/Wavetables.cpp
@@ -352,14 +352,14 @@ void WavetablePool::clearFileWaves()
     _fileWaves.clear();
 }
 
-const WavetableMulti* WavetablePool::createFileWave(FilePool& filePool, const std::string& filename)
+bool WavetablePool::createFileWave(FilePool& filePool, const std::string& filename)
 {
-    if (const WavetableMulti* wave = getFileWave(filename))
-        return wave;
+    if (_fileWaves.contains(filename))
+        return true;
 
     auto fileHandle = filePool.loadFile(filename);
     if (!fileHandle)
-        return nullptr;
+        return false;
 
     if (fileHandle->information.numChannels > 1)
         DBG("[sfizz] Only the first channel of " << filename << " will be used to create the wavetable");
@@ -391,7 +391,7 @@ const WavetableMulti* WavetablePool::createFileWave(FilePool& filePool, const st
         WavetableMulti::createForHarmonicProfile(hp, 1.0));
 
     _fileWaves[filename] = wave;
-    return wave.get();
+    return true;
 }
 
 } // namespace sfz

--- a/src/sfizz/Wavetables.cpp
+++ b/src/sfizz/Wavetables.cpp
@@ -5,9 +5,9 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "Wavetables.h"
+#include "FilePool.h"
 #include "MathHelpers.h"
 #include <kiss_fftr.h>
-#include <memory>
 
 namespace sfz {
 
@@ -279,6 +279,31 @@ void WavetableMulti::fillExtra()
     }
 }
 
+//------------------------------------------------------------------------------
+
+/**
+ * @brief Harmonic profile which takes its values from a table.
+ */
+class TabulatedHarmonicProfile : public HarmonicProfile {
+public:
+    explicit TabulatedHarmonicProfile(absl::Span<const std::complex<float>> harmonics)
+        : _harmonics(harmonics)
+    {
+    }
+
+    std::complex<double> getHarmonic(size_t index) const override
+    {
+        if (index >= _harmonics.size())
+            return {};
+
+        return _harmonics[index];
+    }
+
+private:
+    absl::Span<const std::complex<float>> _harmonics;
+};
+
+//------------------------------------------------------------------------------
 
 WavetablePool::WavetablePool()
 {
@@ -311,6 +336,67 @@ const WavetableMulti* WavetablePool::getWaveSquare()
     static auto wave = WavetableMulti::createForHarmonicProfile(
             HarmonicProfile::getSquare(), config::amplitudeSquare);
     return &wave;
+}
+
+const WavetableMulti* WavetablePool::getFileWave(const std::string& filename)
+{
+    auto it = _fileWaves.find(filename);
+    if (it == _fileWaves.end())
+        return nullptr;
+
+    return it->second.get();
+}
+
+void WavetablePool::clearFileWaves()
+{
+    _fileWaves.clear();
+}
+
+const WavetableMulti* WavetablePool::createFileWave(FilePool& filePool, const std::string& filename)
+{
+    if (const WavetableMulti* wave = getFileWave(filename))
+        return wave;
+
+    if (!filePool.preloadFile(filename, 0))
+        return nullptr;
+
+    FilePromisePtr fp = filePool.getFilePromise(filename);
+    if (!fp)
+        return nullptr;
+
+    fp->waitCompletion();
+    if (fp->dataStatus == FilePromise::DataStatus::Error)
+        return nullptr;
+
+    // use 1 channel only, maybe warn if file has more channels
+    auto audioData = fp->fileData.getSpan(0);
+    size_t fftSize = audioData.size();
+    size_t specSize = fftSize / 2 + 1;
+
+    typedef std::complex<kiss_fft_scalar> cpx;
+    std::unique_ptr<cpx[]> spec { new cpx[specSize] };
+
+    kiss_fftr_cfg cfg = kiss_fftr_alloc(fftSize, false, nullptr, nullptr);
+    if (!cfg)
+        throw std::bad_alloc();
+
+    kiss_fftr(cfg, audioData.data(), reinterpret_cast<kiss_fft_cpx*>(spec.get()));
+    kiss_fftr_free(cfg);
+
+    // scale transform, and normalize amplitude and phase
+    const std::complex<double> k = std::polar(2.0 / fftSize, -M_PI / 2);
+    for (size_t i = 0; i < specSize; ++i)
+        spec[i] *= k;
+
+    TabulatedHarmonicProfile hp {
+        absl::Span<const std::complex<float>> { spec.get(), specSize }
+    };
+
+    auto wave = std::make_shared<WavetableMulti>(
+        WavetableMulti::createForHarmonicProfile(hp, 1.0));
+
+    _fileWaves[filename] = wave;
+    return wave.get();
 }
 
 } // namespace sfz

--- a/src/sfizz/Wavetables.cpp
+++ b/src/sfizz/Wavetables.cpp
@@ -11,12 +11,10 @@
 
 namespace sfz {
 
-static WavetableMulti silenceMulti = WavetableMulti::createSilence();
-
 void WavetableOscillator::init(double sampleRate)
 {
     _sampleInterval = 1.0 / sampleRate;
-    _multi = &silenceMulti;
+    _multi = WavetableMulti::getSilenceWavetable();
     clear();
 }
 
@@ -27,7 +25,7 @@ void WavetableOscillator::clear()
 
 void WavetableOscillator::setWavetable(const WavetableMulti* wave)
 {
-    _multi = wave ? wave : &silenceMulti;
+    _multi = wave ? wave : WavetableMulti::getSilenceWavetable();
 }
 
 void WavetableOscillator::setPhase(float phase)
@@ -252,12 +250,12 @@ WavetableMulti WavetableMulti::createForHarmonicProfile(
     return wm;
 }
 
-WavetableMulti WavetableMulti::createSilence()
+WavetableMulti* WavetableMulti::getSilenceWavetable()
 {
-    WavetableMulti wm;
+    static WavetableMulti wm;
     wm.allocateStorage(1);
     wm.fillExtra();
-    return wm;
+    return &wm;
 }
 
 void WavetableMulti::allocateStorage(unsigned tableSize)

--- a/src/sfizz/Wavetables.cpp
+++ b/src/sfizz/Wavetables.cpp
@@ -250,7 +250,7 @@ WavetableMulti WavetableMulti::createForHarmonicProfile(
     return wm;
 }
 
-WavetableMulti* WavetableMulti::getSilenceWavetable()
+const WavetableMulti* WavetableMulti::getSilenceWavetable()
 {
     static WavetableMulti wm;
     wm.allocateStorage(1);

--- a/src/sfizz/Wavetables.cpp
+++ b/src/sfizz/Wavetables.cpp
@@ -389,7 +389,7 @@ const WavetableMulti* WavetablePool::createFileWave(FilePool& filePool, const st
     };
 
     auto wave = std::make_shared<WavetableMulti>(
-        WavetableMulti::createForHarmonicProfile(hp, 1.0));
+        WavetableMulti::createForHarmonicProfile(hp, 1.0, config::tableSize, fileHandle->information.sampleRate));
 
     _fileWaves[filename] = wave;
     return wave.get();

--- a/src/sfizz/Wavetables.cpp
+++ b/src/sfizz/Wavetables.cpp
@@ -361,7 +361,6 @@ const WavetableMulti* WavetablePool::createFileWave(FilePool& filePool, const st
     if (!fileHandle)
         return nullptr;
 
-
     if (fileHandle->information.numChannels > 1)
         DBG("[sfizz] Only the first channel of " << filename << " will be used to create the wavetable");
 
@@ -389,7 +388,7 @@ const WavetableMulti* WavetablePool::createFileWave(FilePool& filePool, const st
     };
 
     auto wave = std::make_shared<WavetableMulti>(
-        WavetableMulti::createForHarmonicProfile(hp, 1.0, config::tableSize, fileHandle->information.sampleRate));
+        WavetableMulti::createForHarmonicProfile(hp, 1.0));
 
     _fileWaves[filename] = wave;
     return wave.get();

--- a/src/sfizz/Wavetables.h
+++ b/src/sfizz/Wavetables.h
@@ -159,8 +159,8 @@ public:
     static WavetableMulti createForHarmonicProfile(
         const HarmonicProfile& hp, double amplitude, unsigned tableSize = config::tableSize, double refSampleRate = 44100.0);
 
-    // create the tiniest wavetable with null content for use with oscillators
-    static WavetableMulti createSilence();
+    // get a tiny silent wavetable with null content for use with oscillators
+    static WavetableMulti* getSilenceWavetable();
 
 private:
     // get a pointer to the beginning of the N-th table

--- a/src/sfizz/Wavetables.h
+++ b/src/sfizz/Wavetables.h
@@ -208,9 +208,9 @@ struct WavetablePool {
      *
      * @param filePool the file pool to use to load the file
      * @param filename the file name to load
-     * @return the wavetable
+     * @return true if the wavetable was correctly created (or existed already)
      */
-    const WavetableMulti* createFileWave(FilePool& filePool, const std::string& filename);
+    bool createFileWave(FilePool& filePool, const std::string& filename);
     /**
      * @brief Removes all the stored file waves from the wavetable pool.
      */

--- a/src/sfizz/Wavetables.h
+++ b/src/sfizz/Wavetables.h
@@ -9,10 +9,12 @@
 #include "LeakDetector.h"
 #include "Buffer.h"
 #include <absl/types/span.h>
+#include <absl/container/flat_hash_map.h>
 #include <memory>
 #include <complex>
 
 namespace sfz {
+class FilePool;
 
 class WavetableMulti;
 
@@ -185,15 +187,23 @@ private:
 };
 
 /**
- * @brief Holds predefined wavetables.
+ * @brief Holds predefined and loaded wavetables.
  *
  */
 struct WavetablePool {
     WavetablePool();
+
+    const WavetableMulti* getFileWave(const std::string& filename);
+    const WavetableMulti* createFileWave(FilePool& filePool, const std::string& filename);
+    void clearFileWaves();
+
     static const WavetableMulti* getWaveSin();
     static const WavetableMulti* getWaveTriangle();
     static const WavetableMulti* getWaveSaw();
     static const WavetableMulti* getWaveSquare();
+
+private:
+    absl::flat_hash_map<std::string, std::shared_ptr<WavetableMulti>> _fileWaves;
 };
 
 } // namespace sfz

--- a/src/sfizz/Wavetables.h
+++ b/src/sfizz/Wavetables.h
@@ -193,8 +193,27 @@ private:
 struct WavetablePool {
     WavetablePool();
 
+    /**
+     * @brief Get a file wave. Return a silent table if the wave does not exist yet.
+     * Use createFileWave to preload file waves before calling this function.
+     * This function is real-time safe.
+     *
+     * @param filename the name of the file wave
+     * @return the wavetable, or a silent table
+     */
     const WavetableMulti* getFileWave(const std::string& filename);
+    /**
+     * @brief Load a file wave from the filepool and use it to create a wavetable.
+     * This function is not real-time safe.
+     *
+     * @param filePool the file pool to use to load the file
+     * @param filename the file name to load
+     * @return the wavetable
+     */
     const WavetableMulti* createFileWave(FilePool& filePool, const std::string& filename);
+    /**
+     * @brief Removes all the stored file waves from the wavetable pool.
+     */
     void clearFileWaves();
 
     static const WavetableMulti* getWaveSin();

--- a/src/sfizz/Wavetables.h
+++ b/src/sfizz/Wavetables.h
@@ -160,7 +160,7 @@ public:
         const HarmonicProfile& hp, double amplitude, unsigned tableSize = config::tableSize, double refSampleRate = 44100.0);
 
     // get a tiny silent wavetable with null content for use with oscillators
-    static WavetableMulti* getSilenceWavetable();
+    static const WavetableMulti* getSilenceWavetable();
 
 private:
     // get a pointer to the beginning of the N-th table


### PR DESCRIPTION
This supports loading wavetables from file.
The file will be loaded directly and mipmapped.

I've added a status enum to `FilePromise` which I hope correct, and adapted.
This lets me know if file loading has failed because of an error of libsndfile.

- Example

```
<region>
sample=ramp.wav
oscillator=on
```

- Demo files

[sinewave.wav.gz](https://github.com/sfztools/sfizz/files/4340849/sinewave.wav.gz)
[ramp.wav.gz](https://github.com/sfztools/sfizz/files/4340848/ramp.wav.gz)
[nimportequoi.wav.gz](https://github.com/sfztools/sfizz/files/4340847/nimportequoi.wav.gz)

