### PR TITLE
Simplify the amplitude stage by only applying the final gain on the buffer

### DIFF
--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -237,6 +237,7 @@ private:
      * @param buffer
      */
     void fillWithGenerator(AudioSpan<float> buffer) noexcept;
+    void amplitudeEnvelope(absl::Span<float> modulationSpan) noexcept;
     void ampStageMono(AudioSpan<float> buffer) noexcept;
     void ampStageStereo(AudioSpan<float> buffer) noexcept;
     void panStageMono(AudioSpan<float> buffer) noexcept;


### PR DESCRIPTION
By avoiding these needless intermediate gains the amp stage went from 40 to 20 µs per voice on my test cases.