### PR TITLE
Envelopes

### DIFF
--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -28,7 +28,7 @@ namespace config {
     constexpr float defaultSampleRate { 48000 };
     constexpr int defaultSamplesPerBlock { 1024 };
     constexpr int maxBlockSize { 8192 };
-    constexpr int bufferPoolSize { 4 };
+    constexpr int bufferPoolSize { 8 };
     constexpr int stereoBufferPoolSize { 4 };
     constexpr int indexBufferPoolSize { 2 };
     constexpr int preloadSize { 8192 };

--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -206,12 +206,18 @@ namespace Default
 	constexpr float start { 0.0 };
 	constexpr float sustain { 100.0 };
 	constexpr float vel2sustain { 0.0 };
+	constexpr float pitchEgDepth { 0.0 };
+	constexpr float pitchEgVel2depth { 0.0 };
+	constexpr float filterEgDepth { 0.0 };
+	constexpr float filterEgVel2depth { 0.0 };
 	constexpr int depth { 0 };
 	constexpr Range<float> egTimeRange { 0.0, 100.0 };
 	constexpr Range<float> egPercentRange { 0.0, 100.0 };
 	constexpr Range<int> egDepthRange { -12000, 12000 };
 	constexpr Range<float> egOnCCTimeRange { -100.0, 100.0 };
 	constexpr Range<float> egOnCCPercentRange { -100.0, 100.0 };
+	constexpr Range<float> pitchEgDepthRange { -12000.0, 12000.0 };
+	constexpr Range<float> filterEgDepthRange { -12000.0, 12000.0 };
 
     // ***** SFZ v2 ********
 	constexpr bool checkSustain { true }; // sustain_sw

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -829,6 +829,31 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
     case hash("fileg_sustain_oncc&"):
         return parseEGopcode(opcode, filterEG);
 
+    case hash("pitcheg_depth"):
+        setValueFromOpcode(opcode, pitchEgDepth, Default::pitchEgDepthRange);
+        break;
+    case hash("pitcheg_vel&depth"):
+        if (opcode.parameters.front() != 2)
+            return false; // Was not vel2...
+        setValueFromOpcode(opcode, pitchEgVel2depth, Default::pitchEgDepthRange);
+        break;
+    case hash("fileg_depth"):
+        setValueFromOpcode(opcode, filterEgDepth, Default::filterEgDepthRange);
+        break;
+    case hash("fileg_vel&depth"):
+        if (opcode.parameters.front() != 2)
+            return false; // Was not vel2...
+        setValueFromOpcode(opcode, filterEgVel2depth, Default::filterEgDepthRange);
+        break;
+
+    // TODO ARIA extensions
+    /*
+    case hash("pitcheg_depth_oncc&"):
+        break;
+    case hash("fileg_depth_oncc&"):
+        break;
+    */
+
     case hash("effect&"):
     {
         const auto effectNumber = opcode.parameters.back();

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -741,84 +741,93 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
 
     // Amplitude Envelope
     case hash("ampeg_attack"):
-        setValueFromOpcode(opcode, amplitudeEG.attack, Default::egTimeRange);
-        break;
     case hash("ampeg_decay"):
-        setValueFromOpcode(opcode, amplitudeEG.decay, Default::egTimeRange);
-        break;
     case hash("ampeg_delay"):
-        setValueFromOpcode(opcode, amplitudeEG.delay, Default::egTimeRange);
-        break;
     case hash("ampeg_hold"):
-        setValueFromOpcode(opcode, amplitudeEG.hold, Default::egTimeRange);
-        break;
     case hash("ampeg_release"):
-        setValueFromOpcode(opcode, amplitudeEG.release, Default::egTimeRange);
-        break;
     case hash("ampeg_start"):
-        setValueFromOpcode(opcode, amplitudeEG.start, Default::egPercentRange);
-        break;
     case hash("ampeg_sustain"):
-        setValueFromOpcode(opcode, amplitudeEG.sustain, Default::egPercentRange);
-        break;
     case hash("ampeg_vel&attack"):
-        if (opcode.parameters.front() != 2)
-            return false; // Was not vel2...
-        setValueFromOpcode(opcode, amplitudeEG.vel2attack, Default::egOnCCTimeRange);
-        break;
     case hash("ampeg_vel&decay"):
-        if (opcode.parameters.front() != 2)
-            return false; // Was not vel2...
-        setValueFromOpcode(opcode, amplitudeEG.vel2decay, Default::egOnCCTimeRange);
-        break;
     case hash("ampeg_vel&delay"):
-        if (opcode.parameters.front() != 2)
-            return false; // Was not vel2...
-        setValueFromOpcode(opcode, amplitudeEG.vel2delay, Default::egOnCCTimeRange);
-        break;
     case hash("ampeg_vel&hold"):
-        if (opcode.parameters.front() != 2)
-            return false; // Was not vel2...
-        setValueFromOpcode(opcode, amplitudeEG.vel2hold, Default::egOnCCTimeRange);
-        break;
     case hash("ampeg_vel&release"):
-        if (opcode.parameters.front() != 2)
-            return false; // Was not vel2...
-        setValueFromOpcode(opcode, amplitudeEG.vel2release, Default::egOnCCTimeRange);
-        break;
     case hash("ampeg_vel&sustain"):
-        if (opcode.parameters.front() != 2)
-            return false; // Was not vel2...
-        setValueFromOpcode(opcode, amplitudeEG.vel2sustain, Default::egOnCCPercentRange);
-        break;
-    case hash("ampeg_attackcc&"): // fallthrough
+    case hash("ampeg_attackcc&"):
     case hash("ampeg_attack_oncc&"):
-        setCCPairFromOpcode(opcode, amplitudeEG.ccAttack, Default::egOnCCTimeRange);
-        break;
-    case hash("ampeg_decaycc&"): // fallthrough
+    case hash("ampeg_decaycc&"):
     case hash("ampeg_decay_oncc&"):
-        setCCPairFromOpcode(opcode, amplitudeEG.ccDecay, Default::egOnCCTimeRange);
-        break;
-    case hash("ampeg_delaycc&"): // fallthrough
+    case hash("ampeg_delaycc&"):
     case hash("ampeg_delay_oncc&"):
-        setCCPairFromOpcode(opcode, amplitudeEG.ccDelay, Default::egOnCCTimeRange);
-        break;
-    case hash("ampeg_holdcc&"): // fallthrough
+    case hash("ampeg_holdcc&"):
     case hash("ampeg_hold_oncc&"):
-        setCCPairFromOpcode(opcode, amplitudeEG.ccHold, Default::egOnCCTimeRange);
-        break;
-    case hash("ampeg_releasecc&"): // fallthrough
+    case hash("ampeg_releasecc&"):
     case hash("ampeg_release_oncc&"):
-        setCCPairFromOpcode(opcode, amplitudeEG.ccRelease, Default::egOnCCTimeRange);
-        break;
-    case hash("ampeg_startcc&"): // fallthrough
+    case hash("ampeg_startcc&"):
     case hash("ampeg_start_oncc&"):
-        setCCPairFromOpcode(opcode, amplitudeEG.ccStart, Default::egOnCCPercentRange);
-        break;
-    case hash("ampeg_sustaincc&"): // fallthrough
+    case hash("ampeg_sustaincc&"):
     case hash("ampeg_sustain_oncc&"):
-        setCCPairFromOpcode(opcode, amplitudeEG.ccSustain, Default::egOnCCPercentRange);
-        break;
+        return parseEGopcode(opcode, amplitudeEG);
+
+    // Pitch envelope
+    case hash("pitcheg_attack"):
+    case hash("pitcheg_decay"):
+    case hash("pitcheg_delay"):
+    case hash("pitcheg_hold"):
+    case hash("pitcheg_release"):
+    case hash("pitcheg_start"):
+    case hash("pitcheg_sustain"):
+    case hash("pitcheg_vel&attack"):
+    case hash("pitcheg_vel&decay"):
+    case hash("pitcheg_vel&delay"):
+    case hash("pitcheg_vel&hold"):
+    case hash("pitcheg_vel&release"):
+    case hash("pitcheg_vel&sustain"):
+    case hash("pitcheg_attackcc&"):
+    case hash("pitcheg_attack_oncc&"):
+    case hash("pitcheg_decaycc&"):
+    case hash("pitcheg_decay_oncc&"):
+    case hash("pitcheg_delaycc&"):
+    case hash("pitcheg_delay_oncc&"):
+    case hash("pitcheg_holdcc&"):
+    case hash("pitcheg_hold_oncc&"):
+    case hash("pitcheg_releasecc&"):
+    case hash("pitcheg_release_oncc&"):
+    case hash("pitcheg_startcc&"):
+    case hash("pitcheg_start_oncc&"):
+    case hash("pitcheg_sustaincc&"):
+    case hash("pitcheg_sustain_oncc&"):
+        return parseEGopcode(opcode, pitchEG);
+
+    // Filter envelope
+    case hash("fileg_attack"):
+    case hash("fileg_decay"):
+    case hash("fileg_delay"):
+    case hash("fileg_hold"):
+    case hash("fileg_release"):
+    case hash("fileg_start"):
+    case hash("fileg_sustain"):
+    case hash("fileg_vel&attack"):
+    case hash("fileg_vel&decay"):
+    case hash("fileg_vel&delay"):
+    case hash("fileg_vel&hold"):
+    case hash("fileg_vel&release"):
+    case hash("fileg_vel&sustain"):
+    case hash("fileg_attackcc&"):
+    case hash("fileg_attack_oncc&"):
+    case hash("fileg_decaycc&"):
+    case hash("fileg_decay_oncc&"):
+    case hash("fileg_delaycc&"):
+    case hash("fileg_delay_oncc&"):
+    case hash("fileg_holdcc&"):
+    case hash("fileg_hold_oncc&"):
+    case hash("fileg_releasecc&"):
+    case hash("fileg_release_oncc&"):
+    case hash("fileg_startcc&"):
+    case hash("fileg_start_oncc&"):
+    case hash("fileg_sustaincc&"):
+    case hash("fileg_sustain_oncc&"):
+        return parseEGopcode(opcode, filterEG);
 
     case hash("effect&"):
     {
@@ -839,6 +848,149 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
     case hash("lochan"):
     case hash("ampeg_depth"):
     case hash("ampeg_vel&depth"):
+        break;
+    default:
+        return false;
+    }
+
+    return true;
+}
+
+bool sfz::Region::parseEGopcode(const Opcode& opcode, EGDescription& target)
+{
+    switch (opcode.lettersOnlyHash) {
+    case hash("ampeg_attack"):
+    case hash("pitcheg_attack"):
+    case hash("fileg_attack"):
+        setValueFromOpcode(opcode, target.attack, Default::egTimeRange);
+        break;
+    case hash("ampeg_decay"):
+    case hash("pitcheg_decay"):
+    case hash("fileg_decay"):
+        setValueFromOpcode(opcode, target.decay, Default::egTimeRange);
+        break;
+    case hash("ampeg_delay"):
+    case hash("pitcheg_delay"):
+    case hash("fileg_delay"):
+        setValueFromOpcode(opcode, target.delay, Default::egTimeRange);
+        break;
+    case hash("ampeg_hold"):
+    case hash("pitcheg_hold"):
+    case hash("fileg_hold"):
+        setValueFromOpcode(opcode, target.hold, Default::egTimeRange);
+        break;
+    case hash("ampeg_release"):
+    case hash("pitcheg_release"):
+    case hash("fileg_release"):
+        setValueFromOpcode(opcode, target.release, Default::egTimeRange);
+        break;
+    case hash("ampeg_start"):
+    case hash("pitcheg_start"):
+    case hash("fileg_start"):
+        setValueFromOpcode(opcode, target.start, Default::egPercentRange);
+        break;
+    case hash("ampeg_sustain"):
+    case hash("pitcheg_sustain"):
+    case hash("fileg_sustain"):
+        setValueFromOpcode(opcode, target.sustain, Default::egPercentRange);
+        break;
+    case hash("ampeg_vel&attack"):
+    case hash("pitcheg_vel&attack"):
+    case hash("fileg_vel&attack"):
+        if (opcode.parameters.front() != 2)
+            return false; // Was not vel2...
+        setValueFromOpcode(opcode, target.vel2attack, Default::egOnCCTimeRange);
+        break;
+    case hash("ampeg_vel&decay"):
+    case hash("pitcheg_vel&decay"):
+    case hash("fileg_vel&decay"):
+        if (opcode.parameters.front() != 2)
+            return false; // Was not vel2...
+        setValueFromOpcode(opcode, target.vel2decay, Default::egOnCCTimeRange);
+        break;
+    case hash("ampeg_vel&delay"):
+    case hash("pitcheg_vel&delay"):
+    case hash("fileg_vel&delay"):
+        if (opcode.parameters.front() != 2)
+            return false; // Was not vel2...
+        setValueFromOpcode(opcode, target.vel2delay, Default::egOnCCTimeRange);
+        break;
+    case hash("ampeg_vel&hold"):
+    case hash("pitcheg_vel&hold"):
+    case hash("fileg_vel&hold"):
+        if (opcode.parameters.front() != 2)
+            return false; // Was not vel2...
+        setValueFromOpcode(opcode, target.vel2hold, Default::egOnCCTimeRange);
+        break;
+    case hash("ampeg_vel&release"):
+    case hash("pitcheg_vel&release"):
+    case hash("fileg_vel&release"):
+        if (opcode.parameters.front() != 2)
+            return false; // Was not vel2...
+        setValueFromOpcode(opcode, target.vel2release, Default::egOnCCTimeRange);
+        break;
+    case hash("ampeg_vel&sustain"):
+    case hash("pitcheg_vel&sustain"):
+    case hash("fileg_vel&sustain"):
+        if (opcode.parameters.front() != 2)
+            return false; // Was not vel2...
+        setValueFromOpcode(opcode, target.vel2sustain, Default::egOnCCPercentRange);
+        break;
+    case hash("ampeg_attackcc&"):
+    case hash("pitcheg_attackcc&"):
+    case hash("fileg_attackcc&"): // fallthrough
+    case hash("ampeg_attack_oncc&"):
+    case hash("pitcheg_attack_oncc&"):
+    case hash("fileg_attack_oncc&"):
+        setCCPairFromOpcode(opcode, target.ccAttack, Default::egOnCCTimeRange);
+        break;
+    case hash("ampeg_decaycc&"):
+    case hash("pitcheg_decaycc&"):
+    case hash("fileg_decaycc&"): // fallthrough
+    case hash("ampeg_decay_oncc&"):
+    case hash("pitcheg_decay_oncc&"):
+    case hash("fileg_decay_oncc&"):
+        setCCPairFromOpcode(opcode, target.ccDecay, Default::egOnCCTimeRange);
+        break;
+    case hash("ampeg_delaycc&"):
+    case hash("pitcheg_delaycc&"):
+    case hash("fileg_delaycc&"): // fallthrough
+    case hash("ampeg_delay_oncc&"):
+    case hash("pitcheg_delay_oncc&"):
+    case hash("fileg_delay_oncc&"):
+        setCCPairFromOpcode(opcode, target.ccDelay, Default::egOnCCTimeRange);
+        break;
+    case hash("ampeg_holdcc&"):
+    case hash("pitcheg_holdcc&"):
+    case hash("fileg_holdcc&"): // fallthrough
+    case hash("ampeg_hold_oncc&"):
+    case hash("pitcheg_hold_oncc&"):
+    case hash("fileg_hold_oncc&"):
+        setCCPairFromOpcode(opcode, target.ccHold, Default::egOnCCTimeRange);
+        break;
+    case hash("ampeg_releasecc&"):
+    case hash("pitcheg_releasecc&"):
+    case hash("fileg_releasecc&"): // fallthrough
+    case hash("ampeg_release_oncc&"):
+    case hash("pitcheg_release_oncc&"):
+    case hash("fileg_release_oncc&"):
+        setCCPairFromOpcode(opcode, target.ccRelease, Default::egOnCCTimeRange);
+        break;
+    case hash("ampeg_startcc&"):
+    case hash("pitcheg_startcc&"):
+    case hash("fileg_startcc&"): // fallthrough
+    case hash("ampeg_start_oncc&"):
+    case hash("pitcheg_start_oncc&"):
+    case hash("fileg_start_oncc&"):
+        setCCPairFromOpcode(opcode, target.ccStart, Default::egOnCCPercentRange);
+        break;
+    case hash("ampeg_sustaincc&"):
+    case hash("pitcheg_sustaincc&"):
+    case hash("fileg_sustaincc&"): // fallthrough
+    case hash("ampeg_sustain_oncc&"):
+    case hash("pitcheg_sustain_oncc&"):
+    case hash("fileg_sustain_oncc&"):
+        setCCPairFromOpcode(opcode, target.ccSustain, Default::egOnCCPercentRange);
         break;
     default:
         return false;

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -207,6 +207,16 @@ struct Region {
      * @return false
      */
     bool parseOpcode(const Opcode& opcode);
+    /**
+     * @brief Parse a opcode which is specific to a particular SFZv1 EG:
+     * ampeg, pitcheg, fileg.
+     *
+     * @param opcode
+     * @param target
+     * @return true if the opcode was properly read and stored.
+     * @return false
+     */
+    bool parseEGopcode(const Opcode& opcode, EGDescription& target);
 
     void offsetAllKeys(int offset) noexcept;
 

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -327,6 +327,10 @@ struct Region {
     EGDescription amplitudeEG;
     EGDescription pitchEG;
     EGDescription filterEG;
+    float pitchEgDepth = Default::pitchEgDepth;
+    float pitchEgVel2depth = Default::pitchEgVel2depth;
+    float filterEgDepth = Default::filterEgDepth;
+    float filterEgVel2depth = Default::filterEgVel2depth;
 
     bool isStereo { false };
 

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -281,7 +281,9 @@ private:
     std::vector<FilterHolderPtr> filters;
     std::vector<EQHolderPtr> equalizers;
 
-    ADSREnvelope<float> egEnvelope;
+    ADSREnvelope<float> egAmplitude;
+    ADSREnvelope<float> egPitch;
+    ADSREnvelope<float> egFilter;
     float bendStepFactor { centsFactor(1) };
 
     WavetableOscillator waveOscillator;


### PR DESCRIPTION
I work to add support of `fileg` and `pitcheg` envelopes.
So far opcode handling is made.

The effect of these 2 envelopes are defined by
- `fileg/pitcheg_depth`
- `fileg/pitcheg_vel2depth`

`depth` indicates the detune at the top point of the envelope
`vel2depth` indicates how much more detune applies given the velocity (multiplicative)

eg. if `depth=1200` and `vel2depth=1200` and the note plays at full velocity, the EG varies tune in range `0` to `2400`.