### PR TITLE
Update travis deployment to v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -174,8 +174,8 @@ after_failure:
 - bash ${TRAVIS_BUILD_DIR}/.travis/discord_webhook.sh failure
 
 deploy:
+  edge: true
   provider:     releases
-  skip_cleanup: true
   file:         "${INSTALL_DIR}.tar.gz"
   token:
     secure: jBIMWMPva8OazC8Wnqc2vqATa3exjvGDGvejEu6fgwt/BMDkgJCsJ7gS3ITpYFuO0HoHtLGfTVrFcZIE+agGVRdRGRni5xZRp5Vuf9hvLf8hCTaxkS/HYoliYYPp9FLY6J4yq9mp/R/QyGrwgssQEjhYlI2GL4+lJzt750AcmYibnQo2AMe5SSOp3q8KdLBG1vca1o1BZWBhW/S7l2hA1aJ7y1ytwm0ETIdrTZHxgfz7bqdqQcw/Ytqjm1rgzty6iQKX3B/InaZNB6CqXy6FoGLf771lery8nWJbjTjKYD4QK2NelExldyp1vrdHGvknWguFk+8vlQ16Dt0+R7Byr/LOPRLTCf/T+IehMQGtVA9/gjrkH8LqHy9oVFB+33p11gGu3h6hvg7yB6z3sSck0u4FHjrlpNd5XmmCsKQVQ9vI1cPPkVkbMHIewc7uOu+bD6cmotFj1vJ9UYesvN6n4siyCiPOIhgV9++bjcyiLqX3DWP5UWyZ9/VT8bz5VcxUdJnEYtdNPx4x5pRW4081VUjIf2EmHhQTrjb1iz6FAGwNU/fpefA8x+bBxXP9MkFFgU0tbCDKw2y6o0GOXX82mZr/IB0/DIBg7UllTzCBKTuiJQV1prFPlZLc6V22H5ozAXHgu3E+qNjvHoMsoYjGssX3+AYHwu8isBINo/gGo6Y=


### PR DESCRIPTION
See: https://docs.travis-ci.com/user/deployment-v2
This is an attempt.

- allows the repo to pass `travis lint` (DPL v1 becoming deprecated)
- Failed deployments now always error the build when using dpl v2
  cf. https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release
