### PR TITLE
Fix libatomic detection on clang 10 compiler

### DIFF
--- a/cmake/SfizzConfig.cmake
+++ b/cmake/SfizzConfig.cmake
@@ -78,8 +78,18 @@ add_library(sfizz-spline STATIC "src/external/spline/spline/spline.cpp")
 target_include_directories(sfizz-spline PUBLIC "src/external/spline")
 
 include (CheckLibraryExists)
+add_library (sfizz-atomic INTERFACE)
 if (UNIX AND NOT APPLE)
-    check_library_exists(atomic __atomic_load "" LIBATOMIC_FOUND)
+    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/check_libatomic")
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/check_libatomic/check_libatomic.c" "int main() { return 0; }")
+    try_compile(SFIZZ_LINK_LIBATOMIC "${CMAKE_CURRENT_BINARY_DIR}/check_libatomic"
+        SOURCES "${CMAKE_CURRENT_BINARY_DIR}/check_libatomic/check_libatomic.c"
+        LINK_LIBRARIES "atomic")
+    if (SFIZZ_LINK_LIBATOMIC)
+        target_link_libraries (sfizz-atomic INTERFACE "atomic")
+    endif()
+else()
+    set(SFIZZ_LINK_LIBATOMIC FALSE)
 endif()
 
 # Don't show build information when building a different project
@@ -98,6 +108,7 @@ Build benchmarks:              ${SFIZZ_BENCHMARKS}
 Build tests:                   ${SFIZZ_TESTS}
 Use vcpkg:                     ${SFIZZ_USE_VCPKG}
 Statically link libsndfile:    ${SFIZZ_STATIC_LIBSNDFILE}
+Link libatomic:                ${SFIZZ_LINK_LIBATOMIC}
 
 Install prefix:                ${CMAKE_INSTALL_PREFIX}
 LV2 destination directory:     ${LV2PLUGIN_INSTALL_DIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,7 +55,7 @@ target_sources(sfizz_static PRIVATE ${SFIZZ_SOURCES} sfizz/sfizz_wrapper.cpp sfi
 target_include_directories (sfizz_static PUBLIC .)
 target_include_directories (sfizz_static PUBLIC external)
 target_link_libraries (sfizz_static PUBLIC absl::strings absl::span)
-target_link_libraries (sfizz_static PRIVATE sfizz_parser absl::flat_hash_map Threads::Threads sfizz-sndfile sfizz-pugixml sfizz-spline sfizz-kissfft sfizz-cpuid)
+target_link_libraries (sfizz_static PRIVATE sfizz_parser absl::flat_hash_map Threads::Threads sfizz-sndfile sfizz-pugixml sfizz-spline sfizz-kissfft sfizz-cpuid sfizz-atomic)
 set_target_properties (sfizz_static PROPERTIES OUTPUT_NAME sfizz PUBLIC_HEADER "sfizz.h;sfizz.hpp")
 if (WIN32)
     target_compile_definitions (sfizz_static PRIVATE _USE_MATH_DEFINES)
@@ -80,9 +80,6 @@ configure_file (${PROJECT_SOURCE_DIR}/doxygen/scripts/Doxyfile.in ${PROJECT_SOUR
 
 add_library (sfizz::parser ALIAS sfizz_parser)
 add_library (sfizz::sfizz ALIAS sfizz_static)
-if (LIBATOMIC_FOUND)
-    target_link_libraries (sfizz_static PRIVATE atomic)
-endif()
 
 # Shared library and installation target
 if (SFIZZ_SHARED)
@@ -90,7 +87,7 @@ if (SFIZZ_SHARED)
     target_sources(sfizz_shared PRIVATE ${SFIZZ_SOURCES} sfizz/sfizz_wrapper.cpp sfizz/sfizz.cpp)
     target_include_directories (sfizz_shared PRIVATE .)
     target_include_directories (sfizz_shared PRIVATE external)
-    target_link_libraries (sfizz_shared PRIVATE absl::strings absl::span sfizz_parser absl::flat_hash_map Threads::Threads sfizz-sndfile sfizz-pugixml sfizz-spline sfizz-kissfft sfizz-cpuid)
+    target_link_libraries (sfizz_shared PRIVATE absl::strings absl::span sfizz_parser absl::flat_hash_map Threads::Threads sfizz-sndfile sfizz-pugixml sfizz-spline sfizz-kissfft sfizz-cpuid sfizz-atomic)
     if (WIN32)
         target_compile_definitions (sfizz_shared PRIVATE _USE_MATH_DEFINES)
     endif()
@@ -103,11 +100,5 @@ if (SFIZZ_SHARED)
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    endif()
-
-    if (UNIX AND NOT APPLE)
-        if (LIBATOMIC_FOUND)
-            target_link_libraries (sfizz_shared PRIVATE atomic)
-        endif()
     endif()
 endif()


### PR DESCRIPTION
On clang10, libatomic fails to be detected, and the program does not link.

The reason is as follows:
cmake builds a test program that tries to access the named symbol by address.
In clang, the `__atomic` functions work as builtins, and their address can't be taken.

Solution:
I'm attempting a `try_compile` which just links the library and nothing else.
I'm also changing libatomic into an INTERFACE target.