### PR TITLE
Support the direction opcode

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(external/cpuid)
 
 set (SFIZZ_SOURCES
     sfizz/Synth.cpp
+    sfizz/FileId.cpp
     sfizz/FilePool.cpp
     sfizz/FilterPool.cpp
     sfizz/EQPool.cpp

--- a/src/sfizz/FileId.cpp
+++ b/src/sfizz/FileId.cpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "FileId.h"
+#include "StringViewHelpers.h"
+#include <iostream>
+
+size_t std::hash<sfz::FileId>::operator()(const sfz::FileId &id) const
+{
+    uint64_t h = ::hash(id.filename);
+    h = ::hash(id.reverse ? "!" : "", h);
+    return h;
+}
+
+std::ostream &operator<<(std::ostream &os, const sfz::FileId &fileId)
+{
+    os << fileId.filename;
+    if (fileId.reverse)
+        os << " (reverse)";
+    return os;
+}

--- a/src/sfizz/FileId.h
+++ b/src/sfizz/FileId.h
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include <string>
+#include <iosfwd>
+
+namespace sfz {
+
+/**
+ * @brief Sample file identifier within a file pool.
+ */
+struct FileId {
+    std::string filename;
+    bool reverse = false;
+
+    /**
+     * @brief Construct a null identifier.
+     */
+    FileId()
+    {
+    }
+
+    /**
+     * @brief Construct a file identifier, optionally reversed.
+     *
+     * @param filename
+     * @param reverse
+     */
+    FileId(std::string filename, bool reverse = false)
+        : filename(std::move(filename)), reverse(reverse)
+    {
+    }
+
+    /**
+     * @brief Check equality with another identifier.
+     *
+     * @param other
+     */
+    bool operator==(const FileId &other) const
+    {
+        return reverse == other.reverse && filename == other.filename;
+    }
+
+    /**
+     * @brief Check inequality with another identifier.
+     *
+     * @param other
+     */
+    bool operator!=(const FileId &other) const
+    {
+        return !operator==(other);
+    }
+};
+
+}
+
+namespace std {
+    template <> struct hash<sfz::FileId> {
+        size_t operator()(const sfz::FileId &id) const;
+    };
+}
+
+std::ostream &operator<<(std::ostream &os, const sfz::FileId &fileId);

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -42,10 +42,13 @@ bool sfz::Region::parseOpcode(const Opcode& opcode)
                 break;
 
             if (trimmedSample[0] == '*')
-                sample = std::string(trimmedSample);
+                sampleId.filename = std::string(trimmedSample);
             else
-                sample = absl::StrCat(defaultPath, absl::StrReplaceAll(trimmedSample, { { "\\", "/" } }));
+                sampleId.filename = absl::StrCat(defaultPath, absl::StrReplaceAll(trimmedSample, { { "\\", "/" } }));
         }
+        break;
+    case hash("direction"):
+        sampleId.reverse = opcode.value == "reverse";
         break;
     case hash("delay"):
         setValueFromOpcode(opcode, delay, Default::delayRange);

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -14,6 +14,7 @@
 #include "Opcode.h"
 #include "AudioBuffer.h"
 #include "MidiState.h"
+#include "FileId.h"
 #include "absl/types/optional.h"
 #include <bitset>
 #include <string>
@@ -57,7 +58,7 @@ struct Region {
      * @return true
      * @return false
      */
-    bool isGenerator() const noexcept { return sample.size() > 0 ? sample[0] == '*' : false; }
+    bool isGenerator() const noexcept { return sampleId.filename.size() > 0 ? sampleId.filename[0] == '*' : false; }
     /**
      * @brief Is stereo (has stereo sample or is unison oscillator)?
      *
@@ -227,7 +228,7 @@ struct Region {
     float getGainToEffectBus(unsigned number) const noexcept;
 
     // Sound source: sample playback
-    std::string sample {}; // Sample
+    FileId sampleId {}; // Sample
     float delay { Default::delay }; // delay
     float delayRandom { Default::delayRandom }; // delay_random
     int64_t offset { Default::offset }; // offset

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -332,7 +332,7 @@ bool sfz::Synth::loadSfzFile(const fs::path& file)
         if (currentRegion->get() == nullptr)
             return;
 
-        DBG("Removing the region with sample " << currentRegion->get()->sample);
+        DBG("Removing the region with sample " << currentRegion->get()->sampleId);
         std::iter_swap(currentRegion, lastRegion);
         ++lastRegion;
     };
@@ -344,12 +344,12 @@ bool sfz::Synth::loadSfzFile(const fs::path& file)
         auto region = currentRegion->get();
 
         if (!region->oscillator && !region->isGenerator()) {
-            if (!resources.filePool.checkSample(region->sample)) {
+            if (!resources.filePool.checkSample(region->sampleId.filename)) {
                 removeCurrentRegion();
                 continue;
             }
 
-            const auto fileInformation = resources.filePool.getFileInformation(region->sample);
+            const auto fileInformation = resources.filePool.getFileInformation(region->sampleId);
             if (!fileInformation) {
                 removeCurrentRegion();
                 continue;
@@ -381,16 +381,16 @@ bool sfz::Synth::loadSfzFile(const fs::path& file)
                 return Default::offsetCCRange.clamp(sumOffsetCC);
             }();
 
-            if (!resources.filePool.preloadFile(region->sample, maxOffset))
+            if (!resources.filePool.preloadFile(region->sampleId, maxOffset))
                 removeCurrentRegion();
         }
         else if (region->oscillator && !region->isGenerator()) {
-            if (!resources.filePool.checkSample(region->sample)) {
+            if (!resources.filePool.checkSample(region->sampleId.filename)) {
                 removeCurrentRegion();
                 continue;
             }
 
-            if (!resources.wavePool.createFileWave(resources.filePool, region->sample)) {
+            if (!resources.wavePool.createFileWave(resources.filePool, region->sampleId.filename)) {
                 removeCurrentRegion();
                 continue;
             }

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -40,7 +40,7 @@ void sfz::Voice::startVoice(Region* region, int delay, int number, float value, 
 
     if (region->isGenerator()) {
         const WavetableMulti* wave = nullptr;
-        switch (hash(region->sample)) {
+        switch (hash(region->sampleId.filename)) {
         default:
         case hash("*silence"):
             break;
@@ -64,14 +64,14 @@ void sfz::Voice::startVoice(Region* region, int delay, int number, float value, 
         }
         setupOscillatorUnison();
     } else if (region->oscillator) {
-        const WavetableMulti* wave = resources.wavePool.getFileWave(region->sample);
+        const WavetableMulti* wave = resources.wavePool.getFileWave(region->sampleId.filename);
         for (WavetableOscillator& osc : waveOscillators) {
             osc.setWavetable(wave);
             osc.setPhase(region->getPhase());
         }
         setupOscillatorUnison();
     } else {
-        currentPromise = resources.filePool.getFilePromise(region->sample);
+        currentPromise = resources.filePool.getFilePromise(region->sampleId);
         if (currentPromise == nullptr) {
             reset();
             return;
@@ -483,7 +483,7 @@ void sfz::Voice::fillWithData(AudioSpan<float> buffer) noexcept
                     DBG("[sfizz] Underflow: source available samples "
                         << source.getNumFrames() << "/"
                         << region->trueSampleEnd(currentPromise->oversamplingFactor)
-                        << " for sample " << region->sample);
+                        << " for sample " << region->sampleId);
                 }
                 fill<int>(indices->last(remainingElements), sampleEnd);
                 fill<float>(leftCoeffs->last(remainingElements), 0.0f);
@@ -529,7 +529,7 @@ void sfz::Voice::fillWithGenerator(AudioSpan<float> buffer) noexcept
     const auto leftSpan = buffer.getSpan(0);
     const auto rightSpan  = buffer.getSpan(1);
 
-    if (region->sample == "*noise") {
+    if (region->sampleId.filename == "*noise") {
         absl::c_generate(leftSpan, [&](){ return noiseDist(Random::randomGenerator); });
         absl::c_generate(rightSpan, [&](){ return noiseDist(Random::randomGenerator); });
     } else {

--- a/tests/FilesT.cpp
+++ b/tests/FilesT.cpp
@@ -19,7 +19,7 @@ TEST_CASE("[Files] Single region (regions_one.sfz)")
     sfz::Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Regions/regions_one.sfz");
     REQUIRE(synth.getNumRegions() == 1);
-    REQUIRE(synth.getRegionView(0)->sample == "dummy.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == "dummy.wav");
 }
 
 
@@ -28,9 +28,9 @@ TEST_CASE("[Files] Multiple regions (regions_many.sfz)")
     sfz::Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Regions/regions_many.sfz");
     REQUIRE(synth.getNumRegions() == 3);
-    REQUIRE(synth.getRegionView(0)->sample == "dummy.wav");
-    REQUIRE(synth.getRegionView(1)->sample == "dummy.1.wav");
-    REQUIRE(synth.getRegionView(2)->sample == "dummy.2.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == "dummy.wav");
+    REQUIRE(synth.getRegionView(1)->sampleId.filename == "dummy.1.wav");
+    REQUIRE(synth.getRegionView(2)->sampleId.filename == "dummy.2.wav");
 }
 
 TEST_CASE("[Files] Basic opcodes (regions_opcodes.sfz)")
@@ -54,8 +54,8 @@ TEST_CASE("[Files] (regions_bad.sfz)")
     sfz::Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Regions/regions_bad.sfz");
     REQUIRE(synth.getNumRegions() == 2);
-    REQUIRE(synth.getRegionView(0)->sample == "dummy.wav");
-    REQUIRE(synth.getRegionView(1)->sample == "dummy.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == "dummy.wav");
+    REQUIRE(synth.getRegionView(1)->sampleId.filename == "dummy.wav");
 }
 
 TEST_CASE("[Files] Local include")
@@ -63,7 +63,7 @@ TEST_CASE("[Files] Local include")
     sfz::Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Includes/root_local.sfz");
     REQUIRE(synth.getNumRegions() == 1);
-    REQUIRE(synth.getRegionView(0)->sample == "dummy.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == "dummy.wav");
 }
 
 TEST_CASE("[Files] Multiple includes")
@@ -71,8 +71,8 @@ TEST_CASE("[Files] Multiple includes")
     sfz::Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Includes/multiple_includes.sfz");
     REQUIRE(synth.getNumRegions() == 2);
-    REQUIRE(synth.getRegionView(0)->sample == "dummy.wav");
-    REQUIRE(synth.getRegionView(1)->sample == "dummy2.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == "dummy.wav");
+    REQUIRE(synth.getRegionView(1)->sampleId.filename == "dummy2.wav");
 }
 
 TEST_CASE("[Files] Multiple includes with comments")
@@ -80,8 +80,8 @@ TEST_CASE("[Files] Multiple includes with comments")
     sfz::Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Includes/multiple_includes_with_comments.sfz");
     REQUIRE(synth.getNumRegions() == 2);
-    REQUIRE(synth.getRegionView(0)->sample == "dummy.wav");
-    REQUIRE(synth.getRegionView(1)->sample == "dummy2.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == "dummy.wav");
+    REQUIRE(synth.getRegionView(1)->sampleId.filename == "dummy2.wav");
 }
 
 TEST_CASE("[Files] Subdir include")
@@ -89,7 +89,7 @@ TEST_CASE("[Files] Subdir include")
     sfz::Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Includes/root_subdir.sfz");
     REQUIRE(synth.getNumRegions() == 1);
-    REQUIRE(synth.getRegionView(0)->sample == "dummy_subdir.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == "dummy_subdir.wav");
 }
 
 TEST_CASE("[Files] Subdir include Win")
@@ -97,7 +97,7 @@ TEST_CASE("[Files] Subdir include Win")
     sfz::Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Includes/root_subdir_win.sfz");
     REQUIRE(synth.getNumRegions() == 1);
-    REQUIRE(synth.getRegionView(0)->sample == "dummy_subdir.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == "dummy_subdir.wav");
 }
 
 TEST_CASE("[Files] Recursive include (with include guard)")
@@ -107,8 +107,8 @@ TEST_CASE("[Files] Recursive include (with include guard)")
     parser.setRecursiveIncludeGuardEnabled(true);
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Includes/root_recursive.sfz");
     REQUIRE(synth.getNumRegions() == 2);
-    REQUIRE(synth.getRegionView(0)->sample == "dummy_recursive2.wav");
-    REQUIRE(synth.getRegionView(1)->sample == "dummy_recursive1.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == "dummy_recursive2.wav");
+    REQUIRE(synth.getRegionView(1)->sampleId.filename == "dummy_recursive1.wav");
 }
 
 TEST_CASE("[Files] Include loops (with include guard)")
@@ -118,8 +118,8 @@ TEST_CASE("[Files] Include loops (with include guard)")
     parser.setRecursiveIncludeGuardEnabled(true);
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Includes/root_loop.sfz");
     REQUIRE(synth.getNumRegions() == 2);
-    REQUIRE(synth.getRegionView(0)->sample == "dummy_loop2.wav");
-    REQUIRE(synth.getRegionView(1)->sample == "dummy_loop1.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == "dummy_loop2.wav");
+    REQUIRE(synth.getRegionView(1)->sampleId.filename == "dummy_loop1.wav");
 }
 
 TEST_CASE("[Files] Define test")
@@ -205,28 +205,28 @@ TEST_CASE("[Files] Full hierarchy with antislashes")
         sfz::Synth synth;
         synth.loadSfzFile(fs::current_path() / "tests/TestFiles/basic_hierarchy.sfz");
         REQUIRE(synth.getNumRegions() == 8);
-        REQUIRE(synth.getRegionView(0)->sample == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(1)->sample == "Regions/dummy.1.wav");
-        REQUIRE(synth.getRegionView(2)->sample == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(3)->sample == "Regions/dummy.1.wav");
-        REQUIRE(synth.getRegionView(4)->sample == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(5)->sample == "Regions/dummy.1.wav");
-        REQUIRE(synth.getRegionView(6)->sample == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(7)->sample == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(0)->sampleId.filename == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(1)->sampleId.filename == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(2)->sampleId.filename == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(3)->sampleId.filename == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(4)->sampleId.filename == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(5)->sampleId.filename == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(6)->sampleId.filename == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(7)->sampleId.filename == "Regions/dummy.1.wav");
     }
 
     {
         sfz::Synth synth;
         synth.loadSfzFile(fs::current_path() / "tests/TestFiles/basic_hierarchy_antislash.sfz");
         REQUIRE(synth.getNumRegions() == 8);
-        REQUIRE(synth.getRegionView(0)->sample == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(1)->sample == "Regions/dummy.1.wav");
-        REQUIRE(synth.getRegionView(2)->sample == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(3)->sample == "Regions/dummy.1.wav");
-        REQUIRE(synth.getRegionView(4)->sample == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(5)->sample == "Regions/dummy.1.wav");
-        REQUIRE(synth.getRegionView(6)->sample == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(7)->sample == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(0)->sampleId.filename == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(1)->sampleId.filename == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(2)->sampleId.filename == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(3)->sampleId.filename == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(4)->sampleId.filename == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(5)->sampleId.filename == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(6)->sampleId.filename == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(7)->sampleId.filename == "Regions/dummy.1.wav");
     }
 }
 
@@ -245,10 +245,10 @@ TEST_CASE("[Files] Pizz basic")
     REQUIRE(synth.getRegionView(1)->randRange == sfz::Range<float>(0.25, 0.5));
     REQUIRE(synth.getRegionView(2)->randRange == sfz::Range<float>(0.5, 0.75));
     REQUIRE(synth.getRegionView(3)->randRange == sfz::Range<float>(0.75, 1.0));
-    REQUIRE(synth.getRegionView(0)->sample == R"(../Samples/pizz/a0_vl4_rr1.wav)");
-    REQUIRE(synth.getRegionView(1)->sample == R"(../Samples/pizz/a0_vl4_rr2.wav)");
-    REQUIRE(synth.getRegionView(2)->sample == R"(../Samples/pizz/a0_vl4_rr3.wav)");
-    REQUIRE(synth.getRegionView(3)->sample == R"(../Samples/pizz/a0_vl4_rr4.wav)");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == R"(../Samples/pizz/a0_vl4_rr1.wav)");
+    REQUIRE(synth.getRegionView(1)->sampleId.filename == R"(../Samples/pizz/a0_vl4_rr2.wav)");
+    REQUIRE(synth.getRegionView(2)->sampleId.filename == R"(../Samples/pizz/a0_vl4_rr3.wav)");
+    REQUIRE(synth.getRegionView(3)->sampleId.filename == R"(../Samples/pizz/a0_vl4_rr4.wav)");
 }
 
 TEST_CASE("[Files] Channels (channels.sfz)")
@@ -256,9 +256,9 @@ TEST_CASE("[Files] Channels (channels.sfz)")
     sfz::Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/channels.sfz");
     REQUIRE(synth.getNumRegions() == 2);
-    REQUIRE(synth.getRegionView(0)->sample == "mono_sample.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == "mono_sample.wav");
     REQUIRE(!synth.getRegionView(0)->isStereo());
-    REQUIRE(synth.getRegionView(1)->sample == "stereo_sample.wav");
+    REQUIRE(synth.getRegionView(1)->sampleId.filename == "stereo_sample.wav");
     REQUIRE(synth.getRegionView(1)->isStereo());
 }
 
@@ -268,32 +268,32 @@ TEST_CASE("[Files] Channels (channels_multi.sfz)")
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/channels_multi.sfz");
     REQUIRE(synth.getNumRegions() == 6);
 
-    REQUIRE(synth.getRegionView(0)->sample == "*sine");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == "*sine");
     REQUIRE(!synth.getRegionView(0)->isStereo());
     REQUIRE(synth.getRegionView(0)->isGenerator());
     REQUIRE(!synth.getRegionView(0)->oscillator);
 
-    REQUIRE(synth.getRegionView(1)->sample == "*sine");
+    REQUIRE(synth.getRegionView(1)->sampleId.filename == "*sine");
     REQUIRE(synth.getRegionView(1)->isStereo());
     REQUIRE(synth.getRegionView(1)->isGenerator());
     REQUIRE(!synth.getRegionView(1)->oscillator);
 
-    REQUIRE(synth.getRegionView(2)->sample == "ramp_wave.wav");
+    REQUIRE(synth.getRegionView(2)->sampleId.filename == "ramp_wave.wav");
     REQUIRE(!synth.getRegionView(2)->isStereo());
     REQUIRE(!synth.getRegionView(2)->isGenerator());
     REQUIRE(synth.getRegionView(2)->oscillator);
 
-    REQUIRE(synth.getRegionView(3)->sample == "ramp_wave.wav");
+    REQUIRE(synth.getRegionView(3)->sampleId.filename == "ramp_wave.wav");
     REQUIRE(synth.getRegionView(3)->isStereo());
     REQUIRE(!synth.getRegionView(3)->isGenerator());
     REQUIRE(synth.getRegionView(3)->oscillator);
 
-    REQUIRE(synth.getRegionView(4)->sample == "*sine");
+    REQUIRE(synth.getRegionView(4)->sampleId.filename == "*sine");
     REQUIRE(!synth.getRegionView(4)->isStereo());
     REQUIRE(synth.getRegionView(4)->isGenerator());
     REQUIRE(!synth.getRegionView(4)->oscillator);
 
-    REQUIRE(synth.getRegionView(5)->sample == "*sine");
+    REQUIRE(synth.getRegionView(5)->sampleId.filename == "*sine");
     REQUIRE(!synth.getRegionView(5)->isStereo());
     REQUIRE(synth.getRegionView(5)->isGenerator());
     REQUIRE(!synth.getRegionView(5)->oscillator);
@@ -359,7 +359,7 @@ TEST_CASE("[Files] Specific bug: relative path with backslashes")
     sfz::Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/SpecificBugs/win_backslashes.sfz");
     REQUIRE(synth.getNumRegions() == 1);
-    REQUIRE(synth.getRegionView(0)->sample == R"(Xylo/Subfolder/closedhat.wav)");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == R"(Xylo/Subfolder/closedhat.wav)");
 }
 
 TEST_CASE("[Files] Default path")
@@ -367,10 +367,10 @@ TEST_CASE("[Files] Default path")
     sfz::Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/default_path.sfz");
     REQUIRE(synth.getNumRegions() == 4);
-    REQUIRE(synth.getRegionView(0)->sample == R"(DefaultPath/SubPath1/sample1.wav)");
-    REQUIRE(synth.getRegionView(1)->sample == R"(DefaultPath/SubPath2/sample2.wav)");
-    REQUIRE(synth.getRegionView(2)->sample == R"(DefaultPath/SubPath1/sample1.wav)");
-    REQUIRE(synth.getRegionView(3)->sample == R"(DefaultPath/SubPath2/sample2.wav)");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == R"(DefaultPath/SubPath1/sample1.wav)");
+    REQUIRE(synth.getRegionView(1)->sampleId.filename == R"(DefaultPath/SubPath2/sample2.wav)");
+    REQUIRE(synth.getRegionView(2)->sampleId.filename == R"(DefaultPath/SubPath1/sample1.wav)");
+    REQUIRE(synth.getRegionView(3)->sampleId.filename == R"(DefaultPath/SubPath2/sample2.wav)");
 }
 
 TEST_CASE("[Files] Default path reset when calling loadSfzFile again")
@@ -380,7 +380,7 @@ TEST_CASE("[Files] Default path reset when calling loadSfzFile again")
     REQUIRE(synth.getNumRegions() == 4);
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/default_path_reset.sfz");
     REQUIRE(synth.getNumRegions() == 1);
-    REQUIRE(synth.getRegionView(0)->sample == R"(DefaultPath/SubPath2/sample2.wav)");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == R"(DefaultPath/SubPath2/sample2.wav)");
 }
 
 TEST_CASE("[Files] Default path is ignored for generators")
@@ -388,7 +388,7 @@ TEST_CASE("[Files] Default path is ignored for generators")
     sfz::Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/default_path_generator.sfz");
     REQUIRE(synth.getNumRegions() == 1);
-    REQUIRE(synth.getRegionView(0)->sample == R"(*sine)");
+    REQUIRE(synth.getRegionView(0)->sampleId.filename == R"(*sine)");
 }
 
 TEST_CASE("[Files] Set CC applies properly")
@@ -547,10 +547,10 @@ TEST_CASE("[Files] Case sentitiveness")
         sfz::Synth synth;
         synth.loadSfzFile(sfzFilePath);
         REQUIRE(synth.getNumRegions() == 4);
-        REQUIRE(synth.getRegionView(0)->sample == "dummy1.wav");
-        REQUIRE(synth.getRegionView(1)->sample == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(2)->sample == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(3)->sample == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(0)->sampleId.filename == "dummy1.wav");
+        REQUIRE(synth.getRegionView(1)->sampleId.filename == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(2)->sampleId.filename == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(3)->sampleId.filename == "Regions/dummy.wav");
     }
 }
 

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -18,9 +18,9 @@ TEST_CASE("[Region] Parsing opcodes")
 
     SECTION("sample")
     {
-        REQUIRE(region.sample == "");
+        REQUIRE(region.sampleId.filename == "");
         region.parseOpcode({ "sample", "dummy.wav" });
-        REQUIRE(region.sample == "dummy.wav");
+        REQUIRE(region.sampleId.filename == "dummy.wav");
     }
 
     SECTION("direction")

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -23,6 +23,15 @@ TEST_CASE("[Region] Parsing opcodes")
         REQUIRE(region.sample == "dummy.wav");
     }
 
+    SECTION("direction")
+    {
+        REQUIRE(!region.sampleId.reverse);
+        region.parseOpcode({ "direction", "reverse" });
+        REQUIRE(region.sampleId.reverse);
+        region.parseOpcode({ "direction", "forward" });
+        REQUIRE(!region.sampleId.reverse);
+    }
+
     SECTION("delay")
     {
         REQUIRE(region.delay == 0.0);


### PR DESCRIPTION
Implement #179

This supports `direction=reverse`.

- Instead of being identified by filename, samples are identified by filename + reverse bit.
  The class `FileId` is created for this purpose.
- This change is propagated throughout sfizz in places where applicable.
- For non-oscillator regions, the file will be requested in the pool with option `reverse=1`.
  At load time, the sound file seeks at `end-N` frames, reads N frames to the buffer, and reverses the result.

Note: loop is ignored on `reverse=1`, a comment is written to indicate it.

Example
```
<region>
pitch_keycenter=69
sample=mysound.wav
direction=reverse
```