### PR TITLE
Bundle the dylibs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ jobs:
     - INSTALL_DIR="sfizz-${TRAVIS_BRANCH}-${TRAVIS_OS_NAME}-${TRAVIS_CPU_ARCH}"
     install: .travis/install_osx.sh
     script: .travis/script_osx.sh
-    after_success: .travis/prepare_tarball.sh
+    after_success: .travis/prepare_osx.sh
 
   - name: "MOD devices arm"
     stage: "Build"

--- a/.travis/install_osx.sh
+++ b/.travis/install_osx.sh
@@ -6,3 +6,4 @@ sudo ln -s /usr/local /opt/local
 brew update
 brew upgrade cmake
 brew install jack
+brew install dylibbundler

--- a/.travis/prepare_osx.sh
+++ b/.travis/prepare_osx.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -ex
+
+test -z "$CONTAINER"
+
+if ! [ -z "$CONTAINER" ]; then
+  . .travis/docker_container.sh
+else
+  . .travis/no_container.sh
+fi
+
+cd build
+buildenv make DESTDIR=${PWD}/${INSTALL_DIR} install
+
+# Bundle LV2 dependencies
+cd "${INSTALL_DIR}"/Library/Audio/Plug-Ins/LV2
+dylibbundler -od -b -x sfizz.lv2/sfizz.so -d sfizz.lv2/libs/ -p @loader_path/libs/
+cd "${TRAVIS_BUILD_DIR}/build"
+
+# Bundle VST3 dependencies
+cd "${INSTALL_DIR}"/Library/Audio/Plug-Ins/VST3
+dylibbundler -od -b -x sfizz.vst3/Contents/MacOS/sfizz -d sfizz.vst3/Contents/libs/ -p @loader_path/../libs/
+cd "${TRAVIS_BUILD_DIR}/build"
+
+#
+tar -zcvf "${INSTALL_DIR}.tar.gz" ${INSTALL_DIR}
+
+# Only release a tarball if there is a tag
+if [[ ${TRAVIS_TAG} != "" ]]; then
+  mv "${INSTALL_DIR}.tar.gz" ${TRAVIS_BUILD_DIR}
+fi
+
+cd "${TRAVIS_BUILD_DIR}"

--- a/.travis/prepare_tarball.sh
+++ b/.travis/prepare_tarball.sh
@@ -8,13 +8,13 @@ else
   . .travis/no_container.sh
 fi
 
-# Do not prepare a tarball without a tag
-if [[ ${TRAVIS_TAG} == "" ]]; then
-  exit 0
-fi
-
 cd build
 buildenv make DESTDIR=${PWD}/${INSTALL_DIR} install
 tar -zcvf "${INSTALL_DIR}.tar.gz" ${INSTALL_DIR}
-mv "${INSTALL_DIR}.tar.gz" ${TRAVIS_BUILD_DIR}
+
+# Only release a tarball if there is a tag
+if [[ ${TRAVIS_TAG} != "" ]]; then
+  mv "${INSTALL_DIR}.tar.gz" ${TRAVIS_BUILD_DIR}
+fi
+
 cd ..

--- a/.travis/script_osx.sh
+++ b/.travis/script_osx.sh
@@ -6,6 +6,8 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -DSFIZZ_VST=ON \
       -DSFIZZ_TESTS=OFF \
       -DCMAKE_CXX_STANDARD=17 \
+      -DLV2PLUGIN_INSTALL_DIR=/Library/Audio/Plug-Ins/LV2 \
+      -DVSTPLUGIN_INSTALL_DIR=/Library/Audio/Plug-Ins/VST3 \
       ..
 make -j$(sysctl -n hw.ncpu)
 # Xcode not currently supported, see https://gitlab.kitware.com/cmake/cmake/issues/18088


### PR DESCRIPTION
This fixes up the plugin bundles to make them usable on macOS.

It's supposed to detect dylib dependencies, copy them in the bundle, and update the search paths relative to the binary.

See `@loader_path`
https://www.unix.com/man-page/osx/1/dyld/

Needs to test on macOS