### PR TITLE
Add some copy/fill benchmarks against libc

### DIFF
--- a/benchmarks/BM_simdVsStdc.cpp
+++ b/benchmarks/BM_simdVsStdc.cpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "SIMDHelpers.h"
+#include <benchmark/benchmark.h>
+#include <vector>
+#include <cstdlib>
+
+class MyFixture : public benchmark::Fixture {
+public:
+    void SetUp(const ::benchmark::State& state)
+    {
+        src.resize(state.range(0));
+        dst.resize(state.range(0));
+    }
+
+    std::vector<float> src;
+    std::vector<float> dst;
+};
+
+BENCHMARK_DEFINE_F(MyFixture, SimdFill)(benchmark::State& state) {
+    for (auto _ : state)
+    {
+        sfz::fill(absl::MakeSpan(dst), 0.0f);
+    }
+}
+
+BENCHMARK_DEFINE_F(MyFixture, StdcFill)(benchmark::State& state) {
+    for (auto _ : state)
+    {
+        std::memset(dst.data(), 0, dst.size() * sizeof(dst[0]));
+    }
+}
+
+BENCHMARK_DEFINE_F(MyFixture, SimdCopy)(benchmark::State& state) {
+    for (auto _ : state)
+    {
+        sfz::copy(absl::MakeConstSpan(src), absl::MakeSpan(dst));
+    }
+}
+
+BENCHMARK_DEFINE_F(MyFixture, StdcCopy)(benchmark::State& state) {
+    for (auto _ : state)
+    {
+        std::memcpy(dst.data(), src.data(), dst.size() * sizeof(dst[0]));
+    }
+}
+
+BENCHMARK_REGISTER_F(MyFixture, SimdFill)->RangeMultiplier(4)->Range(1, 1024 * 1024);
+BENCHMARK_REGISTER_F(MyFixture, StdcFill)->RangeMultiplier(4)->Range(1, 1024 * 1024);
+BENCHMARK_REGISTER_F(MyFixture, SimdCopy)->RangeMultiplier(4)->Range(1, 1024 * 1024);
+BENCHMARK_REGISTER_F(MyFixture, StdcCopy)->RangeMultiplier(4)->Range(1, 1024 * 1024);
+BENCHMARK_MAIN();

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -64,6 +64,7 @@ sfizz_add_benchmark(bm_pointerIterationOrOffsets BM_pointerIterationOrOffsets.cp
 sfizz_add_benchmark(bm_maps BM_maps.cpp)
 target_link_libraries(bm_maps PRIVATE absl::flat_hash_map)
 sfizz_add_benchmark(bm_mapVsArray BM_mapVsArray.cpp)
+sfizz_add_benchmark(bm_simdVsStdc BM_simdVsStdc.cpp)
 
 sfizz_add_benchmark(bm_logger BM_logger.cpp)
 target_link_libraries(bm_logger PRIVATE sfizz::sfizz)


### PR DESCRIPTION
```
2020-04-19 00:04:24
Running ./build/benchmarks/bm_simdVsStdc
Run on (8 X 3600 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 64K (x4)
  L2 Unified 512K (x4)
  L3 Unified 4096K (x1)
Load Average: 2.91, 2.16, 1.57
---------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations
---------------------------------------------------------------------
MyFixture/SimdFill/1             2.61 ns         2.49 ns    262934723
MyFixture/SimdFill/4             3.25 ns         3.17 ns    232483187
MyFixture/SimdFill/16            5.49 ns         5.32 ns    136275973
MyFixture/SimdFill/64            13.9 ns         13.2 ns     55808314
MyFixture/SimdFill/256           55.2 ns         52.6 ns     13533225
MyFixture/SimdFill/1024           173 ns          169 ns      4238181
MyFixture/SimdFill/4096           642 ns          639 ns      1035161
MyFixture/SimdFill/16384         2358 ns         2350 ns       291861
MyFixture/SimdFill/65536         9777 ns         9475 ns        75643
MyFixture/SimdFill/262144       40667 ns        38780 ns        19310
MyFixture/SimdFill/1048576     565677 ns       533693 ns         2225
MyFixture/StdcFill/1             3.39 ns         3.23 ns    227691476
MyFixture/StdcFill/4             3.10 ns         2.98 ns    233329808
MyFixture/StdcFill/16            3.10 ns         2.98 ns    235355213
MyFixture/StdcFill/64            8.07 ns         7.69 ns    103203925
MyFixture/StdcFill/256           21.6 ns         20.7 ns     34389782
MyFixture/StdcFill/1024          76.3 ns         73.0 ns      9495598
MyFixture/StdcFill/4096           304 ns          291 ns      2342646
MyFixture/StdcFill/16384         1310 ns         1247 ns       597290
MyFixture/StdcFill/65536         5056 ns         4826 ns       133774
MyFixture/StdcFill/262144       25815 ns        25348 ns        25462
MyFixture/StdcFill/1048576     702025 ns       687197 ns          927
MyFixture/SimdCopy/1            0.882 ns        0.842 ns    825451617
MyFixture/SimdCopy/4             2.52 ns         2.40 ns    292977592
MyFixture/SimdCopy/16            7.52 ns         7.15 ns     91286848
MyFixture/SimdCopy/64            31.7 ns         31.6 ns     19294156
MyFixture/SimdCopy/256           94.5 ns         90.8 ns      8118643
MyFixture/SimdCopy/1024           310 ns          308 ns      2324769
MyFixture/SimdCopy/4096          1338 ns         1332 ns       546499
MyFixture/SimdCopy/16384         5650 ns         5619 ns       124135
MyFixture/SimdCopy/65536        28133 ns        27967 ns        25400
MyFixture/SimdCopy/262144       93601 ns        92970 ns         7466
MyFixture/SimdCopy/1048576    1362244 ns      1324803 ns          520
MyFixture/StdcCopy/1             3.78 ns         3.72 ns    191547758
MyFixture/StdcCopy/4             3.17 ns         3.12 ns    226374628
MyFixture/StdcCopy/16            3.32 ns         3.26 ns    221013524
MyFixture/StdcCopy/64            7.61 ns         7.45 ns    104321814
MyFixture/StdcCopy/256           22.2 ns         21.9 ns     30998622
MyFixture/StdcCopy/1024          78.2 ns         76.9 ns      9222549
MyFixture/StdcCopy/4096           348 ns          343 ns      1804254
MyFixture/StdcCopy/16384         1353 ns         1334 ns       498010
MyFixture/StdcCopy/65536         5721 ns         5668 ns       119365
MyFixture/StdcCopy/262144       32003 ns        31800 ns        22064
MyFixture/StdcCopy/1048576     966866 ns       955757 ns          715
```