### PR TITLE
Add the modulation matrix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set (SFIZZ_SOURCES
     sfizz/SfzFilter.cpp
     sfizz/Curve.cpp
     sfizz/Wavetables.cpp
+    sfizz/ModMatrix.cpp
     sfizz/RTSemaphore.cpp
     sfizz/Effects.cpp
     sfizz/effects/Nothing.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ set (SFIZZ_SOURCES
     sfizz/Curve.cpp
     sfizz/Wavetables.cpp
     sfizz/ModMatrix.cpp
+    sfizz/ModMatrixHelpers.cpp
     sfizz/RTSemaphore.cpp
     sfizz/Effects.cpp
     sfizz/effects/Nothing.cpp

--- a/src/sfizz/ModMatrix.cpp
+++ b/src/sfizz/ModMatrix.cpp
@@ -95,9 +95,9 @@ ModMatrix::SourceId ModMatrix::registerSource(ModKey key, ModGenerator* gen, boo
     return id;
 }
 
-ModMatrix::TargetId ModMatrix::registerTarget(ModKey key, int32_t flags)
+ModMatrix::TargetId ModMatrix::registerTarget(ModKey key, uint32_t region, int32_t flags)
 {
-    auto it = _targetIndex.find(key);
+    auto it = _targetIndex.find(std::make_pair(key, region));
     if (it != _targetIndex.end()) {
         TargetId id;
         id.index = it->second;
@@ -114,7 +114,7 @@ ModMatrix::TargetId ModMatrix::registerTarget(ModKey key, int32_t flags)
     target.bufferReady = false;
     target.buffer.resize(_samplesPerBlock);
 
-    _targetIndex[key] = id.index;
+    _targetIndex[std::make_pair(key, region)] = id.index;
     return id;
 }
 
@@ -131,11 +131,11 @@ ModMatrix::SourceId ModMatrix::findSource(ModKey key)
     return id;
 }
 
-ModMatrix::TargetId ModMatrix::findTarget(ModKey key)
+ModMatrix::TargetId ModMatrix::findTarget(ModKey key, uint32_t region)
 {
     TargetId id;
 
-    auto it = _targetIndex.find(key);
+    auto it = _targetIndex.find(std::make_pair(key, region));
     if (it != _targetIndex.end())
         id.index = it->second;
     else

--- a/src/sfizz/ModMatrix.cpp
+++ b/src/sfizz/ModMatrix.cpp
@@ -118,6 +118,32 @@ ModMatrix::TargetId ModMatrix::registerTarget(ModKey key, int32_t flags)
     return id;
 }
 
+ModMatrix::SourceId ModMatrix::findSource(ModKey key)
+{
+    SourceId id;
+
+    auto it = _sourceIndex.find(key);
+    if (it != _sourceIndex.end())
+        id.index = it->second;
+    else
+        id.index = -1;
+
+    return id;
+}
+
+ModMatrix::TargetId ModMatrix::findTarget(ModKey key)
+{
+    TargetId id;
+
+    auto it = _targetIndex.find(key);
+    if (it != _targetIndex.end())
+        id.index = it->second;
+    else
+        id.index = -1;
+
+    return id;
+}
+
 bool ModMatrix::connect(SourceId sourceId, TargetId targetId)
 {
     uint32_t sourceIndex = sourceId.index;
@@ -160,13 +186,12 @@ void ModMatrix::beginVoice(unsigned voiceNum)
     }
 }
 
-float* ModMatrix::getModulation(ModKey targetKey)
+float* ModMatrix::getModulation(TargetId targetId)
 {
-    auto it = _targetIndex.find(targetKey);
-    if (it == _targetIndex.end())
+    if (!validTarget(targetId))
         return nullptr;
 
-    uint32_t targetIndex = it->second;
+    const uint32_t targetIndex = targetId.index;
     Target &target = _targets[targetIndex];
 
     absl::Span<float> buffer = absl::MakeSpan(target.buffer);
@@ -183,7 +208,7 @@ float* ModMatrix::getModulation(ModKey targetKey)
     sfz::fill(buffer, 0.0f);
 
     const std::vector<uint32_t> &sourceIndices = target.sources;
-    size_t numSources = sourceIndices.size();
+    const size_t numSources = sourceIndices.size();
 
     // generate the first source in buffer
     if (numSources > 0) {

--- a/src/sfizz/ModMatrix.cpp
+++ b/src/sfizz/ModMatrix.cpp
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "ModMatrix.h"
+#include "Config.h"
+#include "StringViewHelpers.h"
+#include "SIMDHelpers.h"
+#include <algorithm>
+#include <cassert>
+
+size_t std::hash<sfz::ModKey>::operator()(const sfz::ModKey &key) const
+{
+    auto hashableInt32 = [](const int32_t *p) -> absl::string_view {
+        return absl::string_view(reinterpret_cast<const char *>(p), sizeof(*p));
+    };
+    uint64_t k = key.id;
+    k = ::hash(hashableInt32(&key.index1), k);
+    k = ::hash(hashableInt32(&key.index2), k);
+    return k;
+}
+
+bool sfz::ModKey::operator==(const ModKey &other) const noexcept
+{
+    return id == other.id && index1 == other.index1 && index2 == other.index2;
+}
+
+bool sfz::ModKey::operator!=(const ModKey &other) const noexcept
+{
+    return !this->operator==(other);
+}
+
+namespace sfz {
+
+ModMatrix::ModMatrix()
+    : _samplesPerBlock(config::defaultSamplesPerBlock)
+{
+    _temp.resize(_samplesPerBlock);
+}
+
+ModMatrix::~ModMatrix()
+{
+}
+
+void ModMatrix::clear()
+{
+    _sourceIndex.clear();
+    _targetIndex.clear();
+    _sources.clear();
+    _targets.clear();
+}
+
+void ModMatrix::setSamplesPerBlock(unsigned samplesPerBlock)
+{
+    _samplesPerBlock = samplesPerBlock;
+
+    for (Source &source : _sources)
+        source.buffer.resize(samplesPerBlock);
+    for (Target &target : _targets)
+        target.buffer.resize(samplesPerBlock);
+
+    _temp.resize(samplesPerBlock);
+}
+
+ModMatrix::SourceId ModMatrix::registerSource(ModKey key, ModGenerator* gen, bool genOwned, int32_t flags)
+{
+    assert(gen);
+
+    std::unique_ptr<ModGenerator> genOwnerPtr;
+    if (genOwned)
+        genOwnerPtr.reset(gen);
+
+    auto it = _sourceIndex.find(key);
+    if (it != _sourceIndex.end()) {
+        SourceId id;
+        id.index = it->second;
+        return id;
+    }
+
+    SourceId id;
+    id.index = _sources.size();
+    _sources.emplace_back();
+
+    Source &source = _sources.back();
+    source.gen = gen;
+    source.genOwnerPtr = std::move(genOwnerPtr);
+    source.flags = flags;
+    source.bufferReady = false;
+    source.buffer.resize(_samplesPerBlock);
+
+    _sourceIndex[key] = id.index;
+    return id;
+}
+
+ModMatrix::TargetId ModMatrix::registerTarget(ModKey key, int32_t flags)
+{
+    auto it = _targetIndex.find(key);
+    if (it != _targetIndex.end()) {
+        TargetId id;
+        id.index = it->second;
+        return id;
+    }
+
+    TargetId id;
+    id.index = _targets.size();
+    _targets.emplace_back();
+
+    Target &target = _targets.back();
+    target.flags = flags;
+    target.bufferReady = false;
+    target.buffer.resize(_samplesPerBlock);
+
+    _targetIndex[key] = id.index;
+    return id;
+}
+
+bool ModMatrix::connect(SourceId sourceId, TargetId targetId)
+{
+    uint32_t sourceIndex = sourceId.index;
+    uint32_t targetIndex = targetId.index;
+
+    if (sourceIndex >= _sources.size() || targetIndex >= _targets.size())
+        return false;
+
+    Target& target = _targets[targetIndex];
+    std::vector<uint32_t> &list = target.sources;
+
+    // add the source if not already present
+    if (std::find(list.begin(), list.end(), sourceIndex) == list.end())
+        list.push_back(sourceIndex);
+
+    return true;
+}
+
+void ModMatrix::beginCycle(unsigned numFrames)
+{
+    _numFrames = numFrames;
+
+    for (Source &source : _sources)
+        source.bufferReady = false;
+    for (Target &target : _targets)
+        target.bufferReady = false;
+}
+
+void ModMatrix::beginVoice(unsigned voiceNum)
+{
+    _voiceNum = voiceNum;
+
+    for (Source &source : _sources) {
+        if (source.flags & kModIsPerVoice)
+            source.bufferReady = false;
+    }
+    for (Target &target : _targets) {
+        if (target.flags & kModIsPerVoice)
+            target.bufferReady = false;
+    }
+}
+
+float* ModMatrix::getModulation(ModKey targetKey)
+{
+    auto it = _targetIndex.find(targetKey);
+    if (it == _targetIndex.end())
+        return nullptr;
+
+    uint32_t targetIndex = it->second;
+    Target &target = _targets[targetIndex];
+
+    absl::Span<float> buffer = absl::MakeSpan(target.buffer);
+
+    // check if already processed
+    if (target.bufferReady)
+        return buffer.data();
+
+    const uint32_t numFrames = _numFrames;
+
+    // set the ready flag to prevent a cycle
+    // in case there is, be sure to initialize the buffer
+    target.bufferReady = true;
+    sfz::fill(buffer, 0.0f);
+
+    const std::vector<uint32_t> &sourceIndices = target.sources;
+    size_t numSources = sourceIndices.size();
+
+    // generate the first source in buffer
+    if (numSources > 0) {
+        Source &source = _sources[sourceIndices[0]];
+        source.gen->process(_voiceNum, buffer.data(), numFrames);
+    }
+
+    // generate next sources in temporary buffer
+    // then add or multiply, depending on target flags
+    absl::Span<float> temp = absl::MakeSpan(_temp);
+    for (uint32_t s = 1; s < numSources; ++s) {
+        Source &source = _sources[sourceIndices[s]];
+        source.gen->process(_voiceNum, temp.data(), numFrames);
+        if (target.flags & kModIsMultiplicative) {
+            for (uint32_t i = 0; i < numFrames; ++i)
+                buffer[i] *= temp[i];
+        }
+        else {
+            for (uint32_t i = 0; i < numFrames; ++i)
+                buffer[i] += temp[i];
+        }
+    }
+
+    return buffer.data();
+}
+
+} // namespace sfz

--- a/src/sfizz/ModMatrix.cpp
+++ b/src/sfizz/ModMatrix.cpp
@@ -84,6 +84,7 @@ ModMatrix::SourceId ModMatrix::registerSource(ModKey key, ModGenerator* gen, boo
     _sources.emplace_back();
 
     Source &source = _sources.back();
+    source.key = key;
     source.gen = gen;
     source.genOwnerPtr = std::move(genOwnerPtr);
     source.flags = flags;
@@ -108,6 +109,7 @@ ModMatrix::TargetId ModMatrix::registerTarget(ModKey key, int32_t flags)
     _targets.emplace_back();
 
     Target &target = _targets.back();
+    target.key = key;
     target.flags = flags;
     target.bufferReady = false;
     target.buffer.resize(_samplesPerBlock);
@@ -186,7 +188,7 @@ float* ModMatrix::getModulation(ModKey targetKey)
     // generate the first source in buffer
     if (numSources > 0) {
         Source &source = _sources[sourceIndices[0]];
-        source.gen->process(_voiceNum, buffer.data(), numFrames);
+        source.gen->generateModulation(source.key, _voiceNum, buffer.data(), numFrames);
     }
 
     // generate next sources in temporary buffer
@@ -194,7 +196,7 @@ float* ModMatrix::getModulation(ModKey targetKey)
     absl::Span<float> temp = absl::MakeSpan(_temp);
     for (uint32_t s = 1; s < numSources; ++s) {
         Source &source = _sources[sourceIndices[s]];
-        source.gen->process(_voiceNum, temp.data(), numFrames);
+        source.gen->generateModulation(source.key, _voiceNum, temp.data(), numFrames);
         if (target.flags & kModIsMultiplicative) {
             for (uint32_t i = 0; i < numFrames; ++i)
                 buffer[i] *= temp[i];

--- a/src/sfizz/ModMatrix.h
+++ b/src/sfizz/ModMatrix.h
@@ -112,9 +112,10 @@ public:
      * @brief Register a modulation target inside the matrix.
      *
      * @param key target key
+     * @param region target region
      * @param flags target flags
      */
-    TargetId registerTarget(ModKey key, int32_t flags);
+    TargetId registerTarget(ModKey key, uint32_t region, int32_t flags);
 
     /**
      * @brief Look up a source by key.
@@ -127,8 +128,9 @@ public:
      * @brief Look up a target by key.
      *
      * @param key target key
+     * @param index of target region
      */
-    TargetId findTarget(ModKey key);
+    TargetId findTarget(ModKey key, uint32_t region);
 
     /**
      * @brief Connect a source and a destination inside the matrix.
@@ -200,14 +202,17 @@ private:
 
     struct Target {
         ModKey key;
+        uint32_t region {};
         int32_t flags {};
         std::vector<uint32_t> sources;
         bool bufferReady {};
         Buffer<float> buffer;
     };
 
+    typedef std::pair<ModKey, uint32_t> TargetKey;
+
     absl::flat_hash_map<ModKey, uint32_t> _sourceIndex;
-    absl::flat_hash_map<ModKey, uint32_t> _targetIndex;
+    absl::flat_hash_map<TargetKey, uint32_t> _targetIndex;
 
     std::vector<Source> _sources;
     std::vector<Target> _targets;

--- a/src/sfizz/ModMatrix.h
+++ b/src/sfizz/ModMatrix.h
@@ -117,6 +117,20 @@ public:
     TargetId registerTarget(ModKey key, int32_t flags);
 
     /**
+     * @brief Look up a source by key.
+     *
+     * @param key source key
+     */
+    SourceId findSource(ModKey key);
+
+    /**
+     * @brief Look up a target by key.
+     *
+     * @param key target key
+     */
+    TargetId findTarget(ModKey key);
+
+    /**
      * @brief Connect a source and a destination inside the matrix.
      *
      * @param sourceId
@@ -145,9 +159,29 @@ public:
      * @brief Get the modulation buffer for the given target.
      * If the target does not exist, the result is null.
      *
-     * @param targetKey key of the modulation target
+     * @param targetId identifier of the modulation target
      */
-    float* getModulation(ModKey targetKey);
+    float* getModulation(TargetId targetId);
+
+    /**
+     * @brief Return whether the target identifier is valid.
+     *
+     * @param id
+     */
+    bool validTarget(TargetId id) const
+    {
+        return static_cast<uint32_t>(id.index) < _targets.size();
+    }
+
+    /**
+     * @brief Return whether the source identifier is valid.
+     *
+     * @param id
+     */
+    bool validSource(SourceId id) const
+    {
+        return static_cast<uint32_t>(id.index) < _sources.size();
+    }
 
 private:
     uint32_t _samplesPerBlock {};

--- a/src/sfizz/ModMatrix.h
+++ b/src/sfizz/ModMatrix.h
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include "Buffer.h"
+#include "absl/container/flat_hash_map.h"
+#include <vector>
+#include <memory>
+#include <cstdint>
+
+namespace sfz { class ModKey; }
+
+namespace std {
+    template <> struct hash<sfz::ModKey> {
+        size_t operator()(const sfz::ModKey &key) const;
+    };
+}
+
+namespace sfz {
+
+/**
+ * @brief Identifier of a modulation source or target
+ */
+class ModKey {
+public:
+    //! Identifier, a letter-only hash
+    uint64_t id = 0;
+    //! First index of the key or -1 (eg. `N` in `lfoN`)
+    int32_t index1 = -1;
+    //! Second index of the key or -1 (eg. `X` in `lfoN_eqX`)
+    int32_t index2 = -1;
+
+public:
+    bool operator==(const ModKey &other) const noexcept;
+    bool operator!=(const ModKey &other) const noexcept;
+};
+
+
+/**
+ * @brief Modulation bit flags (S=source, T=target, ST=either)
+ */
+enum ModFlags {
+    //! This modulation is global (the default). (ST)
+    kModIsPerCycle = 0,
+    //! This modulation is updated separately for every voice (ST)
+    kModIsPerVoice = 1 << 1,
+    //! This target is additive (the default). (T)
+    kModIsAdditive = 0,
+    //! This target is multiplicative (T)
+    kModIsMultiplicative = 1 << 2,
+};
+
+/**
+ * @brief Generator for modulation sources
+ */
+class ModGenerator {
+public:
+    virtual ~ModGenerator() {}
+
+    /**
+     * @brief Generate a cycle of the modulator
+     *
+     * @param voiceNum voice number if the generator is per-voice, otherwise undefined
+     * @param buffer output buffer
+     * @param numFrames number of frames to generate
+     */
+    virtual void process(int32_t voiceNum, float *buffer, unsigned numFrames) = 0;
+};
+
+/**
+ * @brief Modulation matrix
+ */
+class ModMatrix {
+public:
+    ModMatrix();
+    ~ModMatrix();
+
+    //! Identifier of a modulation source
+    struct SourceId { int32_t index = -1; };
+
+    //! Identifier of a modulation target
+    struct TargetId { int32_t index = -1; };
+
+    /**
+     * @brief Reset the matrix to the empty state.
+     */
+    void clear();
+
+    /**
+     * @brief Resize the modulation buffers.
+     *
+     * @param samplesPerBlock new block size
+     */
+    void setSamplesPerBlock(unsigned samplesPerBlock);
+
+    /**
+     * @brief Register a modulation source inside the matrix.
+     * If it is already present, it just returns the existing id.
+     *
+     * @param key source key
+     * @param gen generator
+     * @param genOwned whether the source takes ownership of the generator
+     * @param flags source flags
+     */
+    SourceId registerSource(ModKey key, ModGenerator* gen, bool genOwned, int32_t flags);
+
+    /**
+     * @brief Register a modulation target inside the matrix.
+     *
+     * @param key target key
+     * @param flags target flags
+     */
+    TargetId registerTarget(ModKey key, int32_t flags);
+
+    /**
+     * @brief Connect a source and a destination inside the matrix.
+     *
+     * @param sourceId
+     * @param targetId
+     * @return true if the connection was successfully made, otherwise false
+     */
+    bool connect(SourceId sourceId, TargetId targetId);
+
+    /**
+     * @brief Start modulation processing for the entire cycle.
+     * This clears all the buffers.
+     *
+     * @param numFrames
+     */
+    void beginCycle(unsigned numFrames);
+
+    /**
+     * @brief Start modulation processing for a given voice.
+     * This clears all the buffers which are per-voice.
+     *
+     * @param voiceNum the number of the current voice
+     */
+    void beginVoice(unsigned voiceNum);
+
+    /**
+     * @brief Get the modulation buffer for the given target.
+     * If the target does not exist, the result is null.
+     *
+     * @param targetKey key of the modulation target
+     */
+    float* getModulation(ModKey targetKey);
+
+private:
+    uint32_t _samplesPerBlock {};
+
+    uint32_t _numFrames {};
+    uint32_t _voiceNum {};
+
+    struct Source {
+        ModGenerator* gen {};
+        std::unique_ptr<ModGenerator> genOwnerPtr;
+        int32_t flags {};
+        bool bufferReady {};
+        Buffer<float> buffer;
+    };
+
+    struct Target {
+        int32_t flags {};
+        std::vector<uint32_t> sources;
+        bool bufferReady {};
+        Buffer<float> buffer;
+    };
+
+    absl::flat_hash_map<ModKey, uint32_t> _sourceIndex;
+    absl::flat_hash_map<ModKey, uint32_t> _targetIndex;
+
+    std::vector<Source> _sources;
+    std::vector<Target> _targets;
+
+    Buffer<float> _temp;
+};
+
+} // namespace sfz

--- a/src/sfizz/ModMatrix.h
+++ b/src/sfizz/ModMatrix.h
@@ -63,11 +63,12 @@ public:
     /**
      * @brief Generate a cycle of the modulator
      *
+     * @param sourceKey source key
      * @param voiceNum voice number if the generator is per-voice, otherwise undefined
      * @param buffer output buffer
      * @param numFrames number of frames to generate
      */
-    virtual void process(int32_t voiceNum, float *buffer, unsigned numFrames) = 0;
+    virtual void generateModulation(ModKey sourceKey, int32_t voiceNum, float *buffer, unsigned numFrames) = 0;
 };
 
 /**
@@ -155,6 +156,7 @@ private:
     uint32_t _voiceNum {};
 
     struct Source {
+        ModKey key;
         ModGenerator* gen {};
         std::unique_ptr<ModGenerator> genOwnerPtr;
         int32_t flags {};
@@ -163,6 +165,7 @@ private:
     };
 
     struct Target {
+        ModKey key;
         int32_t flags {};
         std::vector<uint32_t> sources;
         bool bufferReady {};

--- a/src/sfizz/ModMatrix.h
+++ b/src/sfizz/ModMatrix.h
@@ -28,10 +28,11 @@ class ModKey {
 public:
     //! Identifier, a letter-only hash
     uint64_t id = 0;
-    //! First index of the key or -1 (eg. `N` in `lfoN`)
-    int32_t index1 = -1;
-    //! Second index of the key or -1 (eg. `X` in `lfoN_eqX`)
-    int32_t index2 = -1;
+    //! List of values which identify the key uniquely, along with the hash
+    std::vector<float> params;
+
+    // eg. `N` in `lfoN`, `N, X` in `lfoN_eqX`
+    //     `nsteps, curve, smooth` for controllers
 
 public:
     bool operator==(const ModKey &other) const noexcept;
@@ -135,11 +136,12 @@ public:
     /**
      * @brief Connect a source and a destination inside the matrix.
      *
-     * @param sourceId
-     * @param targetId
+     * @param sourceId source of the connection
+     * @param targetId target of the connection
+     * @param depth factor by which the source signal affects the target
      * @return true if the connection was successfully made, otherwise false
      */
-    bool connect(SourceId sourceId, TargetId targetId);
+    bool connect(SourceId sourceId, TargetId targetId, float depth);
 
     /**
      * @brief Start modulation processing for the entire cycle.
@@ -200,11 +202,15 @@ private:
         Buffer<float> buffer;
     };
 
+    struct ConnectionData {
+        float depthToTarget {};
+    };
+
     struct Target {
         ModKey key;
         uint32_t region {};
         int32_t flags {};
-        std::vector<uint32_t> sources;
+        absl::flat_hash_map<uint32_t, ConnectionData> connectedSources;
         bool bufferReady {};
         Buffer<float> buffer;
     };

--- a/src/sfizz/ModMatrixHelpers.cpp
+++ b/src/sfizz/ModMatrixHelpers.cpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "ModMatrixHelpers.h"
+
+namespace sfz {
+
+} // namespace sfz

--- a/src/sfizz/ModMatrixHelpers.h
+++ b/src/sfizz/ModMatrixHelpers.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include <cstdint>
+
+namespace sfz {
+class ModGenerator;
+
+/**
+ * @brief Factory for various kinds of modulation generators.
+ */
+class ModGeneratorFactory {
+public:
+};
+
+} // namespace sfz

--- a/src/sfizz/ModMatrixHelpers.h
+++ b/src/sfizz/ModMatrixHelpers.h
@@ -15,6 +15,7 @@ class ModGenerator;
  */
 class ModGeneratorFactory {
 public:
+    virtual ~ModGeneratorFactory() {}
 };
 
 } // namespace sfz

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -21,6 +21,9 @@
 #include <vector>
 
 namespace sfz {
+class ModMatrix;
+class ModGeneratorFactory;
+
 /**
  * @brief Regions are the basic building blocks for the SFZ parsing and handling code.
  * All SFZ files are made of regions that are activated when a key is pressed or a CC
@@ -219,10 +222,21 @@ struct Region {
      * @param opcode
      * @param range
      * @param ccMap
+     * @param flags combination of ModFlags to describe the modulation target
      * @return true if the opcode was properly read and stored.
      * @return false
      */
-    bool processGenericCc(const Opcode& opcode, Range<float> range, CCMap<Modifier> *ccMap);
+    bool processGenericCc(const Opcode& opcode, Range<float> range, CCMap<Modifier> *ccMap, int32_t flags);
+
+    /**
+     * @brief Fill the sources and targets which are used by this region into
+     *        the modulation matrix.
+     *
+     * @param mm the modulation matrix
+     * @param index the index which identifies this region in the matrix
+     * @param gf the factory which serves to instantiate source generators
+     */
+    void populateModMatrix(ModMatrix& mm, uint32_t index, ModGeneratorFactory& gf);
 
     void offsetAllKeys(int offset) noexcept;
 
@@ -342,6 +356,15 @@ struct Region {
 
     // Effects
     std::vector<float> gainToEffect;
+
+    // Modulation matrix mappings
+    struct CCModEntry {
+        std::string target;
+        unsigned ccNumber {};
+        int32_t flags {};
+        Modifier modifier;
+    };
+    std::vector<CCModEntry> modulationsCC;
 
 private:
     const MidiState& midiState;

--- a/src/sfizz/Resources.h
+++ b/src/sfizz/Resources.h
@@ -12,6 +12,7 @@
 #include "Logger.h"
 #include "Wavetables.h"
 #include "Curve.h"
+#include "ModMatrix.h"
 
 namespace sfz
 {
@@ -27,6 +28,7 @@ struct Resources
     FilterPool filterPool { midiState };
     EQPool eqPool { midiState };
     WavetablePool wavePool;
+    ModMatrix modMatrix;
 
     void setSampleRate(float samplerate)
     {
@@ -39,6 +41,7 @@ struct Resources
     {
         bufferPool.setBufferSize(samplesPerBlock);
         midiState.setSamplesPerBlock(samplesPerBlock);
+        modMatrix.setSamplesPerBlock(samplesPerBlock);
     }
 
     void clear()
@@ -48,6 +51,7 @@ struct Resources
         wavePool.clearFileWaves();
         logger.clear();
         midiState.reset();
+        modMatrix.clear();
     }
 };
 }

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -95,7 +95,8 @@ void sfz::Synth::onParseWarning(const SourceRange& range, const std::string& mes
 
 void sfz::Synth::buildRegion(const std::vector<Opcode>& regionOpcodes)
 {
-    auto lastRegion = absl::make_unique<Region>(resources.midiState, defaultPath);
+    auto* lastRegion = new Region(resources.midiState, defaultPath);
+    regions.emplace_back(lastRegion);
 
     auto parseOpcodes = [&](const std::vector<Opcode>& opcodes) {
         for (auto& opcode : opcodes) {
@@ -117,7 +118,8 @@ void sfz::Synth::buildRegion(const std::vector<Opcode>& regionOpcodes)
     if (octaveOffset != 0 || noteOffset != 0)
         lastRegion->offsetAllKeys(octaveOffset * 12 + noteOffset);
 
-    regions.push_back(std::move(lastRegion));
+    size_t regionIndex = regions.size();
+    lastRegion->populateModMatrix(resources.modMatrix, static_cast<uint32_t>(regionIndex), *this);
 }
 
 void sfz::Synth::clear()

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -661,6 +661,7 @@ void sfz::Synth::renderBlock(AudioSpan<float> buffer) noexcept
         tempSpan->fill(0.0f);
         tempMixSpan->fill(0.0f);
         resources.filePool.cleanupPromises();
+        resources.modMatrix.beginCycle(numFrames);
 
         // Ramp out whatever is in the buffer at this point; should only be killed voice data
         linearRamp<float>(*rampSpan, 1.0f, -1.0f / static_cast<float>(numFrames));
@@ -670,9 +671,12 @@ void sfz::Synth::renderBlock(AudioSpan<float> buffer) noexcept
             }
         }
 
-        for (auto& voice : voices) {
+        for (int voiceNum = 0, numVoices = voices.size(); voiceNum < numVoices; ++voiceNum) {
+            Voice* voice = voices[voiceNum].get();
             if (voice->isFree())
                 continue;
+
+            resources.modMatrix.beginVoice(voiceNum);
 
             numActiveVoices++;
             renderVoiceToOutputs(*voice, *tempSpan);

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -10,6 +10,7 @@
 #include "Voice.h"
 #include "Region.h"
 #include "Effects.h"
+#include "ModMatrixHelpers.h"
 #include "LeakDetector.h"
 #include "MidiState.h"
 #include "AudioSpan.h"
@@ -60,7 +61,7 @@ namespace sfz {
  * The jack_client.cpp file contains examples of the most classical usage of the
  * synth and can be used as a reference.
  */
-class Synth final : public Parser::Listener {
+class Synth final : public Parser::Listener, public ModGeneratorFactory {
 public:
     /**
      * @brief Construct a new Synth object with no voices. If you want sound


### PR DESCRIPTION
This is the candidate modulation matrix.
It's documented in the header.

Just the basic code, it's not connected to anything.
It's a basic framework, `ModGenerator` is expected to be able to express EG, CC, and LFO.

It's supposed to be used in the cycle of the render method, in a way similar to this.
```
mm ← theModMatrix
mm.beginCycle(numFrames)
for voiceNum ← [0..numVoices-1]
    mm.beginVoice(voiceNum)
    [...]
```

The modulation matrix should be filled, and the connections created, during the opcode parsing stage.

A modulation is computed in a lazy way, by `getModulation`. There is different processing depending if the modulator is per-voice or not.

If `getModulation` returns `nullptr`, the modulation does not exist, then it means the code can choose to call a faster non-modulating variant (for example the filter cutoff). 

For now it doesn't compile because `Buffer` deletes the move assignment.

