### PR TITLE
Support block comments

### DIFF
--- a/src/sfizz/parser/Parser.cpp
+++ b/src/sfizz/parser/Parser.cpp
@@ -389,20 +389,21 @@ size_t Parser::skipComment()
 
     switch (commentType) {
     case CommentType::Line:
-        {
-            int c;
-            while ((c = reader.getChar()) != Reader::kEof && c != '\r' && c != '\n')
-                ++count;
-            terminated = true;
+        while (!terminated) {
+            int c = reader.getChar();
+            count += (c != Reader::kEof);
+            terminated = c == Reader::kEof || c == '\r' || c == '\n';
         }
         break;
     case CommentType::Block:
         {
             int c1 = 0;
             int c2 = reader.getChar();
+            count += (c2 != Reader::kEof);
             while (!terminated && c2 != Reader::kEof) {
                 c1 = c2;
                 c2 = reader.getChar();
+                count += (c2 != Reader::kEof);
                 terminated = c1 == '*' && c2 == '/';
             }
         }

--- a/src/sfizz/parser/Parser.h
+++ b/src/sfizz/parser/Parser.h
@@ -84,7 +84,13 @@ private:
     void flushCurrentHeader();
 
     // helpers
-    static int hasComment(Reader& reader); // 0=None 1=Line 2=Block
+    enum class CommentType {
+        None,
+        Line,
+        Block,
+    };
+
+    static CommentType getCommentType(Reader& reader);
     size_t skipComment();
     static void trimRight(std::string& text);
     static size_t extractToEol(Reader& reader, std::string* dst); // ignores comment

--- a/src/sfizz/parser/Parser.h
+++ b/src/sfizz/parser/Parser.h
@@ -84,8 +84,8 @@ private:
     void flushCurrentHeader();
 
     // helpers
-    static bool hasComment(Reader& reader);
-    static size_t skipComment(Reader& reader);
+    static int hasComment(Reader& reader); // 0=None 1=Line 2=Block
+    size_t skipComment();
     static void trimRight(std::string& text);
     static size_t extractToEol(Reader& reader, std::string* dst); // ignores comment
     std::string expandDollarVars(const SourceRange& range, absl::string_view src);

--- a/tests/DemoParser.cpp
+++ b/tests/DemoParser.cpp
@@ -38,6 +38,11 @@ static const char defaultSfzText[] = R"SFZ(
 // This is a SFZ test file with many problems.                                //
 //----------------------------------------------------------------------------//
 
+/*
+ * This is a block comment. Not all the SFZ players accept it.
+ * It can span over multiple lines.
+*/
+
 // opcode without header
 not_in_header=on    // warning
 
@@ -75,6 +80,12 @@ abcdef=$tata
 
 // opcode name which expands to invalid identifier
 $titi=1
+
+volume=10 /*
+block comments at the end of line
+*/
+
+/* unterminated block comment
 )SFZ";
 
 void Application::init()


### PR DESCRIPTION
#195 

This adds support of block comments in the parser.
There are some examples in the parser demo.

Maybe not all possibilities are supported.
For example, don't expect to be able to write: `sample=/*blabla*/mycomment.wav`

If the comment is not terminated with `*/`, an error will be raised.