### PR TITLE
Filter updates

### DIFF
--- a/src/sfizz/dsp/filters/filters_modulable.dsp
+++ b/src/sfizz/dsp/filters/filters_modulable.dsp
@@ -11,6 +11,7 @@ rbj = library("rbj_filters.dsp");
 //     b0,b1,b2,a1,a2 : normalized coefficients
 //-------------------------------------------------------------------------
 biquad(b0,b1,b2,a1,a2) = fi.iir((b0,b1,b2),(a1,a2));
+biquadTf2(b0,b1,b2,a1,a2) = fi.tf22t(b0,b1,b2,a1,a2);
 
 //-------------------------------------------------------------------------
 // Biquad filter using smoothed coefficients
@@ -18,6 +19,7 @@ biquad(b0,b1,b2,a1,a2) = fi.iir((b0,b1,b2),(a1,a2));
 //     b0,b1,b2,a1,a2 : normalized coefficients
 //-------------------------------------------------------------------------
 smoothBiquad(s,b0,b1,b2,a1,a2) = biquad(b0:s,b1:s,b2:s,a1:s,a2:s);
+smoothBiquadTf2(s,b0,b1,b2,a1,a2) = biquadTf2(b0:s,b1:s,b2:s,a1:s,a2:s);
 
 //-------------------------------------------------------------------------
 // RBJ filter of a specific type using smoothed coefficients
@@ -27,14 +29,14 @@ smoothBiquad(s,b0,b1,b2,a1,a2) = biquad(b0:s,b1:s,b2:s,a1:s,a2:s);
 //     q : height of the resonant peak in linear units
 //-------------------------------------------------------------------------
 rbjLpfSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).LPF,x) : smoothBiquad(s);
-rbjHpfSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).HPF,x) : smoothBiquad(s);
-rbjBpfSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).BPF,x) : smoothBiquad(s);
-rbjNotchSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).notch,x) : smoothBiquad(s);
-rbjApfSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).APF,x) : smoothBiquad(s);
-rbjPeakingEqSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).peakingEQ,x) : smoothBiquad(s);
-rbjPeakingNotchSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).peakNotch,x) : smoothBiquad(s);
-rbjLowShelfSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).lowShelf,x) : smoothBiquad(s);
-rbjHighShelfSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).highShelf,x) : smoothBiquad(s);
+rbjHpfSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).HPF,x) : smoothBiquadTf2(s);
+rbjBpfSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).BPF,x) : smoothBiquadTf2(s);
+rbjNotchSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).notch,x) : smoothBiquadTf2(s);
+rbjApfSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).APF,x) : smoothBiquadTf2(s);
+rbjPeakingEqSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).peakingEQ,x) : smoothBiquadTf2(s);
+rbjPeakingNotchSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).peakNotch,x) : smoothBiquadTf2(s);
+rbjLowShelfSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).lowShelf,x) : smoothBiquadTf2(s);
+rbjHighShelfSmooth(s,f,g,q,x) = (rbj.filtercoeff(f,g,q).highShelf,x) : smoothBiquadTf2(s);
 
 //-------------------------------------------------------------------------
 // 1-pole low-pass filter

--- a/src/sfizz/dsp/filters/sfz_filters.dsp
+++ b/src/sfizz/dsp/filters/sfz_filters.dsp
@@ -78,8 +78,7 @@ sfzLpf2pSv = sk.sallenKey2ndOrderLPF(smoothCoefs,cutoff,Q);
 sfzHpf2pSv = sk.sallenKey2ndOrderHPF(smoothCoefs,cutoff,Q);
 
 // the SFZ 2-pole state-variable bandpass filter
-//   Note: attenuate in order to have the resonant peak at 0 dB (same as sfzBpf2p)
-sfzBpf2pSv = sk.sallenKey2ndOrderBPF(smoothCoefs,cutoff,Q) : *((1./Q):smoothCoefs);
+sfzBpf2pSv = sk.sallenKey2ndOrderBPF(smoothCoefs,cutoff,Q);
 
 // the SFZ 2-pole state-variable notch filter
 sfzBrf2pSv = _ <: (sfzLpf2pSv, sfzHpf2pSv) :> +;

--- a/src/sfizz/gen/filters/sfz2chBpf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf2p.cxx
@@ -34,16 +34,24 @@ class faust2chBpf2p : public sfzFilterDsp {
 	int fSampleRate;
 	double fConst0;
 	double fConst1;
+	double fRec2[2];
+	double fVec0[2];
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec1[2];
-	double fRec2[2];
-	double fRec0[3];
 	double fRec3[2];
 	double fRec4[2];
+	double fVec1[2];
 	double fRec5[2];
-	double fRec6[3];
+	double fVec2[2];
+	double fRec6[2];
+	double fRec1[2];
+	double fRec0[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec8[2];
+	double fRec7[2];
 
  public:
 
@@ -110,25 +118,49 @@ class faust2chBpf2p : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fRec4[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
 		}
-		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
-			fRec6[l6] = 0.0;
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec6[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec1[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fRec0[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec3[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec4[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fVec5[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec8[l13] = 0.0;
+		}
+		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
+			fRec7[l14] = 0.0;
 		}
 	}
 
@@ -164,33 +196,47 @@ class faust2chBpf2p : public sfzFilterDsp {
 		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow4 = (0.5 * (fSlow2 / fSlow3));
 		double fSlow5 = (fSlow4 + 1.0);
-		double fSlow6 = (1.0 - fSlow0);
-		double fSlow7 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow6);
-		double fSlow8 = (((1.0 - fSlow4) / fSlow5) * fSlow6);
-		double fSlow9 = (0.5 * (fSlow2 / (fSlow3 * fSlow5)));
-		double fSlow10 = (fSlow9 * fSlow6);
-		double fSlow11 = ((0.0 - fSlow9) * fSlow6);
+		double fSlow6 = (0.5 * (fSlow2 / (fSlow3 * fSlow5)));
+		double fSlow7 = (1.0 - fSlow0);
+		double fSlow8 = (fSlow6 * fSlow7);
+		double fSlow9 = ((0.0 - fSlow6) * fSlow7);
+		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
+		double fSlow11 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow7);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
-			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow10);
-			fRec4[0] = (fSlow0 * fRec4[1]);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow11);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
-			fRec6[0] = (fTemp1 - ((fRec1[0] * fRec6[1]) + (fRec2[0] * fRec6[2])));
-			output1[i] = FAUSTFLOAT((((fRec3[0] * fRec6[0]) + (fRec4[0] * fRec6[1])) + (fRec5[0] * fRec6[2])));
-			fRec1[1] = fRec1[0];
+			fRec2[0] = (fSlow0 * fRec2[1]);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow8);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow9);
+			fVec1[0] = (fTemp0 * fRec4[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow10);
+			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow11);
+			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
+			fVec3[0] = (fTemp1 * fRec2[0]);
+			fVec4[0] = (fTemp1 * fRec4[0]);
+			fVec5[0] = (fVec4[1] - (fRec5[0] * fRec7[1]));
+			fRec8[0] = ((fVec3[1] + ((fTemp1 * fRec3[0]) + fVec5[1])) - (fRec6[0] * fRec8[1]));
+			fRec7[0] = fRec8[0];
+			output1[i] = FAUSTFLOAT(fRec7[0]);
 			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
-			fRec0[1] = fRec0[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
+			fVec1[1] = fVec1[0];
 			fRec5[1] = fRec5[0];
-			fRec6[2] = fRec6[1];
+			fVec2[1] = fVec2[0];
 			fRec6[1] = fRec6[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec8[1] = fRec8[0];
+			fRec7[1] = fRec7[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfz2chBpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf2pSv.cxx
@@ -42,9 +42,8 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 	double fRec5[2];
 	double fRec1[2];
 	double fRec2[2];
-	double fRec6[2];
+	double fRec7[2];
 	double fRec8[2];
-	double fRec9[2];
 
  public:
 
@@ -126,13 +125,10 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 			fRec2[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
-			fRec6[l5] = 0.0;
+			fRec7[l5] = 0.0;
 		}
 		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
 			fRec8[l6] = 0.0;
-		}
-		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
-			fRec9[l7] = 0.0;
 		}
 	}
 
@@ -166,7 +162,6 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
-		double fSlow4 = (fSlow3 * fSlow1);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
@@ -182,24 +177,22 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 			fRec1[0] = (fRec1[1] + (2.0 * (fRec3[0] * fTemp6)));
 			double fTemp7 = (fRec2[1] + (2.0 * fTemp5));
 			fRec2[0] = fTemp7;
-			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow4);
-			output0[i] = FAUSTFLOAT((fRec0 * fRec6[0]));
-			double fTemp8 = (fTemp1 - (fRec8[1] + (fRec5[0] * fRec9[1])));
+			output0[i] = FAUSTFLOAT(fRec0);
+			double fTemp8 = (fTemp1 - (fRec7[1] + (fRec5[0] * fRec8[1])));
 			double fTemp9 = (fTemp3 * fTemp8);
-			double fTemp10 = (fRec9[1] + fTemp9);
-			double fRec7 = fTemp10;
-			fRec8[0] = (fRec8[1] + (2.0 * (fRec3[0] * fTemp10)));
-			double fTemp11 = (fRec9[1] + (2.0 * fTemp9));
-			fRec9[0] = fTemp11;
-			output1[i] = FAUSTFLOAT((fRec6[0] * fRec7));
+			double fTemp10 = (fRec8[1] + fTemp9);
+			double fRec6 = fTemp10;
+			fRec7[0] = (fRec7[1] + (2.0 * (fRec3[0] * fTemp10)));
+			double fTemp11 = (fRec8[1] + (2.0 * fTemp9));
+			fRec8[0] = fTemp11;
+			output1[i] = FAUSTFLOAT(fRec6);
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
 			fRec5[1] = fRec5[0];
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
-			fRec6[1] = fRec6[0];
+			fRec7[1] = fRec7[0];
 			fRec8[1] = fRec8[0];
-			fRec9[1] = fRec9[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfz2chBpf4p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf4p.cxx
@@ -37,15 +37,31 @@ class faust2chBpf4p : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec0[2];
-	double fRec3[2];
-	double fRec4[2];
-	double fRec2[3];
+	double fRec2[2];
 	double fRec5[2];
+	double fVec0[2];
 	double fRec6[2];
-	double fRec1[3];
-	double fRec8[3];
-	double fRec7[3];
+	double fVec1[2];
+	double fRec7[2];
+	double fVec2[2];
+	double fRec8[2];
+	double fRec4[2];
+	double fRec3[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec1[2];
+	double fRec0[2];
+	double fVec6[2];
+	double fVec7[2];
+	double fVec8[2];
+	double fRec12[2];
+	double fRec11[2];
+	double fVec9[2];
+	double fVec10[2];
+	double fVec11[2];
+	double fRec10[2];
+	double fRec9[2];
 
  public:
 
@@ -112,31 +128,79 @@ class faust2chBpf4p : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec0[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec3[l1] = 0.0;
+			fRec5[l1] = 0.0;
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
-			fRec4[l2] = 0.0;
+			fVec0[l2] = 0.0;
 		}
-		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
-			fRec2[l3] = 0.0;
+		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
+			fRec6[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec5[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
-			fRec6[l5] = 0.0;
+			fRec7[l5] = 0.0;
 		}
-		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
-			fRec1[l6] = 0.0;
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
 		}
-		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
 			fRec8[l7] = 0.0;
 		}
-		for (int l8 = 0; (l8 < 3); l8 = (l8 + 1)) {
-			fRec7[l8] = 0.0;
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec4[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fRec3[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec3[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec4[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fVec5[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec1[l13] = 0.0;
+		}
+		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
+			fRec0[l14] = 0.0;
+		}
+		for (int l15 = 0; (l15 < 2); l15 = (l15 + 1)) {
+			fVec6[l15] = 0.0;
+		}
+		for (int l16 = 0; (l16 < 2); l16 = (l16 + 1)) {
+			fVec7[l16] = 0.0;
+		}
+		for (int l17 = 0; (l17 < 2); l17 = (l17 + 1)) {
+			fVec8[l17] = 0.0;
+		}
+		for (int l18 = 0; (l18 < 2); l18 = (l18 + 1)) {
+			fRec12[l18] = 0.0;
+		}
+		for (int l19 = 0; (l19 < 2); l19 = (l19 + 1)) {
+			fRec11[l19] = 0.0;
+		}
+		for (int l20 = 0; (l20 < 2); l20 = (l20 + 1)) {
+			fVec9[l20] = 0.0;
+		}
+		for (int l21 = 0; (l21 < 2); l21 = (l21 + 1)) {
+			fVec10[l21] = 0.0;
+		}
+		for (int l22 = 0; (l22 < 2); l22 = (l22 + 1)) {
+			fVec11[l22] = 0.0;
+		}
+		for (int l23 = 0; (l23 < 2); l23 = (l23 + 1)) {
+			fRec10[l23] = 0.0;
+		}
+		for (int l24 = 0; (l24 < 2); l24 = (l24 + 1)) {
+			fRec9[l24] = 0.0;
 		}
 	}
 
@@ -174,37 +238,65 @@ class faust2chBpf4p : public sfzFilterDsp {
 		double fSlow5 = (fSlow4 + 1.0);
 		double fSlow6 = (0.5 * (fSlow2 / (fSlow3 * fSlow5)));
 		double fSlow7 = (1.0 - fSlow0);
-		double fSlow8 = (fSlow6 * fSlow7);
-		double fSlow9 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
+		double fSlow8 = ((0.0 - fSlow6) * fSlow7);
+		double fSlow9 = (fSlow6 * fSlow7);
 		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
-		double fSlow11 = ((0.0 - fSlow6) * fSlow7);
+		double fSlow11 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow8);
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow9);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow10);
-			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
 			fRec5[0] = (fSlow0 * fRec5[1]);
-			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow11);
-			fRec1[0] = ((((fRec2[0] * fRec0[0]) + (fRec5[0] * fRec2[1])) + (fRec6[0] * fRec2[2])) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec5[0] * fRec1[1])) + (fRec6[0] * fRec1[2])));
-			fRec8[0] = (fTemp1 - ((fRec3[0] * fRec8[1]) + (fRec4[0] * fRec8[2])));
-			fRec7[0] = ((((fRec0[0] * fRec8[0]) + (fRec5[0] * fRec8[1])) + (fRec6[0] * fRec8[2])) - ((fRec3[0] * fRec7[1]) + (fRec4[0] * fRec7[2])));
-			output1[i] = FAUSTFLOAT((((fRec0[0] * fRec7[0]) + (fRec5[0] * fRec7[1])) + (fRec6[0] * fRec7[2])));
-			fRec0[1] = fRec0[0];
-			fRec3[1] = fRec3[0];
-			fRec4[1] = fRec4[0];
-			fRec2[2] = fRec2[1];
+			fVec0[0] = (fTemp0 * fRec5[0]);
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow9);
+			fVec1[0] = (fTemp0 * fRec2[0]);
+			fRec7[0] = ((fSlow0 * fRec7[1]) + fSlow10);
+			fVec2[0] = (fVec1[1] - (fRec7[0] * fRec3[1]));
+			fRec8[0] = ((fSlow0 * fRec8[1]) + fSlow11);
+			fRec4[0] = ((fVec0[1] + ((fTemp0 * fRec6[0]) + fVec2[1])) - (fRec8[0] * fRec4[1]));
+			fRec3[0] = fRec4[0];
+			fVec3[0] = (fRec2[0] * fRec3[0]);
+			fVec4[0] = (fVec3[1] - (fRec7[0] * fRec0[1]));
+			fVec5[0] = (fRec5[0] * fRec3[0]);
+			fRec1[0] = (((fVec4[1] + fVec5[1]) + (fRec6[0] * fRec3[0])) - (fRec8[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
+			fVec6[0] = (fTemp1 * fRec5[0]);
+			fVec7[0] = (fTemp1 * fRec2[0]);
+			fVec8[0] = (fVec7[1] - (fRec7[0] * fRec11[1]));
+			fRec12[0] = ((fVec6[1] + ((fTemp1 * fRec6[0]) + fVec8[1])) - (fRec8[0] * fRec12[1]));
+			fRec11[0] = fRec12[0];
+			fVec9[0] = (fRec2[0] * fRec11[0]);
+			fVec10[0] = (fVec9[1] - (fRec7[0] * fRec9[1]));
+			fVec11[0] = (fRec5[0] * fRec11[0]);
+			fRec10[0] = (((fVec10[1] + fVec11[1]) + (fRec6[0] * fRec11[0])) - (fRec8[0] * fRec10[1]));
+			fRec9[0] = fRec10[0];
+			output1[i] = FAUSTFLOAT(fRec9[0]);
 			fRec2[1] = fRec2[0];
 			fRec5[1] = fRec5[0];
+			fVec0[1] = fVec0[0];
 			fRec6[1] = fRec6[0];
-			fRec1[2] = fRec1[1];
-			fRec1[1] = fRec1[0];
-			fRec8[2] = fRec8[1];
-			fRec8[1] = fRec8[0];
-			fRec7[2] = fRec7[1];
+			fVec1[1] = fVec1[0];
 			fRec7[1] = fRec7[0];
+			fVec2[1] = fVec2[0];
+			fRec8[1] = fRec8[0];
+			fRec4[1] = fRec4[0];
+			fRec3[1] = fRec3[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
+			fVec6[1] = fVec6[0];
+			fVec7[1] = fVec7[0];
+			fVec8[1] = fVec8[0];
+			fRec12[1] = fRec12[0];
+			fRec11[1] = fRec11[0];
+			fVec9[1] = fVec9[0];
+			fVec10[1] = fVec10[0];
+			fVec11[1] = fVec11[0];
+			fRec10[1] = fRec10[0];
+			fRec9[1] = fRec9[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfz2chBpf6p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBpf6p.cxx
@@ -37,17 +37,41 @@ class faust2chBpf6p : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec0[2];
-	double fRec4[2];
-	double fRec5[2];
-	double fRec3[3];
-	double fRec6[2];
+	double fRec2[2];
 	double fRec7[2];
-	double fRec2[3];
-	double fRec1[3];
-	double fRec10[3];
-	double fRec9[3];
-	double fRec8[3];
+	double fVec0[2];
+	double fRec8[2];
+	double fVec1[2];
+	double fRec9[2];
+	double fVec2[2];
+	double fRec10[2];
+	double fRec6[2];
+	double fRec5[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec4[2];
+	double fRec3[2];
+	double fVec6[2];
+	double fVec7[2];
+	double fVec8[2];
+	double fRec1[2];
+	double fRec0[2];
+	double fVec9[2];
+	double fVec10[2];
+	double fVec11[2];
+	double fRec16[2];
+	double fRec15[2];
+	double fVec12[2];
+	double fVec13[2];
+	double fVec14[2];
+	double fRec14[2];
+	double fRec13[2];
+	double fVec15[2];
+	double fVec16[2];
+	double fVec17[2];
+	double fRec12[2];
+	double fRec11[2];
 
  public:
 
@@ -114,37 +138,109 @@ class faust2chBpf6p : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec0[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec4[l1] = 0.0;
+			fRec7[l1] = 0.0;
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
-			fRec5[l2] = 0.0;
+			fVec0[l2] = 0.0;
 		}
-		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
+			fRec8[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec6[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
-			fRec7[l5] = 0.0;
+			fRec9[l5] = 0.0;
 		}
-		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
-			fRec2[l6] = 0.0;
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
 		}
-		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
-			fRec1[l7] = 0.0;
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec10[l7] = 0.0;
 		}
-		for (int l8 = 0; (l8 < 3); l8 = (l8 + 1)) {
-			fRec10[l8] = 0.0;
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec6[l8] = 0.0;
 		}
-		for (int l9 = 0; (l9 < 3); l9 = (l9 + 1)) {
-			fRec9[l9] = 0.0;
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fRec5[l9] = 0.0;
 		}
-		for (int l10 = 0; (l10 < 3); l10 = (l10 + 1)) {
-			fRec8[l10] = 0.0;
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec3[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec4[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fVec5[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec4[l13] = 0.0;
+		}
+		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
+			fRec3[l14] = 0.0;
+		}
+		for (int l15 = 0; (l15 < 2); l15 = (l15 + 1)) {
+			fVec6[l15] = 0.0;
+		}
+		for (int l16 = 0; (l16 < 2); l16 = (l16 + 1)) {
+			fVec7[l16] = 0.0;
+		}
+		for (int l17 = 0; (l17 < 2); l17 = (l17 + 1)) {
+			fVec8[l17] = 0.0;
+		}
+		for (int l18 = 0; (l18 < 2); l18 = (l18 + 1)) {
+			fRec1[l18] = 0.0;
+		}
+		for (int l19 = 0; (l19 < 2); l19 = (l19 + 1)) {
+			fRec0[l19] = 0.0;
+		}
+		for (int l20 = 0; (l20 < 2); l20 = (l20 + 1)) {
+			fVec9[l20] = 0.0;
+		}
+		for (int l21 = 0; (l21 < 2); l21 = (l21 + 1)) {
+			fVec10[l21] = 0.0;
+		}
+		for (int l22 = 0; (l22 < 2); l22 = (l22 + 1)) {
+			fVec11[l22] = 0.0;
+		}
+		for (int l23 = 0; (l23 < 2); l23 = (l23 + 1)) {
+			fRec16[l23] = 0.0;
+		}
+		for (int l24 = 0; (l24 < 2); l24 = (l24 + 1)) {
+			fRec15[l24] = 0.0;
+		}
+		for (int l25 = 0; (l25 < 2); l25 = (l25 + 1)) {
+			fVec12[l25] = 0.0;
+		}
+		for (int l26 = 0; (l26 < 2); l26 = (l26 + 1)) {
+			fVec13[l26] = 0.0;
+		}
+		for (int l27 = 0; (l27 < 2); l27 = (l27 + 1)) {
+			fVec14[l27] = 0.0;
+		}
+		for (int l28 = 0; (l28 < 2); l28 = (l28 + 1)) {
+			fRec14[l28] = 0.0;
+		}
+		for (int l29 = 0; (l29 < 2); l29 = (l29 + 1)) {
+			fRec13[l29] = 0.0;
+		}
+		for (int l30 = 0; (l30 < 2); l30 = (l30 + 1)) {
+			fVec15[l30] = 0.0;
+		}
+		for (int l31 = 0; (l31 < 2); l31 = (l31 + 1)) {
+			fVec16[l31] = 0.0;
+		}
+		for (int l32 = 0; (l32 < 2); l32 = (l32 + 1)) {
+			fVec17[l32] = 0.0;
+		}
+		for (int l33 = 0; (l33 < 2); l33 = (l33 + 1)) {
+			fRec12[l33] = 0.0;
+		}
+		for (int l34 = 0; (l34 < 2); l34 = (l34 + 1)) {
+			fRec11[l34] = 0.0;
 		}
 	}
 
@@ -182,43 +278,85 @@ class faust2chBpf6p : public sfzFilterDsp {
 		double fSlow5 = (fSlow4 + 1.0);
 		double fSlow6 = (0.5 * (fSlow2 / (fSlow3 * fSlow5)));
 		double fSlow7 = (1.0 - fSlow0);
-		double fSlow8 = (fSlow6 * fSlow7);
-		double fSlow9 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
+		double fSlow8 = ((0.0 - fSlow6) * fSlow7);
+		double fSlow9 = (fSlow6 * fSlow7);
 		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
-		double fSlow11 = ((0.0 - fSlow6) * fSlow7);
+		double fSlow11 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow8);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow9);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow10);
-			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (fSlow0 * fRec6[1]);
-			fRec7[0] = ((fSlow0 * fRec7[1]) + fSlow11);
-			fRec2[0] = ((((fRec3[0] * fRec0[0]) + (fRec6[0] * fRec3[1])) + (fRec7[0] * fRec3[2])) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
-			fRec1[0] = (((fRec0[0] * fRec2[0]) + ((fRec6[0] * fRec2[1]) + (fRec7[0] * fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec6[0] * fRec1[1])) + (fRec7[0] * fRec1[2])));
-			fRec10[0] = (fTemp1 - ((fRec4[0] * fRec10[1]) + (fRec5[0] * fRec10[2])));
-			fRec9[0] = ((((fRec0[0] * fRec10[0]) + (fRec6[0] * fRec10[1])) + (fRec7[0] * fRec10[2])) - ((fRec4[0] * fRec9[1]) + (fRec5[0] * fRec9[2])));
-			fRec8[0] = ((((fRec0[0] * fRec9[0]) + (fRec6[0] * fRec9[1])) + (fRec7[0] * fRec9[2])) - ((fRec4[0] * fRec8[1]) + (fRec5[0] * fRec8[2])));
-			output1[i] = FAUSTFLOAT((((fRec0[0] * fRec8[0]) + (fRec6[0] * fRec8[1])) + (fRec7[0] * fRec8[2])));
-			fRec0[1] = fRec0[0];
-			fRec4[1] = fRec4[0];
-			fRec5[1] = fRec5[0];
-			fRec3[2] = fRec3[1];
-			fRec3[1] = fRec3[0];
-			fRec6[1] = fRec6[0];
-			fRec7[1] = fRec7[0];
-			fRec2[2] = fRec2[1];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
+			fRec7[0] = (fSlow0 * fRec7[1]);
+			fVec0[0] = (fTemp0 * fRec7[0]);
+			fRec8[0] = ((fSlow0 * fRec8[1]) + fSlow9);
+			fVec1[0] = (fTemp0 * fRec2[0]);
+			fRec9[0] = ((fSlow0 * fRec9[1]) + fSlow10);
+			fVec2[0] = (fVec1[1] - (fRec9[0] * fRec5[1]));
+			fRec10[0] = ((fSlow0 * fRec10[1]) + fSlow11);
+			fRec6[0] = ((fVec0[1] + ((fTemp0 * fRec8[0]) + fVec2[1])) - (fRec10[0] * fRec6[1]));
+			fRec5[0] = fRec6[0];
+			fVec3[0] = (fRec2[0] * fRec5[0]);
+			fVec4[0] = (fVec3[1] - (fRec9[0] * fRec3[1]));
+			fVec5[0] = (fRec7[0] * fRec5[0]);
+			fRec4[0] = (((fVec4[1] + fVec5[1]) + (fRec8[0] * fRec5[0])) - (fRec10[0] * fRec4[1]));
+			fRec3[0] = fRec4[0];
+			fVec6[0] = (fRec2[0] * fRec3[0]);
+			fVec7[0] = (fVec6[1] - (fRec9[0] * fRec0[1]));
+			fVec8[0] = (fRec7[0] * fRec3[0]);
+			fRec1[0] = (((fVec7[1] + fVec8[1]) + (fRec8[0] * fRec3[0])) - (fRec10[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
+			fVec9[0] = (fTemp1 * fRec7[0]);
+			fVec10[0] = (fTemp1 * fRec2[0]);
+			fVec11[0] = (fVec10[1] - (fRec9[0] * fRec15[1]));
+			fRec16[0] = ((fVec9[1] + ((fTemp1 * fRec8[0]) + fVec11[1])) - (fRec10[0] * fRec16[1]));
+			fRec15[0] = fRec16[0];
+			fVec12[0] = (fRec2[0] * fRec15[0]);
+			fVec13[0] = (fVec12[1] - (fRec9[0] * fRec13[1]));
+			fVec14[0] = (fRec7[0] * fRec15[0]);
+			fRec14[0] = (((fVec13[1] + fVec14[1]) + (fRec8[0] * fRec15[0])) - (fRec10[0] * fRec14[1]));
+			fRec13[0] = fRec14[0];
+			fVec15[0] = (fRec2[0] * fRec13[0]);
+			fVec16[0] = (fVec15[1] - (fRec9[0] * fRec11[1]));
+			fVec17[0] = (fRec7[0] * fRec13[0]);
+			fRec12[0] = (((fVec16[1] + fVec17[1]) + (fRec8[0] * fRec13[0])) - (fRec10[0] * fRec12[1]));
+			fRec11[0] = fRec12[0];
+			output1[i] = FAUSTFLOAT(fRec11[0]);
 			fRec2[1] = fRec2[0];
-			fRec1[2] = fRec1[1];
-			fRec1[1] = fRec1[0];
-			fRec10[2] = fRec10[1];
-			fRec10[1] = fRec10[0];
-			fRec9[2] = fRec9[1];
-			fRec9[1] = fRec9[0];
-			fRec8[2] = fRec8[1];
+			fRec7[1] = fRec7[0];
+			fVec0[1] = fVec0[0];
 			fRec8[1] = fRec8[0];
+			fVec1[1] = fVec1[0];
+			fRec9[1] = fRec9[0];
+			fVec2[1] = fVec2[0];
+			fRec10[1] = fRec10[0];
+			fRec6[1] = fRec6[0];
+			fRec5[1] = fRec5[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec4[1] = fRec4[0];
+			fRec3[1] = fRec3[0];
+			fVec6[1] = fVec6[0];
+			fVec7[1] = fVec7[0];
+			fVec8[1] = fVec8[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
+			fVec9[1] = fVec9[0];
+			fVec10[1] = fVec10[0];
+			fVec11[1] = fVec11[0];
+			fRec16[1] = fRec16[0];
+			fRec15[1] = fRec15[0];
+			fVec12[1] = fVec12[0];
+			fVec13[1] = fVec13[0];
+			fVec14[1] = fVec14[0];
+			fRec14[1] = fRec14[0];
+			fRec13[1] = fRec13[0];
+			fVec15[1] = fVec15[0];
+			fVec16[1] = fVec16[0];
+			fVec17[1] = fVec17[0];
+			fRec12[1] = fRec12[0];
+			fRec11[1] = fRec11[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfz2chBrf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chBrf2p.cxx
@@ -37,11 +37,19 @@ class faust2chBrf2p : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec0[2];
 	double fRec2[2];
-	double fRec1[3];
+	double fVec0[2];
 	double fRec3[2];
-	double fRec4[3];
+	double fVec1[2];
+	double fRec4[2];
+	double fVec2[2];
+	double fRec1[2];
+	double fRec0[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec6[2];
+	double fRec5[2];
 
  public:
 
@@ -108,19 +116,43 @@ class faust2chBrf2p : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec0[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec1[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fVec1[l3] = 0.0;
 		}
-		for (int l4 = 0; (l4 < 3); l4 = (l4 + 1)) {
+		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+		}
+		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
+			fVec2[l5] = 0.0;
+		}
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fRec1[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec0[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fVec3[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fVec4[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec5[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fRec6[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fRec5[l12] = 0.0;
 		}
 	}
 
@@ -156,27 +188,41 @@ class faust2chBrf2p : public sfzFilterDsp {
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = (1.0 - fSlow0);
 		double fSlow5 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow3) * fSlow4);
-		double fSlow6 = (((1.0 - fSlow2) / fSlow3) * fSlow4);
-		double fSlow7 = ((1.0 / fSlow3) * fSlow4);
+		double fSlow6 = ((1.0 / fSlow3) * fSlow4);
+		double fSlow7 = (((1.0 - fSlow2) / fSlow3) * fSlow4);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow5);
-			double fTemp2 = (fRec0[0] * fRec1[1]);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
-			fRec1[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec1[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow7);
-			output0[i] = FAUSTFLOAT((fTemp2 + (fRec3[0] * (fRec1[0] + fRec1[2]))));
-			double fTemp3 = (fRec0[0] * fRec4[1]);
-			fRec4[0] = (fTemp1 - (fTemp3 + (fRec2[0] * fRec4[2])));
-			output1[i] = FAUSTFLOAT((fTemp3 + (fRec3[0] * (fRec4[0] + fRec4[2]))));
-			fRec0[1] = fRec0[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow5);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow6);
+			double fTemp2 = (fTemp0 * fRec3[0]);
+			fVec1[0] = fTemp2;
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow7);
+			fVec2[0] = (fVec1[1] - (fRec4[0] * fRec0[1]));
+			fRec1[0] = ((fVec0[1] + (fTemp2 + fVec2[1])) - (fRec2[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
+			fVec3[0] = (fTemp1 * fRec2[0]);
+			double fTemp3 = (fTemp1 * fRec3[0]);
+			fVec4[0] = fTemp3;
+			fVec5[0] = (fVec4[1] - (fRec4[0] * fRec5[1]));
+			fRec6[0] = ((fVec3[1] + (fTemp3 + fVec5[1])) - (fRec2[0] * fRec6[1]));
+			fRec5[0] = fRec6[0];
+			output1[i] = FAUSTFLOAT(fRec5[0]);
 			fRec2[1] = fRec2[0];
-			fRec1[2] = fRec1[1];
-			fRec1[1] = fRec1[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
-			fRec4[2] = fRec4[1];
+			fVec1[1] = fVec1[0];
 			fRec4[1] = fRec4[0];
+			fVec2[1] = fVec2[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec6[1] = fRec6[0];
+			fRec5[1] = fRec5[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfz2chEqHshelf.cxx
+++ b/src/sfizz/gen/filters/sfz2chEqHshelf.cxx
@@ -41,13 +41,21 @@ class faust2chEqHshelf : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fBandwidth;
-	double fRec1[2];
 	double fRec2[2];
-	double fRec0[3];
+	double fVec0[2];
 	double fRec3[2];
 	double fRec4[2];
+	double fVec1[2];
 	double fRec5[2];
-	double fRec6[3];
+	double fVec2[2];
+	double fRec6[2];
+	double fRec1[2];
+	double fRec0[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec8[2];
+	double fRec7[2];
 
  public:
 
@@ -115,25 +123,49 @@ class faust2chEqHshelf : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fRec4[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
 		}
-		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
-			fRec6[l6] = 0.0;
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec6[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec1[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fRec0[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec3[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec4[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fVec5[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec8[l13] = 0.0;
+		}
+		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
+			fRec7[l14] = 0.0;
 		}
 	}
 
@@ -175,33 +207,47 @@ class faust2chEqHshelf : public sfzFilterDsp {
 		double fSlow9 = (fSlow3 * fSlow6);
 		double fSlow10 = ((fSlow1 + fSlow8) + (1.0 - fSlow9));
 		double fSlow11 = (1.0 - fSlow0);
-		double fSlow12 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow10)) * fSlow11);
+		double fSlow12 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow1 + fSlow4) + -1.0)) / fSlow10) * fSlow11);
 		double fSlow13 = (fSlow9 + fSlow8);
-		double fSlow14 = (((fSlow1 + (1.0 - fSlow13)) / fSlow10) * fSlow11);
-		double fSlow15 = (((fSlow1 * ((fSlow1 + fSlow13) + 1.0)) / fSlow10) * fSlow11);
-		double fSlow16 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow1 + fSlow4) + -1.0)) / fSlow10) * fSlow11);
-		double fSlow17 = (((fSlow1 * ((fSlow1 + fSlow9) + (1.0 - fSlow8))) / fSlow10) * fSlow11);
+		double fSlow14 = (((fSlow1 * ((fSlow1 + fSlow13) + 1.0)) / fSlow10) * fSlow11);
+		double fSlow15 = (((fSlow1 * ((fSlow1 + fSlow9) + (1.0 - fSlow8))) / fSlow10) * fSlow11);
+		double fSlow16 = (((fSlow1 + (1.0 - fSlow13)) / fSlow10) * fSlow11);
+		double fSlow17 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow10)) * fSlow11);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow12);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow14);
-			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow15);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow16);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow17);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
-			fRec6[0] = (fTemp1 - ((fRec1[0] * fRec6[1]) + (fRec2[0] * fRec6[2])));
-			output1[i] = FAUSTFLOAT((((fRec3[0] * fRec6[0]) + (fRec4[0] * fRec6[1])) + (fRec5[0] * fRec6[2])));
-			fRec1[1] = fRec1[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow12);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow14);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow15);
+			fVec1[0] = (fTemp0 * fRec4[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow16);
+			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow17);
+			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
+			fVec3[0] = (fTemp1 * fRec2[0]);
+			fVec4[0] = (fTemp1 * fRec4[0]);
+			fVec5[0] = (fVec4[1] - (fRec5[0] * fRec7[1]));
+			fRec8[0] = ((fVec3[1] + ((fTemp1 * fRec3[0]) + fVec5[1])) - (fRec6[0] * fRec8[1]));
+			fRec7[0] = fRec8[0];
+			output1[i] = FAUSTFLOAT(fRec7[0]);
 			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
-			fRec0[1] = fRec0[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
+			fVec1[1] = fVec1[0];
 			fRec5[1] = fRec5[0];
-			fRec6[2] = fRec6[1];
+			fVec2[1] = fVec2[0];
 			fRec6[1] = fRec6[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec8[1] = fRec8[0];
+			fRec7[1] = fRec7[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfz2chEqLshelf.cxx
+++ b/src/sfizz/gen/filters/sfz2chEqLshelf.cxx
@@ -41,13 +41,21 @@ class faust2chEqLshelf : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fBandwidth;
-	double fRec1[2];
 	double fRec2[2];
-	double fRec0[3];
+	double fVec0[2];
 	double fRec3[2];
 	double fRec4[2];
+	double fVec1[2];
 	double fRec5[2];
-	double fRec6[3];
+	double fVec2[2];
+	double fRec6[2];
+	double fRec1[2];
+	double fRec0[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec8[2];
+	double fRec7[2];
 
  public:
 
@@ -115,25 +123,49 @@ class faust2chEqLshelf : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fRec4[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
 		}
-		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
-			fRec6[l6] = 0.0;
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec6[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec1[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fRec0[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec3[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec4[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fVec5[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec8[l13] = 0.0;
+		}
+		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
+			fRec7[l14] = 0.0;
 		}
 	}
 
@@ -176,32 +208,46 @@ class faust2chEqLshelf : public sfzFilterDsp {
 		double fSlow10 = (fSlow6 + fSlow9);
 		double fSlow11 = ((fSlow1 + fSlow10) + 1.0);
 		double fSlow12 = (1.0 - fSlow0);
-		double fSlow13 = (((0.0 - (2.0 * ((fSlow1 + fSlow4) + -1.0))) / fSlow11) * fSlow12);
-		double fSlow14 = ((((fSlow1 + fSlow6) + (1.0 - fSlow9)) / fSlow11) * fSlow12);
-		double fSlow15 = (((fSlow1 * ((fSlow1 + fSlow9) + (1.0 - fSlow6))) / fSlow11) * fSlow12);
-		double fSlow16 = ((2.0 * ((fSlow1 * (fSlow1 + (-1.0 - fSlow4))) / fSlow11)) * fSlow12);
-		double fSlow17 = (((fSlow1 * (fSlow1 + (1.0 - fSlow10))) / fSlow11) * fSlow12);
+		double fSlow13 = ((2.0 * ((fSlow1 * (fSlow1 + (-1.0 - fSlow4))) / fSlow11)) * fSlow12);
+		double fSlow14 = (((fSlow1 * ((fSlow1 + fSlow9) + (1.0 - fSlow6))) / fSlow11) * fSlow12);
+		double fSlow15 = (((fSlow1 * (fSlow1 + (1.0 - fSlow10))) / fSlow11) * fSlow12);
+		double fSlow16 = ((((fSlow1 + fSlow6) + (1.0 - fSlow9)) / fSlow11) * fSlow12);
+		double fSlow17 = (((0.0 - (2.0 * ((fSlow1 + fSlow4) + -1.0))) / fSlow11) * fSlow12);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow13);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow14);
-			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow15);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow16);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow17);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
-			fRec6[0] = (fTemp1 - ((fRec1[0] * fRec6[1]) + (fRec2[0] * fRec6[2])));
-			output1[i] = FAUSTFLOAT((((fRec3[0] * fRec6[0]) + (fRec4[0] * fRec6[1])) + (fRec5[0] * fRec6[2])));
-			fRec1[1] = fRec1[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow13);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow14);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow15);
+			fVec1[0] = (fTemp0 * fRec4[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow16);
+			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow17);
+			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
+			fVec3[0] = (fTemp1 * fRec2[0]);
+			fVec4[0] = (fTemp1 * fRec4[0]);
+			fVec5[0] = (fVec4[1] - (fRec5[0] * fRec7[1]));
+			fRec8[0] = ((fVec3[1] + ((fTemp1 * fRec3[0]) + fVec5[1])) - (fRec6[0] * fRec8[1]));
+			fRec7[0] = fRec8[0];
+			output1[i] = FAUSTFLOAT(fRec7[0]);
 			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
-			fRec0[1] = fRec0[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
+			fVec1[1] = fVec1[0];
 			fRec5[1] = fRec5[0];
-			fRec6[2] = fRec6[1];
+			fVec2[1] = fVec2[0];
 			fRec6[1] = fRec6[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec8[1] = fRec8[0];
+			fRec7[1] = fRec7[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfz2chEqPeak.cxx
+++ b/src/sfizz/gen/filters/sfz2chEqPeak.cxx
@@ -40,12 +40,20 @@ class faust2chEqPeak : public sfzFilterDsp {
 	double fConst3;
 	FAUSTFLOAT fBandwidth;
 	FAUSTFLOAT fPkShGain;
-	double fRec1[2];
 	double fRec2[2];
-	double fRec0[3];
+	double fVec0[2];
 	double fRec3[2];
 	double fRec4[2];
-	double fRec5[3];
+	double fVec1[2];
+	double fRec5[2];
+	double fVec2[2];
+	double fRec1[2];
+	double fRec0[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec7[2];
+	double fRec6[2];
 
  public:
 
@@ -114,22 +122,46 @@ class faust2chEqPeak : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fRec4[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
-		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
+		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+		}
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec1[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec0[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fVec3[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec4[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec5[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fRec7[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec6[l13] = 0.0;
 		}
 	}
 
@@ -169,31 +201,43 @@ class faust2chEqPeak : public sfzFilterDsp {
 		double fSlow7 = (fSlow6 + 1.0);
 		double fSlow8 = (1.0 - fSlow0);
 		double fSlow9 = (((0.0 - (2.0 * std::cos(fSlow2))) / fSlow7) * fSlow8);
-		double fSlow10 = (((1.0 - fSlow6) / fSlow7) * fSlow8);
-		double fSlow11 = (0.5 * ((fSlow3 * fSlow5) / fSlow4));
-		double fSlow12 = (((fSlow11 + 1.0) / fSlow7) * fSlow8);
-		double fSlow13 = (((1.0 - fSlow11) / fSlow7) * fSlow8);
+		double fSlow10 = (0.5 * ((fSlow3 * fSlow5) / fSlow4));
+		double fSlow11 = (((fSlow10 + 1.0) / fSlow7) * fSlow8);
+		double fSlow12 = (((1.0 - fSlow10) / fSlow7) * fSlow8);
+		double fSlow13 = (((1.0 - fSlow6) / fSlow7) * fSlow8);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow9);
-			double fTemp2 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow10);
-			fRec0[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp2) + (fRec4[0] * fRec0[2])));
-			double fTemp3 = (fRec1[0] * fRec5[1]);
-			fRec5[0] = (fTemp1 - (fTemp3 + (fRec2[0] * fRec5[2])));
-			output1[i] = FAUSTFLOAT(((fTemp3 + (fRec3[0] * fRec5[0])) + (fRec4[0] * fRec5[2])));
-			fRec1[1] = fRec1[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow9);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow12);
+			fVec1[0] = (fTemp0 * fRec4[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow13);
+			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
+			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec2[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
+			fVec3[0] = (fTemp1 * fRec2[0]);
+			fVec4[0] = (fTemp1 * fRec4[0]);
+			fVec5[0] = (fVec4[1] - (fRec5[0] * fRec6[1]));
+			fRec7[0] = ((fVec3[1] + ((fTemp1 * fRec3[0]) + fVec5[1])) - (fRec2[0] * fRec7[1]));
+			fRec6[0] = fRec7[0];
+			output1[i] = FAUSTFLOAT(fRec6[0]);
 			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
-			fRec0[1] = fRec0[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
-			fRec5[2] = fRec5[1];
+			fVec1[1] = fVec1[0];
 			fRec5[1] = fRec5[0];
+			fVec2[1] = fVec2[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec7[1] = fRec7[0];
+			fRec6[1] = fRec6[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfz2chHpf2p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf2p.cxx
@@ -37,12 +37,20 @@ class faust2chHpf2p : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec0[2];
 	double fRec2[2];
+	double fVec0[2];
 	double fRec3[2];
-	double fRec1[3];
+	double fVec1[2];
 	double fRec4[2];
-	double fRec5[3];
+	double fVec2[2];
+	double fRec5[2];
+	double fRec1[2];
+	double fRec0[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec7[2];
+	double fRec6[2];
 
  public:
 
@@ -109,22 +117,46 @@ class faust2chHpf2p : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec0[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec3[l2] = 0.0;
 		}
-		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
-			fRec1[l3] = 0.0;
+		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
+			fVec1[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
 		}
-		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
-			fRec5[l5] = 0.0;
+		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
+			fVec2[l5] = 0.0;
+		}
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fRec5[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec1[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec0[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fVec3[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec4[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec5[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fRec7[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec6[l13] = 0.0;
 		}
 	}
 
@@ -161,28 +193,44 @@ class faust2chHpf2p : public sfzFilterDsp {
 		double fSlow4 = (fSlow3 + 1.0);
 		double fSlow5 = (1.0 - fSlow0);
 		double fSlow6 = (((-1.0 - fSlow2) / fSlow4) * fSlow5);
-		double fSlow7 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
+		double fSlow7 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
-		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
+		double fSlow9 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow6);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow7);
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow8);
-			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow9);
-			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec4[0] * (fRec1[0] + fRec1[2]))));
-			fRec5[0] = (fTemp1 - ((fRec2[0] * fRec5[1]) + (fRec3[0] * fRec5[2])));
-			output1[i] = FAUSTFLOAT(((fRec0[0] * fRec5[1]) + (fRec4[0] * (fRec5[0] + fRec5[2]))));
-			fRec0[1] = fRec0[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow7);
+			double fTemp2 = (fTemp0 * fRec3[0]);
+			fVec1[0] = fTemp2;
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow8);
+			fVec2[0] = (fVec1[1] - (fRec4[0] * fRec0[1]));
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow9);
+			fRec1[0] = ((fVec0[1] + (fTemp2 + fVec2[1])) - (fRec5[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
+			fVec3[0] = (fTemp1 * fRec2[0]);
+			double fTemp3 = (fTemp1 * fRec3[0]);
+			fVec4[0] = fTemp3;
+			fVec5[0] = (fVec4[1] - (fRec4[0] * fRec6[1]));
+			fRec7[0] = ((fVec3[1] + (fTemp3 + fVec5[1])) - (fRec5[0] * fRec7[1]));
+			fRec6[0] = fRec7[0];
+			output1[i] = FAUSTFLOAT(fRec6[0]);
 			fRec2[1] = fRec2[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
-			fRec1[2] = fRec1[1];
-			fRec1[1] = fRec1[0];
+			fVec1[1] = fVec1[0];
 			fRec4[1] = fRec4[0];
-			fRec5[2] = fRec5[1];
+			fVec2[1] = fVec2[0];
 			fRec5[1] = fRec5[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec7[1] = fRec7[0];
+			fRec6[1] = fRec6[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfz2chHpf4p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf4p.cxx
@@ -37,14 +37,30 @@ class faust2chHpf4p : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec0[2];
-	double fRec3[2];
-	double fRec4[2];
-	double fRec2[3];
+	double fRec2[2];
+	double fVec0[2];
 	double fRec5[2];
-	double fRec1[3];
-	double fRec7[3];
-	double fRec6[3];
+	double fVec1[2];
+	double fRec6[2];
+	double fVec2[2];
+	double fRec7[2];
+	double fRec4[2];
+	double fRec3[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec1[2];
+	double fRec0[2];
+	double fVec6[2];
+	double fVec7[2];
+	double fVec8[2];
+	double fRec11[2];
+	double fRec10[2];
+	double fVec9[2];
+	double fVec10[2];
+	double fVec11[2];
+	double fRec9[2];
+	double fRec8[2];
 
  public:
 
@@ -111,28 +127,76 @@ class faust2chHpf4p : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec0[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec3[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
-			fRec4[l2] = 0.0;
+			fRec5[l2] = 0.0;
 		}
-		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
-			fRec2[l3] = 0.0;
+		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
+			fVec1[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec5[l4] = 0.0;
+			fRec6[l4] = 0.0;
 		}
-		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
-			fRec1[l5] = 0.0;
+		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
+			fVec2[l5] = 0.0;
 		}
-		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
 			fRec7[l6] = 0.0;
 		}
-		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
-			fRec6[l7] = 0.0;
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec4[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec3[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fVec3[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec4[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec5[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fRec1[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec0[l13] = 0.0;
+		}
+		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
+			fVec6[l14] = 0.0;
+		}
+		for (int l15 = 0; (l15 < 2); l15 = (l15 + 1)) {
+			fVec7[l15] = 0.0;
+		}
+		for (int l16 = 0; (l16 < 2); l16 = (l16 + 1)) {
+			fVec8[l16] = 0.0;
+		}
+		for (int l17 = 0; (l17 < 2); l17 = (l17 + 1)) {
+			fRec11[l17] = 0.0;
+		}
+		for (int l18 = 0; (l18 < 2); l18 = (l18 + 1)) {
+			fRec10[l18] = 0.0;
+		}
+		for (int l19 = 0; (l19 < 2); l19 = (l19 + 1)) {
+			fVec9[l19] = 0.0;
+		}
+		for (int l20 = 0; (l20 < 2); l20 = (l20 + 1)) {
+			fVec10[l20] = 0.0;
+		}
+		for (int l21 = 0; (l21 < 2); l21 = (l21 + 1)) {
+			fVec11[l21] = 0.0;
+		}
+		for (int l22 = 0; (l22 < 2); l22 = (l22 + 1)) {
+			fRec9[l22] = 0.0;
+		}
+		for (int l23 = 0; (l23 < 2); l23 = (l23 + 1)) {
+			fRec8[l23] = 0.0;
 		}
 	}
 
@@ -169,34 +233,66 @@ class faust2chHpf4p : public sfzFilterDsp {
 		double fSlow4 = (fSlow3 + 1.0);
 		double fSlow5 = (1.0 - fSlow0);
 		double fSlow6 = (((-1.0 - fSlow2) / fSlow4) * fSlow5);
-		double fSlow7 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
+		double fSlow7 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
-		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
+		double fSlow9 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow6);
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow7);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow8);
-			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow9);
-			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
-			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec5[0] * (fRec1[0] + fRec1[2]))));
-			fRec7[0] = (fTemp1 - ((fRec3[0] * fRec7[1]) + (fRec4[0] * fRec7[2])));
-			fRec6[0] = (((fRec0[0] * fRec7[1]) + (fRec5[0] * (fRec7[0] + fRec7[2]))) - ((fRec3[0] * fRec6[1]) + (fRec4[0] * fRec6[2])));
-			output1[i] = FAUSTFLOAT(((fRec0[0] * fRec6[1]) + (fRec5[0] * (fRec6[0] + fRec6[2]))));
-			fRec0[1] = fRec0[0];
-			fRec3[1] = fRec3[0];
-			fRec4[1] = fRec4[0];
-			fRec2[2] = fRec2[1];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow7);
+			double fTemp2 = (fTemp0 * fRec5[0]);
+			fVec1[0] = fTemp2;
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow8);
+			fVec2[0] = (fVec1[1] - (fRec6[0] * fRec3[1]));
+			fRec7[0] = ((fSlow0 * fRec7[1]) + fSlow9);
+			fRec4[0] = ((fVec0[1] + (fTemp2 + fVec2[1])) - (fRec7[0] * fRec4[1]));
+			fRec3[0] = fRec4[0];
+			fVec3[0] = (fRec2[0] * fRec3[0]);
+			double fTemp3 = (fRec5[0] * fRec3[0]);
+			fVec4[0] = fTemp3;
+			fVec5[0] = (fVec4[1] - (fRec6[0] * fRec0[1]));
+			fRec1[0] = ((fVec3[1] + (fTemp3 + fVec5[1])) - (fRec7[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
+			fVec6[0] = (fTemp1 * fRec2[0]);
+			double fTemp4 = (fTemp1 * fRec5[0]);
+			fVec7[0] = fTemp4;
+			fVec8[0] = (fVec7[1] - (fRec6[0] * fRec10[1]));
+			fRec11[0] = ((fVec6[1] + (fTemp4 + fVec8[1])) - (fRec7[0] * fRec11[1]));
+			fRec10[0] = fRec11[0];
+			fVec9[0] = (fRec2[0] * fRec10[0]);
+			double fTemp5 = (fRec5[0] * fRec10[0]);
+			fVec10[0] = fTemp5;
+			fVec11[0] = (fVec10[1] - (fRec6[0] * fRec8[1]));
+			fRec9[0] = ((fVec9[1] + (fTemp5 + fVec11[1])) - (fRec7[0] * fRec9[1]));
+			fRec8[0] = fRec9[0];
+			output1[i] = FAUSTFLOAT(fRec8[0]);
 			fRec2[1] = fRec2[0];
+			fVec0[1] = fVec0[0];
 			fRec5[1] = fRec5[0];
-			fRec1[2] = fRec1[1];
-			fRec1[1] = fRec1[0];
-			fRec7[2] = fRec7[1];
-			fRec7[1] = fRec7[0];
-			fRec6[2] = fRec6[1];
+			fVec1[1] = fVec1[0];
 			fRec6[1] = fRec6[0];
+			fVec2[1] = fVec2[0];
+			fRec7[1] = fRec7[0];
+			fRec4[1] = fRec4[0];
+			fRec3[1] = fRec3[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
+			fVec6[1] = fVec6[0];
+			fVec7[1] = fVec7[0];
+			fVec8[1] = fVec8[0];
+			fRec11[1] = fRec11[0];
+			fRec10[1] = fRec10[0];
+			fVec9[1] = fVec9[0];
+			fVec10[1] = fVec10[0];
+			fVec11[1] = fVec11[0];
+			fRec9[1] = fRec9[0];
+			fRec8[1] = fRec8[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfz2chHpf6p.cxx
+++ b/src/sfizz/gen/filters/sfz2chHpf6p.cxx
@@ -37,16 +37,40 @@ class faust2chHpf6p : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec0[2];
-	double fRec4[2];
-	double fRec5[2];
-	double fRec3[3];
+	double fRec2[2];
+	double fVec0[2];
+	double fRec7[2];
+	double fVec1[2];
+	double fRec8[2];
+	double fVec2[2];
+	double fRec9[2];
 	double fRec6[2];
-	double fRec2[3];
-	double fRec1[3];
-	double fRec9[3];
-	double fRec8[3];
-	double fRec7[3];
+	double fRec5[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec4[2];
+	double fRec3[2];
+	double fVec6[2];
+	double fVec7[2];
+	double fVec8[2];
+	double fRec1[2];
+	double fRec0[2];
+	double fVec9[2];
+	double fVec10[2];
+	double fVec11[2];
+	double fRec15[2];
+	double fRec14[2];
+	double fVec12[2];
+	double fVec13[2];
+	double fVec14[2];
+	double fRec13[2];
+	double fRec12[2];
+	double fVec15[2];
+	double fVec16[2];
+	double fVec17[2];
+	double fRec11[2];
+	double fRec10[2];
 
  public:
 
@@ -113,34 +137,106 @@ class faust2chHpf6p : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec0[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec4[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
-			fRec5[l2] = 0.0;
+			fRec7[l2] = 0.0;
 		}
-		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
+			fVec1[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec6[l4] = 0.0;
+			fRec8[l4] = 0.0;
 		}
-		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
-			fRec2[l5] = 0.0;
+		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
+			fVec2[l5] = 0.0;
 		}
-		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
-			fRec1[l6] = 0.0;
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fRec9[l6] = 0.0;
 		}
-		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
-			fRec9[l7] = 0.0;
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec6[l7] = 0.0;
 		}
-		for (int l8 = 0; (l8 < 3); l8 = (l8 + 1)) {
-			fRec8[l8] = 0.0;
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec5[l8] = 0.0;
 		}
-		for (int l9 = 0; (l9 < 3); l9 = (l9 + 1)) {
-			fRec7[l9] = 0.0;
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fVec3[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec4[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec5[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fRec4[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec3[l13] = 0.0;
+		}
+		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
+			fVec6[l14] = 0.0;
+		}
+		for (int l15 = 0; (l15 < 2); l15 = (l15 + 1)) {
+			fVec7[l15] = 0.0;
+		}
+		for (int l16 = 0; (l16 < 2); l16 = (l16 + 1)) {
+			fVec8[l16] = 0.0;
+		}
+		for (int l17 = 0; (l17 < 2); l17 = (l17 + 1)) {
+			fRec1[l17] = 0.0;
+		}
+		for (int l18 = 0; (l18 < 2); l18 = (l18 + 1)) {
+			fRec0[l18] = 0.0;
+		}
+		for (int l19 = 0; (l19 < 2); l19 = (l19 + 1)) {
+			fVec9[l19] = 0.0;
+		}
+		for (int l20 = 0; (l20 < 2); l20 = (l20 + 1)) {
+			fVec10[l20] = 0.0;
+		}
+		for (int l21 = 0; (l21 < 2); l21 = (l21 + 1)) {
+			fVec11[l21] = 0.0;
+		}
+		for (int l22 = 0; (l22 < 2); l22 = (l22 + 1)) {
+			fRec15[l22] = 0.0;
+		}
+		for (int l23 = 0; (l23 < 2); l23 = (l23 + 1)) {
+			fRec14[l23] = 0.0;
+		}
+		for (int l24 = 0; (l24 < 2); l24 = (l24 + 1)) {
+			fVec12[l24] = 0.0;
+		}
+		for (int l25 = 0; (l25 < 2); l25 = (l25 + 1)) {
+			fVec13[l25] = 0.0;
+		}
+		for (int l26 = 0; (l26 < 2); l26 = (l26 + 1)) {
+			fVec14[l26] = 0.0;
+		}
+		for (int l27 = 0; (l27 < 2); l27 = (l27 + 1)) {
+			fRec13[l27] = 0.0;
+		}
+		for (int l28 = 0; (l28 < 2); l28 = (l28 + 1)) {
+			fRec12[l28] = 0.0;
+		}
+		for (int l29 = 0; (l29 < 2); l29 = (l29 + 1)) {
+			fVec15[l29] = 0.0;
+		}
+		for (int l30 = 0; (l30 < 2); l30 = (l30 + 1)) {
+			fVec16[l30] = 0.0;
+		}
+		for (int l31 = 0; (l31 < 2); l31 = (l31 + 1)) {
+			fVec17[l31] = 0.0;
+		}
+		for (int l32 = 0; (l32 < 2); l32 = (l32 + 1)) {
+			fRec11[l32] = 0.0;
+		}
+		for (int l33 = 0; (l33 < 2); l33 = (l33 + 1)) {
+			fRec10[l33] = 0.0;
 		}
 	}
 
@@ -177,40 +273,88 @@ class faust2chHpf6p : public sfzFilterDsp {
 		double fSlow4 = (fSlow3 + 1.0);
 		double fSlow5 = (1.0 - fSlow0);
 		double fSlow6 = (((-1.0 - fSlow2) / fSlow4) * fSlow5);
-		double fSlow7 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
+		double fSlow7 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
-		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
+		double fSlow9 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow6);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow7);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow8);
-			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow9);
-			fRec2[0] = (((fRec0[0] * fRec3[1]) + (fRec6[0] * (fRec3[0] + fRec3[2]))) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
-			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec6[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
-			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec6[0] * (fRec1[0] + fRec1[2]))));
-			fRec9[0] = (fTemp1 - ((fRec4[0] * fRec9[1]) + (fRec5[0] * fRec9[2])));
-			fRec8[0] = (((fRec0[0] * fRec9[1]) + (fRec6[0] * (fRec9[0] + fRec9[2]))) - ((fRec4[0] * fRec8[1]) + (fRec5[0] * fRec8[2])));
-			fRec7[0] = (((fRec0[0] * fRec8[1]) + (fRec6[0] * (fRec8[0] + fRec8[2]))) - ((fRec4[0] * fRec7[1]) + (fRec5[0] * fRec7[2])));
-			output1[i] = FAUSTFLOAT(((fRec0[0] * fRec7[1]) + (fRec6[0] * (fRec7[0] + fRec7[2]))));
-			fRec0[1] = fRec0[0];
-			fRec4[1] = fRec4[0];
-			fRec5[1] = fRec5[0];
-			fRec3[2] = fRec3[1];
-			fRec3[1] = fRec3[0];
-			fRec6[1] = fRec6[0];
-			fRec2[2] = fRec2[1];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec7[0] = ((fSlow0 * fRec7[1]) + fSlow7);
+			double fTemp2 = (fTemp0 * fRec7[0]);
+			fVec1[0] = fTemp2;
+			fRec8[0] = ((fSlow0 * fRec8[1]) + fSlow8);
+			fVec2[0] = (fVec1[1] - (fRec8[0] * fRec5[1]));
+			fRec9[0] = ((fSlow0 * fRec9[1]) + fSlow9);
+			fRec6[0] = ((fVec0[1] + (fTemp2 + fVec2[1])) - (fRec9[0] * fRec6[1]));
+			fRec5[0] = fRec6[0];
+			fVec3[0] = (fRec2[0] * fRec5[0]);
+			double fTemp3 = (fRec7[0] * fRec5[0]);
+			fVec4[0] = fTemp3;
+			fVec5[0] = (fVec4[1] - (fRec8[0] * fRec3[1]));
+			fRec4[0] = ((fVec3[1] + (fTemp3 + fVec5[1])) - (fRec9[0] * fRec4[1]));
+			fRec3[0] = fRec4[0];
+			fVec6[0] = (fRec2[0] * fRec3[0]);
+			double fTemp4 = (fRec7[0] * fRec3[0]);
+			fVec7[0] = fTemp4;
+			fVec8[0] = (fVec7[1] - (fRec8[0] * fRec0[1]));
+			fRec1[0] = ((fVec6[1] + (fTemp4 + fVec8[1])) - (fRec9[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
+			fVec9[0] = (fTemp1 * fRec2[0]);
+			double fTemp5 = (fTemp1 * fRec7[0]);
+			fVec10[0] = fTemp5;
+			fVec11[0] = (fVec10[1] - (fRec8[0] * fRec14[1]));
+			fRec15[0] = ((fVec9[1] + (fTemp5 + fVec11[1])) - (fRec9[0] * fRec15[1]));
+			fRec14[0] = fRec15[0];
+			fVec12[0] = (fRec2[0] * fRec14[0]);
+			double fTemp6 = (fRec7[0] * fRec14[0]);
+			fVec13[0] = fTemp6;
+			fVec14[0] = (fVec13[1] - (fRec8[0] * fRec12[1]));
+			fRec13[0] = ((fVec12[1] + (fTemp6 + fVec14[1])) - (fRec9[0] * fRec13[1]));
+			fRec12[0] = fRec13[0];
+			fVec15[0] = (fRec2[0] * fRec12[0]);
+			double fTemp7 = (fRec7[0] * fRec12[0]);
+			fVec16[0] = fTemp7;
+			fVec17[0] = (fVec16[1] - (fRec8[0] * fRec10[1]));
+			fRec11[0] = ((fVec15[1] + (fTemp7 + fVec17[1])) - (fRec9[0] * fRec11[1]));
+			fRec10[0] = fRec11[0];
+			output1[i] = FAUSTFLOAT(fRec10[0]);
 			fRec2[1] = fRec2[0];
-			fRec1[2] = fRec1[1];
-			fRec1[1] = fRec1[0];
-			fRec9[2] = fRec9[1];
-			fRec9[1] = fRec9[0];
-			fRec8[2] = fRec8[1];
-			fRec8[1] = fRec8[0];
-			fRec7[2] = fRec7[1];
+			fVec0[1] = fVec0[0];
 			fRec7[1] = fRec7[0];
+			fVec1[1] = fVec1[0];
+			fRec8[1] = fRec8[0];
+			fVec2[1] = fVec2[0];
+			fRec9[1] = fRec9[0];
+			fRec6[1] = fRec6[0];
+			fRec5[1] = fRec5[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec4[1] = fRec4[0];
+			fRec3[1] = fRec3[0];
+			fVec6[1] = fVec6[0];
+			fVec7[1] = fVec7[0];
+			fVec8[1] = fVec8[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
+			fVec9[1] = fVec9[0];
+			fVec10[1] = fVec10[0];
+			fVec11[1] = fVec11[0];
+			fRec15[1] = fRec15[0];
+			fRec14[1] = fRec14[0];
+			fVec12[1] = fVec12[0];
+			fVec13[1] = fVec13[0];
+			fVec14[1] = fVec14[0];
+			fRec13[1] = fRec13[0];
+			fRec12[1] = fRec12[0];
+			fVec15[1] = fVec15[0];
+			fVec16[1] = fVec16[0];
+			fVec17[1] = fVec17[0];
+			fRec11[1] = fRec11[0];
+			fRec10[1] = fRec10[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfz2chHsh.cxx
+++ b/src/sfizz/gen/filters/sfz2chHsh.cxx
@@ -38,13 +38,21 @@ class faust2chHsh : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec1[2];
 	double fRec2[2];
-	double fRec0[3];
+	double fVec0[2];
 	double fRec3[2];
 	double fRec4[2];
+	double fVec1[2];
 	double fRec5[2];
-	double fRec6[3];
+	double fVec2[2];
+	double fRec6[2];
+	double fRec1[2];
+	double fRec0[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec8[2];
+	double fRec7[2];
 
  public:
 
@@ -112,25 +120,49 @@ class faust2chHsh : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fRec4[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
 		}
-		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
-			fRec6[l6] = 0.0;
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec6[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec1[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fRec0[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec3[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec4[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fVec5[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec8[l13] = 0.0;
+		}
+		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
+			fRec7[l14] = 0.0;
 		}
 	}
 
@@ -169,33 +201,47 @@ class faust2chHsh : public sfzFilterDsp {
 		double fSlow6 = (fSlow3 * (fSlow1 + -1.0));
 		double fSlow7 = ((fSlow1 + fSlow5) + (1.0 - fSlow6));
 		double fSlow8 = (1.0 - fSlow0);
-		double fSlow9 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow7)) * fSlow8);
-		double fSlow10 = (((fSlow1 + (1.0 - (fSlow5 + fSlow6))) / fSlow7) * fSlow8);
-		double fSlow11 = (fSlow1 + fSlow6);
-		double fSlow12 = (((fSlow1 * ((fSlow5 + fSlow11) + 1.0)) / fSlow7) * fSlow8);
-		double fSlow13 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow1 + fSlow4) + -1.0)) / fSlow7) * fSlow8);
-		double fSlow14 = (((fSlow1 * (fSlow11 + (1.0 - fSlow5))) / fSlow7) * fSlow8);
+		double fSlow9 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow1 + fSlow4) + -1.0)) / fSlow7) * fSlow8);
+		double fSlow10 = (fSlow1 + fSlow6);
+		double fSlow11 = (((fSlow1 * ((fSlow5 + fSlow10) + 1.0)) / fSlow7) * fSlow8);
+		double fSlow12 = (((fSlow1 * (fSlow10 + (1.0 - fSlow5))) / fSlow7) * fSlow8);
+		double fSlow13 = (((fSlow1 + (1.0 - (fSlow5 + fSlow6))) / fSlow7) * fSlow8);
+		double fSlow14 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow7)) * fSlow8);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow9);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow10);
-			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow14);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
-			fRec6[0] = (fTemp1 - ((fRec1[0] * fRec6[1]) + (fRec2[0] * fRec6[2])));
-			output1[i] = FAUSTFLOAT((((fRec3[0] * fRec6[0]) + (fRec4[0] * fRec6[1])) + (fRec5[0] * fRec6[2])));
-			fRec1[1] = fRec1[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow9);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow12);
+			fVec1[0] = (fTemp0 * fRec4[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow13);
+			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow14);
+			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
+			fVec3[0] = (fTemp1 * fRec2[0]);
+			fVec4[0] = (fTemp1 * fRec4[0]);
+			fVec5[0] = (fVec4[1] - (fRec5[0] * fRec7[1]));
+			fRec8[0] = ((fVec3[1] + ((fTemp1 * fRec3[0]) + fVec5[1])) - (fRec6[0] * fRec8[1]));
+			fRec7[0] = fRec8[0];
+			output1[i] = FAUSTFLOAT(fRec7[0]);
 			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
-			fRec0[1] = fRec0[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
+			fVec1[1] = fVec1[0];
 			fRec5[1] = fRec5[0];
-			fRec6[2] = fRec6[1];
+			fVec2[1] = fVec2[0];
 			fRec6[1] = fRec6[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec8[1] = fRec8[0];
+			fRec7[1] = fRec7[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfz2chLsh.cxx
+++ b/src/sfizz/gen/filters/sfz2chLsh.cxx
@@ -38,13 +38,21 @@ class faust2chLsh : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec1[2];
 	double fRec2[2];
-	double fRec0[3];
+	double fVec0[2];
 	double fRec3[2];
 	double fRec4[2];
+	double fVec1[2];
 	double fRec5[2];
-	double fRec6[3];
+	double fVec2[2];
+	double fRec6[2];
+	double fRec1[2];
+	double fRec0[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec8[2];
+	double fRec7[2];
 
  public:
 
@@ -112,25 +120,49 @@ class faust2chLsh : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fRec4[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
 		}
-		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
-			fRec6[l6] = 0.0;
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec6[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec1[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fRec0[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec3[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec4[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fVec5[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec8[l13] = 0.0;
+		}
+		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
+			fRec7[l14] = 0.0;
 		}
 	}
 
@@ -170,32 +202,46 @@ class faust2chLsh : public sfzFilterDsp {
 		double fSlow7 = (fSlow1 + fSlow6);
 		double fSlow8 = ((fSlow5 + fSlow7) + 1.0);
 		double fSlow9 = (1.0 - fSlow0);
-		double fSlow10 = (((0.0 - (2.0 * ((fSlow1 + fSlow4) + -1.0))) / fSlow8) * fSlow9);
-		double fSlow11 = (((fSlow7 + (1.0 - fSlow5)) / fSlow8) * fSlow9);
-		double fSlow12 = (((fSlow1 * ((fSlow1 + fSlow5) + (1.0 - fSlow6))) / fSlow8) * fSlow9);
-		double fSlow13 = ((2.0 * ((fSlow1 * (fSlow1 + (-1.0 - fSlow4))) / fSlow8)) * fSlow9);
-		double fSlow14 = (((fSlow1 * (fSlow1 + (1.0 - (fSlow5 + fSlow6)))) / fSlow8) * fSlow9);
+		double fSlow10 = ((2.0 * ((fSlow1 * (fSlow1 + (-1.0 - fSlow4))) / fSlow8)) * fSlow9);
+		double fSlow11 = (((fSlow1 * ((fSlow1 + fSlow5) + (1.0 - fSlow6))) / fSlow8) * fSlow9);
+		double fSlow12 = (((fSlow1 * (fSlow1 + (1.0 - (fSlow5 + fSlow6)))) / fSlow8) * fSlow9);
+		double fSlow13 = (((fSlow7 + (1.0 - fSlow5)) / fSlow8) * fSlow9);
+		double fSlow14 = (((0.0 - (2.0 * ((fSlow1 + fSlow4) + -1.0))) / fSlow8) * fSlow9);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow10);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow11);
-			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow14);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
-			fRec6[0] = (fTemp1 - ((fRec1[0] * fRec6[1]) + (fRec2[0] * fRec6[2])));
-			output1[i] = FAUSTFLOAT((((fRec3[0] * fRec6[0]) + (fRec4[0] * fRec6[1])) + (fRec5[0] * fRec6[2])));
-			fRec1[1] = fRec1[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow10);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow12);
+			fVec1[0] = (fTemp0 * fRec4[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow13);
+			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow14);
+			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
+			fVec3[0] = (fTemp1 * fRec2[0]);
+			fVec4[0] = (fTemp1 * fRec4[0]);
+			fVec5[0] = (fVec4[1] - (fRec5[0] * fRec7[1]));
+			fRec8[0] = ((fVec3[1] + ((fTemp1 * fRec3[0]) + fVec5[1])) - (fRec6[0] * fRec8[1]));
+			fRec7[0] = fRec8[0];
+			output1[i] = FAUSTFLOAT(fRec7[0]);
 			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
-			fRec0[1] = fRec0[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
+			fVec1[1] = fVec1[0];
 			fRec5[1] = fRec5[0];
-			fRec6[2] = fRec6[1];
+			fVec2[1] = fVec2[0];
 			fRec6[1] = fRec6[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec8[1] = fRec8[0];
+			fRec7[1] = fRec7[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfz2chPeq.cxx
+++ b/src/sfizz/gen/filters/sfz2chPeq.cxx
@@ -38,12 +38,20 @@ class faust2chPeq : public sfzFilterDsp {
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	FAUSTFLOAT fPkShGain;
-	double fRec1[2];
 	double fRec2[2];
-	double fRec0[3];
+	double fVec0[2];
 	double fRec3[2];
 	double fRec4[2];
-	double fRec5[3];
+	double fVec1[2];
+	double fRec5[2];
+	double fVec2[2];
+	double fRec1[2];
+	double fRec0[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec7[2];
+	double fRec6[2];
 
  public:
 
@@ -111,22 +119,46 @@ class faust2chPeq : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fRec4[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
-		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
+		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+		}
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec1[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec0[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fVec3[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec4[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec5[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fRec7[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec6[l13] = 0.0;
 		}
 	}
 
@@ -165,31 +197,43 @@ class faust2chPeq : public sfzFilterDsp {
 		double fSlow6 = (fSlow5 + 1.0);
 		double fSlow7 = (1.0 - fSlow0);
 		double fSlow8 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow6) * fSlow7);
-		double fSlow9 = (((1.0 - fSlow5) / fSlow6) * fSlow7);
-		double fSlow10 = (0.5 * ((fSlow2 * fSlow4) / fSlow3));
-		double fSlow11 = (((fSlow10 + 1.0) / fSlow6) * fSlow7);
-		double fSlow12 = (((1.0 - fSlow10) / fSlow6) * fSlow7);
+		double fSlow9 = (0.5 * ((fSlow2 * fSlow4) / fSlow3));
+		double fSlow10 = (((fSlow9 + 1.0) / fSlow6) * fSlow7);
+		double fSlow11 = (((1.0 - fSlow9) / fSlow6) * fSlow7);
+		double fSlow12 = (((1.0 - fSlow5) / fSlow6) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			double fTemp1 = double(input1[i]);
-			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow8);
-			double fTemp2 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow9);
-			fRec0[0] = (fTemp0 - (fTemp2 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow12);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp2) + (fRec4[0] * fRec0[2])));
-			double fTemp3 = (fRec1[0] * fRec5[1]);
-			fRec5[0] = (fTemp1 - (fTemp3 + (fRec2[0] * fRec5[2])));
-			output1[i] = FAUSTFLOAT(((fTemp3 + (fRec3[0] * fRec5[0])) + (fRec4[0] * fRec5[2])));
-			fRec1[1] = fRec1[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow10);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow11);
+			fVec1[0] = (fTemp0 * fRec4[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow12);
+			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
+			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec2[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
+			fVec3[0] = (fTemp1 * fRec2[0]);
+			fVec4[0] = (fTemp1 * fRec4[0]);
+			fVec5[0] = (fVec4[1] - (fRec5[0] * fRec6[1]));
+			fRec7[0] = ((fVec3[1] + ((fTemp1 * fRec3[0]) + fVec5[1])) - (fRec2[0] * fRec7[1]));
+			fRec6[0] = fRec7[0];
+			output1[i] = FAUSTFLOAT(fRec6[0]);
 			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
-			fRec0[1] = fRec0[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
-			fRec5[2] = fRec5[1];
+			fVec1[1] = fVec1[0];
 			fRec5[1] = fRec5[0];
+			fVec2[1] = fVec2[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec7[1] = fRec7[0];
+			fRec6[1] = fRec6[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfzBpf2p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf2p.cxx
@@ -34,15 +34,19 @@ class faustBpf2p : public sfzFilterDsp {
 	int fSampleRate;
 	double fConst0;
 	double fConst1;
+	double fRec2[2];
+	double fVec0[2];
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec1[2];
-	double fRec2[2];
-	double fRec0[3];
 	double fRec3[2];
 	double fRec4[2];
+	double fVec1[2];
 	double fRec5[2];
+	double fVec2[2];
+	double fRec6[2];
+	double fRec1[2];
+	double fRec0[2];
 
  public:
 
@@ -101,22 +105,34 @@ class faustBpf2p : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fRec4[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+		}
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec6[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec1[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fRec0[l9] = 0.0;
 		}
 	}
 
@@ -150,28 +166,35 @@ class faustBpf2p : public sfzFilterDsp {
 		double fSlow3 = std::max<double>(0.001, std::pow(10.0, (0.050000000000000003 * double(fQ))));
 		double fSlow4 = (0.5 * (fSlow2 / fSlow3));
 		double fSlow5 = (fSlow4 + 1.0);
-		double fSlow6 = (1.0 - fSlow0);
-		double fSlow7 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow6);
-		double fSlow8 = (((1.0 - fSlow4) / fSlow5) * fSlow6);
-		double fSlow9 = (0.5 * (fSlow2 / (fSlow3 * fSlow5)));
-		double fSlow10 = (fSlow9 * fSlow6);
-		double fSlow11 = ((0.0 - fSlow9) * fSlow6);
+		double fSlow6 = (0.5 * (fSlow2 / (fSlow3 * fSlow5)));
+		double fSlow7 = (1.0 - fSlow0);
+		double fSlow8 = (fSlow6 * fSlow7);
+		double fSlow9 = ((0.0 - fSlow6) * fSlow7);
+		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
+		double fSlow11 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow7);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
-			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow10);
-			fRec4[0] = (fSlow0 * fRec4[1]);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow11);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
-			fRec1[1] = fRec1[0];
+			fRec2[0] = (fSlow0 * fRec2[1]);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow8);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow9);
+			fVec1[0] = (fTemp0 * fRec4[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow10);
+			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow11);
+			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
-			fRec0[1] = fRec0[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
+			fVec1[1] = fVec1[0];
 			fRec5[1] = fRec5[0];
+			fVec2[1] = fVec2[0];
+			fRec6[1] = fRec6[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfzBpf2pSv.cxx
+++ b/src/sfizz/gen/filters/sfzBpf2pSv.cxx
@@ -42,7 +42,6 @@ class faustBpf2pSv : public sfzFilterDsp {
 	double fRec5[2];
 	double fRec1[2];
 	double fRec2[2];
-	double fRec6[2];
 
  public:
 
@@ -115,9 +114,6 @@ class faustBpf2pSv : public sfzFilterDsp {
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec2[l4] = 0.0;
 		}
-		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
-			fRec6[l5] = 0.0;
-		}
 	}
 
 	virtual void init(int sample_rate) {
@@ -148,7 +144,6 @@ class faustBpf2pSv : public sfzFilterDsp {
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * double(fCutoff))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * double(fQ))));
-		double fSlow4 = (fSlow3 * fSlow1);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow2);
@@ -162,14 +157,12 @@ class faustBpf2pSv : public sfzFilterDsp {
 			fRec1[0] = (fRec1[1] + (2.0 * (fRec3[0] * fTemp4)));
 			double fTemp5 = (fRec2[1] + (2.0 * fTemp3));
 			fRec2[0] = fTemp5;
-			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow4);
-			output0[i] = FAUSTFLOAT((fRec0 * fRec6[0]));
+			output0[i] = FAUSTFLOAT(fRec0);
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
 			fRec5[1] = fRec5[0];
 			fRec1[1] = fRec1[0];
 			fRec2[1] = fRec2[0];
-			fRec6[1] = fRec6[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfzBpf4p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf4p.cxx
@@ -37,13 +37,21 @@ class faustBpf4p : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec0[2];
-	double fRec3[2];
-	double fRec4[2];
-	double fRec2[3];
+	double fRec2[2];
 	double fRec5[2];
+	double fVec0[2];
 	double fRec6[2];
-	double fRec1[3];
+	double fVec1[2];
+	double fRec7[2];
+	double fVec2[2];
+	double fRec8[2];
+	double fRec4[2];
+	double fRec3[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec1[2];
+	double fRec0[2];
 
  public:
 
@@ -102,25 +110,49 @@ class faustBpf4p : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec0[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec3[l1] = 0.0;
+			fRec5[l1] = 0.0;
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
-			fRec4[l2] = 0.0;
+			fVec0[l2] = 0.0;
 		}
-		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
-			fRec2[l3] = 0.0;
+		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
+			fRec6[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec5[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
-			fRec6[l5] = 0.0;
+			fRec7[l5] = 0.0;
 		}
-		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
-			fRec1[l6] = 0.0;
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec8[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec4[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fRec3[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec3[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec4[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fVec5[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec1[l13] = 0.0;
+		}
+		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
+			fRec0[l14] = 0.0;
 		}
 	}
 
@@ -156,29 +188,43 @@ class faustBpf4p : public sfzFilterDsp {
 		double fSlow5 = (fSlow4 + 1.0);
 		double fSlow6 = (0.5 * (fSlow2 / (fSlow3 * fSlow5)));
 		double fSlow7 = (1.0 - fSlow0);
-		double fSlow8 = (fSlow6 * fSlow7);
-		double fSlow9 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
+		double fSlow8 = ((0.0 - fSlow6) * fSlow7);
+		double fSlow9 = (fSlow6 * fSlow7);
 		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
-		double fSlow11 = ((0.0 - fSlow6) * fSlow7);
+		double fSlow11 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow8);
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow9);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow10);
-			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
 			fRec5[0] = (fSlow0 * fRec5[1]);
-			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow11);
-			fRec1[0] = ((((fRec2[0] * fRec0[0]) + (fRec5[0] * fRec2[1])) + (fRec6[0] * fRec2[2])) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec5[0] * fRec1[1])) + (fRec6[0] * fRec1[2])));
-			fRec0[1] = fRec0[0];
-			fRec3[1] = fRec3[0];
-			fRec4[1] = fRec4[0];
-			fRec2[2] = fRec2[1];
+			fVec0[0] = (fTemp0 * fRec5[0]);
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow9);
+			fVec1[0] = (fTemp0 * fRec2[0]);
+			fRec7[0] = ((fSlow0 * fRec7[1]) + fSlow10);
+			fVec2[0] = (fVec1[1] - (fRec7[0] * fRec3[1]));
+			fRec8[0] = ((fSlow0 * fRec8[1]) + fSlow11);
+			fRec4[0] = ((fVec0[1] + ((fTemp0 * fRec6[0]) + fVec2[1])) - (fRec8[0] * fRec4[1]));
+			fRec3[0] = fRec4[0];
+			fVec3[0] = (fRec2[0] * fRec3[0]);
+			fVec4[0] = (fVec3[1] - (fRec7[0] * fRec0[1]));
+			fVec5[0] = (fRec5[0] * fRec3[0]);
+			fRec1[0] = (((fVec4[1] + fVec5[1]) + (fRec6[0] * fRec3[0])) - (fRec8[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fRec5[1] = fRec5[0];
+			fVec0[1] = fVec0[0];
 			fRec6[1] = fRec6[0];
-			fRec1[2] = fRec1[1];
+			fVec1[1] = fVec1[0];
+			fRec7[1] = fRec7[0];
+			fVec2[1] = fVec2[0];
+			fRec8[1] = fRec8[0];
+			fRec4[1] = fRec4[0];
+			fRec3[1] = fRec3[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
 			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfzBpf6p.cxx
+++ b/src/sfizz/gen/filters/sfzBpf6p.cxx
@@ -37,14 +37,26 @@ class faustBpf6p : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec0[2];
-	double fRec4[2];
-	double fRec5[2];
-	double fRec3[3];
-	double fRec6[2];
+	double fRec2[2];
 	double fRec7[2];
-	double fRec2[3];
-	double fRec1[3];
+	double fVec0[2];
+	double fRec8[2];
+	double fVec1[2];
+	double fRec9[2];
+	double fVec2[2];
+	double fRec10[2];
+	double fRec6[2];
+	double fRec5[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec4[2];
+	double fRec3[2];
+	double fVec6[2];
+	double fVec7[2];
+	double fVec8[2];
+	double fRec1[2];
+	double fRec0[2];
 
  public:
 
@@ -103,28 +115,64 @@ class faustBpf6p : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec0[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec4[l1] = 0.0;
+			fRec7[l1] = 0.0;
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
-			fRec5[l2] = 0.0;
+			fVec0[l2] = 0.0;
 		}
-		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
+			fRec8[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec6[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
-			fRec7[l5] = 0.0;
+			fRec9[l5] = 0.0;
 		}
-		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
-			fRec2[l6] = 0.0;
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
 		}
-		for (int l7 = 0; (l7 < 3); l7 = (l7 + 1)) {
-			fRec1[l7] = 0.0;
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec10[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec6[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fRec5[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec3[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec4[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fVec5[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec4[l13] = 0.0;
+		}
+		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
+			fRec3[l14] = 0.0;
+		}
+		for (int l15 = 0; (l15 < 2); l15 = (l15 + 1)) {
+			fVec6[l15] = 0.0;
+		}
+		for (int l16 = 0; (l16 < 2); l16 = (l16 + 1)) {
+			fVec7[l16] = 0.0;
+		}
+		for (int l17 = 0; (l17 < 2); l17 = (l17 + 1)) {
+			fVec8[l17] = 0.0;
+		}
+		for (int l18 = 0; (l18 < 2); l18 = (l18 + 1)) {
+			fRec1[l18] = 0.0;
+		}
+		for (int l19 = 0; (l19 < 2); l19 = (l19 + 1)) {
+			fRec0[l19] = 0.0;
 		}
 	}
 
@@ -160,32 +208,53 @@ class faustBpf6p : public sfzFilterDsp {
 		double fSlow5 = (fSlow4 + 1.0);
 		double fSlow6 = (0.5 * (fSlow2 / (fSlow3 * fSlow5)));
 		double fSlow7 = (1.0 - fSlow0);
-		double fSlow8 = (fSlow6 * fSlow7);
-		double fSlow9 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
+		double fSlow8 = ((0.0 - fSlow6) * fSlow7);
+		double fSlow9 = (fSlow6 * fSlow7);
 		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
-		double fSlow11 = ((0.0 - fSlow6) * fSlow7);
+		double fSlow11 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow8);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow9);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow10);
-			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = (fSlow0 * fRec6[1]);
-			fRec7[0] = ((fSlow0 * fRec7[1]) + fSlow11);
-			fRec2[0] = ((((fRec3[0] * fRec0[0]) + (fRec6[0] * fRec3[1])) + (fRec7[0] * fRec3[2])) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
-			fRec1[0] = ((((fRec0[0] * fRec2[0]) + (fRec6[0] * fRec2[1])) + (fRec7[0] * fRec2[2])) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec1[0]) + (fRec6[0] * fRec1[1])) + (fRec7[0] * fRec1[2])));
-			fRec0[1] = fRec0[0];
-			fRec4[1] = fRec4[0];
-			fRec5[1] = fRec5[0];
-			fRec3[2] = fRec3[1];
-			fRec3[1] = fRec3[0];
-			fRec6[1] = fRec6[0];
-			fRec7[1] = fRec7[0];
-			fRec2[2] = fRec2[1];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
+			fRec7[0] = (fSlow0 * fRec7[1]);
+			fVec0[0] = (fTemp0 * fRec7[0]);
+			fRec8[0] = ((fSlow0 * fRec8[1]) + fSlow9);
+			fVec1[0] = (fTemp0 * fRec2[0]);
+			fRec9[0] = ((fSlow0 * fRec9[1]) + fSlow10);
+			fVec2[0] = (fVec1[1] - (fRec9[0] * fRec5[1]));
+			fRec10[0] = ((fSlow0 * fRec10[1]) + fSlow11);
+			fRec6[0] = ((fVec0[1] + ((fTemp0 * fRec8[0]) + fVec2[1])) - (fRec10[0] * fRec6[1]));
+			fRec5[0] = fRec6[0];
+			fVec3[0] = (fRec2[0] * fRec5[0]);
+			fVec4[0] = (fVec3[1] - (fRec9[0] * fRec3[1]));
+			fVec5[0] = (fRec7[0] * fRec5[0]);
+			fRec4[0] = (((fVec4[1] + fVec5[1]) + (fRec8[0] * fRec5[0])) - (fRec10[0] * fRec4[1]));
+			fRec3[0] = fRec4[0];
+			fVec6[0] = (fRec2[0] * fRec3[0]);
+			fVec7[0] = (fVec6[1] - (fRec9[0] * fRec0[1]));
+			fVec8[0] = (fRec7[0] * fRec3[0]);
+			fRec1[0] = (((fVec7[1] + fVec8[1]) + (fRec8[0] * fRec3[0])) - (fRec10[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
-			fRec1[2] = fRec1[1];
+			fRec7[1] = fRec7[0];
+			fVec0[1] = fVec0[0];
+			fRec8[1] = fRec8[0];
+			fVec1[1] = fVec1[0];
+			fRec9[1] = fRec9[0];
+			fVec2[1] = fVec2[0];
+			fRec10[1] = fRec10[0];
+			fRec6[1] = fRec6[0];
+			fRec5[1] = fRec5[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec4[1] = fRec4[0];
+			fRec3[1] = fRec3[0];
+			fVec6[1] = fVec6[0];
+			fVec7[1] = fVec7[0];
+			fVec8[1] = fVec8[0];
 			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfzBrf2p.cxx
+++ b/src/sfizz/gen/filters/sfzBrf2p.cxx
@@ -37,10 +37,14 @@ class faustBrf2p : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec0[2];
 	double fRec2[2];
-	double fRec1[3];
+	double fVec0[2];
 	double fRec3[2];
+	double fVec1[2];
+	double fRec4[2];
+	double fVec2[2];
+	double fRec1[2];
+	double fRec0[2];
 
  public:
 
@@ -99,16 +103,28 @@ class faustBrf2p : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec0[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec1[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fVec1[l3] = 0.0;
+		}
+		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
+			fRec4[l4] = 0.0;
+		}
+		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
+			fVec2[l5] = 0.0;
+		}
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fRec1[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec0[l7] = 0.0;
 		}
 	}
 
@@ -142,21 +158,28 @@ class faustBrf2p : public sfzFilterDsp {
 		double fSlow3 = (fSlow2 + 1.0);
 		double fSlow4 = (1.0 - fSlow0);
 		double fSlow5 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow3) * fSlow4);
-		double fSlow6 = (((1.0 - fSlow2) / fSlow3) * fSlow4);
-		double fSlow7 = ((1.0 / fSlow3) * fSlow4);
+		double fSlow6 = ((1.0 / fSlow3) * fSlow4);
+		double fSlow7 = (((1.0 - fSlow2) / fSlow3) * fSlow4);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow5);
-			double fTemp1 = (fRec0[0] * fRec1[1]);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
-			fRec1[0] = (fTemp0 - (fTemp1 + (fRec2[0] * fRec1[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow7);
-			output0[i] = FAUSTFLOAT((fTemp1 + (fRec3[0] * (fRec1[0] + fRec1[2]))));
-			fRec0[1] = fRec0[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow5);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow6);
+			double fTemp1 = (fTemp0 * fRec3[0]);
+			fVec1[0] = fTemp1;
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow7);
+			fVec2[0] = (fVec1[1] - (fRec4[0] * fRec0[1]));
+			fRec1[0] = ((fVec0[1] + (fTemp1 + fVec2[1])) - (fRec2[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
-			fRec1[2] = fRec1[1];
-			fRec1[1] = fRec1[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
+			fVec1[1] = fVec1[0];
+			fRec4[1] = fRec4[0];
+			fVec2[1] = fVec2[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfzEqHshelf.cxx
+++ b/src/sfizz/gen/filters/sfzEqHshelf.cxx
@@ -41,12 +41,16 @@ class faustEqHshelf : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fBandwidth;
-	double fRec1[2];
 	double fRec2[2];
-	double fRec0[3];
+	double fVec0[2];
 	double fRec3[2];
 	double fRec4[2];
+	double fVec1[2];
 	double fRec5[2];
+	double fVec2[2];
+	double fRec6[2];
+	double fRec1[2];
+	double fRec0[2];
 
  public:
 
@@ -106,22 +110,34 @@ class faustEqHshelf : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fRec4[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+		}
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec6[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec1[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fRec0[l9] = 0.0;
 		}
 	}
 
@@ -161,28 +177,35 @@ class faustEqHshelf : public sfzFilterDsp {
 		double fSlow9 = (fSlow3 * fSlow6);
 		double fSlow10 = ((fSlow1 + fSlow8) + (1.0 - fSlow9));
 		double fSlow11 = (1.0 - fSlow0);
-		double fSlow12 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow10)) * fSlow11);
+		double fSlow12 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow1 + fSlow4) + -1.0)) / fSlow10) * fSlow11);
 		double fSlow13 = (fSlow9 + fSlow8);
-		double fSlow14 = (((fSlow1 + (1.0 - fSlow13)) / fSlow10) * fSlow11);
-		double fSlow15 = (((fSlow1 * ((fSlow1 + fSlow13) + 1.0)) / fSlow10) * fSlow11);
-		double fSlow16 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow1 + fSlow4) + -1.0)) / fSlow10) * fSlow11);
-		double fSlow17 = (((fSlow1 * ((fSlow1 + fSlow9) + (1.0 - fSlow8))) / fSlow10) * fSlow11);
+		double fSlow14 = (((fSlow1 * ((fSlow1 + fSlow13) + 1.0)) / fSlow10) * fSlow11);
+		double fSlow15 = (((fSlow1 * ((fSlow1 + fSlow9) + (1.0 - fSlow8))) / fSlow10) * fSlow11);
+		double fSlow16 = (((fSlow1 + (1.0 - fSlow13)) / fSlow10) * fSlow11);
+		double fSlow17 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow10)) * fSlow11);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow12);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow14);
-			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow15);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow16);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow17);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
-			fRec1[1] = fRec1[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow12);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow14);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow15);
+			fVec1[0] = (fTemp0 * fRec4[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow16);
+			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow17);
+			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
-			fRec0[1] = fRec0[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
+			fVec1[1] = fVec1[0];
 			fRec5[1] = fRec5[0];
+			fVec2[1] = fVec2[0];
+			fRec6[1] = fRec6[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfzEqLshelf.cxx
+++ b/src/sfizz/gen/filters/sfzEqLshelf.cxx
@@ -41,12 +41,16 @@ class faustEqLshelf : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fBandwidth;
-	double fRec1[2];
 	double fRec2[2];
-	double fRec0[3];
+	double fVec0[2];
 	double fRec3[2];
 	double fRec4[2];
+	double fVec1[2];
 	double fRec5[2];
+	double fVec2[2];
+	double fRec6[2];
+	double fRec1[2];
+	double fRec0[2];
 
  public:
 
@@ -106,22 +110,34 @@ class faustEqLshelf : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fRec4[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+		}
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec6[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec1[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fRec0[l9] = 0.0;
 		}
 	}
 
@@ -162,27 +178,34 @@ class faustEqLshelf : public sfzFilterDsp {
 		double fSlow10 = (fSlow6 + fSlow9);
 		double fSlow11 = ((fSlow1 + fSlow10) + 1.0);
 		double fSlow12 = (1.0 - fSlow0);
-		double fSlow13 = (((0.0 - (2.0 * ((fSlow1 + fSlow4) + -1.0))) / fSlow11) * fSlow12);
-		double fSlow14 = ((((fSlow1 + fSlow6) + (1.0 - fSlow9)) / fSlow11) * fSlow12);
-		double fSlow15 = (((fSlow1 * ((fSlow1 + fSlow9) + (1.0 - fSlow6))) / fSlow11) * fSlow12);
-		double fSlow16 = ((2.0 * ((fSlow1 * (fSlow1 + (-1.0 - fSlow4))) / fSlow11)) * fSlow12);
-		double fSlow17 = (((fSlow1 * (fSlow1 + (1.0 - fSlow10))) / fSlow11) * fSlow12);
+		double fSlow13 = ((2.0 * ((fSlow1 * (fSlow1 + (-1.0 - fSlow4))) / fSlow11)) * fSlow12);
+		double fSlow14 = (((fSlow1 * ((fSlow1 + fSlow9) + (1.0 - fSlow6))) / fSlow11) * fSlow12);
+		double fSlow15 = (((fSlow1 * (fSlow1 + (1.0 - fSlow10))) / fSlow11) * fSlow12);
+		double fSlow16 = ((((fSlow1 + fSlow6) + (1.0 - fSlow9)) / fSlow11) * fSlow12);
+		double fSlow17 = (((0.0 - (2.0 * ((fSlow1 + fSlow4) + -1.0))) / fSlow11) * fSlow12);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow13);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow14);
-			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow15);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow16);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow17);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
-			fRec1[1] = fRec1[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow13);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow14);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow15);
+			fVec1[0] = (fTemp0 * fRec4[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow16);
+			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow17);
+			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
-			fRec0[1] = fRec0[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
+			fVec1[1] = fVec1[0];
 			fRec5[1] = fRec5[0];
+			fVec2[1] = fVec2[0];
+			fRec6[1] = fRec6[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfzEqPeak.cxx
+++ b/src/sfizz/gen/filters/sfzEqPeak.cxx
@@ -40,11 +40,15 @@ class faustEqPeak : public sfzFilterDsp {
 	double fConst3;
 	FAUSTFLOAT fBandwidth;
 	FAUSTFLOAT fPkShGain;
-	double fRec1[2];
 	double fRec2[2];
-	double fRec0[3];
+	double fVec0[2];
 	double fRec3[2];
 	double fRec4[2];
+	double fVec1[2];
+	double fRec5[2];
+	double fVec2[2];
+	double fRec1[2];
+	double fRec0[2];
 
  public:
 
@@ -105,19 +109,31 @@ class faustEqPeak : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fRec4[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
+			fVec1[l4] = 0.0;
+		}
+		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
+			fRec5[l5] = 0.0;
+		}
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec1[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec0[l8] = 0.0;
 		}
 	}
 
@@ -155,25 +171,31 @@ class faustEqPeak : public sfzFilterDsp {
 		double fSlow7 = (fSlow6 + 1.0);
 		double fSlow8 = (1.0 - fSlow0);
 		double fSlow9 = (((0.0 - (2.0 * std::cos(fSlow2))) / fSlow7) * fSlow8);
-		double fSlow10 = (((1.0 - fSlow6) / fSlow7) * fSlow8);
-		double fSlow11 = (0.5 * ((fSlow3 * fSlow5) / fSlow4));
-		double fSlow12 = (((fSlow11 + 1.0) / fSlow7) * fSlow8);
-		double fSlow13 = (((1.0 - fSlow11) / fSlow7) * fSlow8);
+		double fSlow10 = (0.5 * ((fSlow3 * fSlow5) / fSlow4));
+		double fSlow11 = (((fSlow10 + 1.0) / fSlow7) * fSlow8);
+		double fSlow12 = (((1.0 - fSlow10) / fSlow7) * fSlow8);
+		double fSlow13 = (((1.0 - fSlow6) / fSlow7) * fSlow8);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow9);
-			double fTemp1 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow10);
-			fRec0[0] = (fTemp0 - (fTemp1 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp1) + (fRec4[0] * fRec0[2])));
-			fRec1[1] = fRec1[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow9);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow12);
+			fVec1[0] = (fTemp0 * fRec4[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow13);
+			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
+			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec2[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
-			fRec0[1] = fRec0[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
+			fVec1[1] = fVec1[0];
+			fRec5[1] = fRec5[0];
+			fVec2[1] = fVec2[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfzHpf2p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf2p.cxx
@@ -37,11 +37,15 @@ class faustHpf2p : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec0[2];
 	double fRec2[2];
+	double fVec0[2];
 	double fRec3[2];
-	double fRec1[3];
+	double fVec1[2];
 	double fRec4[2];
+	double fVec2[2];
+	double fRec5[2];
+	double fRec1[2];
+	double fRec0[2];
 
  public:
 
@@ -100,19 +104,31 @@ class faustHpf2p : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec0[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
 			fRec3[l2] = 0.0;
 		}
-		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
-			fRec1[l3] = 0.0;
+		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
+			fVec1[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
 			fRec4[l4] = 0.0;
+		}
+		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
+			fVec2[l5] = 0.0;
+		}
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fRec5[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec1[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec0[l8] = 0.0;
 		}
 	}
 
@@ -147,23 +163,31 @@ class faustHpf2p : public sfzFilterDsp {
 		double fSlow4 = (fSlow3 + 1.0);
 		double fSlow5 = (1.0 - fSlow0);
 		double fSlow6 = (((-1.0 - fSlow2) / fSlow4) * fSlow5);
-		double fSlow7 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
+		double fSlow7 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
-		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
+		double fSlow9 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow6);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow7);
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow8);
-			fRec1[0] = (fTemp0 - ((fRec2[0] * fRec1[1]) + (fRec3[0] * fRec1[2])));
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow9);
-			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec4[0] * (fRec1[0] + fRec1[2]))));
-			fRec0[1] = fRec0[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow7);
+			double fTemp1 = (fTemp0 * fRec3[0]);
+			fVec1[0] = fTemp1;
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow8);
+			fVec2[0] = (fVec1[1] - (fRec4[0] * fRec0[1]));
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow9);
+			fRec1[0] = ((fVec0[1] + (fTemp1 + fVec2[1])) - (fRec5[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
-			fRec1[2] = fRec1[1];
-			fRec1[1] = fRec1[0];
+			fVec1[1] = fVec1[0];
 			fRec4[1] = fRec4[0];
+			fVec2[1] = fVec2[0];
+			fRec5[1] = fRec5[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfzHpf4p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf4p.cxx
@@ -37,12 +37,20 @@ class faustHpf4p : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec0[2];
-	double fRec3[2];
-	double fRec4[2];
-	double fRec2[3];
+	double fRec2[2];
+	double fVec0[2];
 	double fRec5[2];
-	double fRec1[3];
+	double fVec1[2];
+	double fRec6[2];
+	double fVec2[2];
+	double fRec7[2];
+	double fRec4[2];
+	double fRec3[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec1[2];
+	double fRec0[2];
 
  public:
 
@@ -101,22 +109,46 @@ class faustHpf4p : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec0[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec3[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
-			fRec4[l2] = 0.0;
+			fRec5[l2] = 0.0;
 		}
-		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
-			fRec2[l3] = 0.0;
+		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
+			fVec1[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec5[l4] = 0.0;
+			fRec6[l4] = 0.0;
 		}
-		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
-			fRec1[l5] = 0.0;
+		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
+			fVec2[l5] = 0.0;
+		}
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fRec7[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec4[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec3[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fVec3[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec4[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec5[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fRec1[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec0[l13] = 0.0;
 		}
 	}
 
@@ -151,26 +183,42 @@ class faustHpf4p : public sfzFilterDsp {
 		double fSlow4 = (fSlow3 + 1.0);
 		double fSlow5 = (1.0 - fSlow0);
 		double fSlow6 = (((-1.0 - fSlow2) / fSlow4) * fSlow5);
-		double fSlow7 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
+		double fSlow7 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
-		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
+		double fSlow9 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow6);
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow7);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow8);
-			fRec2[0] = (fTemp0 - ((fRec3[0] * fRec2[1]) + (fRec4[0] * fRec2[2])));
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow9);
-			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec5[0] * (fRec2[0] + fRec2[2]))) - ((fRec3[0] * fRec1[1]) + (fRec4[0] * fRec1[2])));
-			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec5[0] * (fRec1[0] + fRec1[2]))));
-			fRec0[1] = fRec0[0];
-			fRec3[1] = fRec3[0];
-			fRec4[1] = fRec4[0];
-			fRec2[2] = fRec2[1];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow7);
+			double fTemp1 = (fTemp0 * fRec5[0]);
+			fVec1[0] = fTemp1;
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow8);
+			fVec2[0] = (fVec1[1] - (fRec6[0] * fRec3[1]));
+			fRec7[0] = ((fSlow0 * fRec7[1]) + fSlow9);
+			fRec4[0] = ((fVec0[1] + (fTemp1 + fVec2[1])) - (fRec7[0] * fRec4[1]));
+			fRec3[0] = fRec4[0];
+			fVec3[0] = (fRec2[0] * fRec3[0]);
+			double fTemp2 = (fRec5[0] * fRec3[0]);
+			fVec4[0] = fTemp2;
+			fVec5[0] = (fVec4[1] - (fRec6[0] * fRec0[1]));
+			fRec1[0] = ((fVec3[1] + (fTemp2 + fVec5[1])) - (fRec7[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
+			fVec0[1] = fVec0[0];
 			fRec5[1] = fRec5[0];
-			fRec1[2] = fRec1[1];
+			fVec1[1] = fVec1[0];
+			fRec6[1] = fRec6[0];
+			fVec2[1] = fVec2[0];
+			fRec7[1] = fRec7[0];
+			fRec4[1] = fRec4[0];
+			fRec3[1] = fRec3[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
 			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfzHpf6p.cxx
+++ b/src/sfizz/gen/filters/sfzHpf6p.cxx
@@ -37,13 +37,25 @@ class faustHpf6p : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec0[2];
-	double fRec4[2];
-	double fRec5[2];
-	double fRec3[3];
+	double fRec2[2];
+	double fVec0[2];
+	double fRec7[2];
+	double fVec1[2];
+	double fRec8[2];
+	double fVec2[2];
+	double fRec9[2];
 	double fRec6[2];
-	double fRec2[3];
-	double fRec1[3];
+	double fRec5[2];
+	double fVec3[2];
+	double fVec4[2];
+	double fVec5[2];
+	double fRec4[2];
+	double fRec3[2];
+	double fVec6[2];
+	double fVec7[2];
+	double fVec8[2];
+	double fRec1[2];
+	double fRec0[2];
 
  public:
 
@@ -102,25 +114,61 @@ class faustHpf6p : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec0[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec4[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
 		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
-			fRec5[l2] = 0.0;
+			fRec7[l2] = 0.0;
 		}
-		for (int l3 = 0; (l3 < 3); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
+			fVec1[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec6[l4] = 0.0;
+			fRec8[l4] = 0.0;
 		}
-		for (int l5 = 0; (l5 < 3); l5 = (l5 + 1)) {
-			fRec2[l5] = 0.0;
+		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
+			fVec2[l5] = 0.0;
 		}
-		for (int l6 = 0; (l6 < 3); l6 = (l6 + 1)) {
-			fRec1[l6] = 0.0;
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fRec9[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec6[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec5[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fVec3[l9] = 0.0;
+		}
+		for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+			fVec4[l10] = 0.0;
+		}
+		for (int l11 = 0; (l11 < 2); l11 = (l11 + 1)) {
+			fVec5[l11] = 0.0;
+		}
+		for (int l12 = 0; (l12 < 2); l12 = (l12 + 1)) {
+			fRec4[l12] = 0.0;
+		}
+		for (int l13 = 0; (l13 < 2); l13 = (l13 + 1)) {
+			fRec3[l13] = 0.0;
+		}
+		for (int l14 = 0; (l14 < 2); l14 = (l14 + 1)) {
+			fVec6[l14] = 0.0;
+		}
+		for (int l15 = 0; (l15 < 2); l15 = (l15 + 1)) {
+			fVec7[l15] = 0.0;
+		}
+		for (int l16 = 0; (l16 < 2); l16 = (l16 + 1)) {
+			fVec8[l16] = 0.0;
+		}
+		for (int l17 = 0; (l17 < 2); l17 = (l17 + 1)) {
+			fRec1[l17] = 0.0;
+		}
+		for (int l18 = 0; (l18 < 2); l18 = (l18 + 1)) {
+			fRec0[l18] = 0.0;
 		}
 	}
 
@@ -155,29 +203,53 @@ class faustHpf6p : public sfzFilterDsp {
 		double fSlow4 = (fSlow3 + 1.0);
 		double fSlow5 = (1.0 - fSlow0);
 		double fSlow6 = (((-1.0 - fSlow2) / fSlow4) * fSlow5);
-		double fSlow7 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
+		double fSlow7 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
-		double fSlow9 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
+		double fSlow9 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec0[0] = ((fSlow0 * fRec0[1]) + fSlow6);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow7);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow8);
-			fRec3[0] = (fTemp0 - ((fRec4[0] * fRec3[1]) + (fRec5[0] * fRec3[2])));
-			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow9);
-			fRec2[0] = (((fRec0[0] * fRec3[1]) + (fRec6[0] * (fRec3[0] + fRec3[2]))) - ((fRec4[0] * fRec2[1]) + (fRec5[0] * fRec2[2])));
-			fRec1[0] = (((fRec0[0] * fRec2[1]) + (fRec6[0] * (fRec2[0] + fRec2[2]))) - ((fRec4[0] * fRec1[1]) + (fRec5[0] * fRec1[2])));
-			output0[i] = FAUSTFLOAT(((fRec0[0] * fRec1[1]) + (fRec6[0] * (fRec1[0] + fRec1[2]))));
-			fRec0[1] = fRec0[0];
-			fRec4[1] = fRec4[0];
-			fRec5[1] = fRec5[0];
-			fRec3[2] = fRec3[1];
-			fRec3[1] = fRec3[0];
-			fRec6[1] = fRec6[0];
-			fRec2[2] = fRec2[1];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec7[0] = ((fSlow0 * fRec7[1]) + fSlow7);
+			double fTemp1 = (fTemp0 * fRec7[0]);
+			fVec1[0] = fTemp1;
+			fRec8[0] = ((fSlow0 * fRec8[1]) + fSlow8);
+			fVec2[0] = (fVec1[1] - (fRec8[0] * fRec5[1]));
+			fRec9[0] = ((fSlow0 * fRec9[1]) + fSlow9);
+			fRec6[0] = ((fVec0[1] + (fTemp1 + fVec2[1])) - (fRec9[0] * fRec6[1]));
+			fRec5[0] = fRec6[0];
+			fVec3[0] = (fRec2[0] * fRec5[0]);
+			double fTemp2 = (fRec7[0] * fRec5[0]);
+			fVec4[0] = fTemp2;
+			fVec5[0] = (fVec4[1] - (fRec8[0] * fRec3[1]));
+			fRec4[0] = ((fVec3[1] + (fTemp2 + fVec5[1])) - (fRec9[0] * fRec4[1]));
+			fRec3[0] = fRec4[0];
+			fVec6[0] = (fRec2[0] * fRec3[0]);
+			double fTemp3 = (fRec7[0] * fRec3[0]);
+			fVec7[0] = fTemp3;
+			fVec8[0] = (fVec7[1] - (fRec8[0] * fRec0[1]));
+			fRec1[0] = ((fVec6[1] + (fTemp3 + fVec8[1])) - (fRec9[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
-			fRec1[2] = fRec1[1];
+			fVec0[1] = fVec0[0];
+			fRec7[1] = fRec7[0];
+			fVec1[1] = fVec1[0];
+			fRec8[1] = fRec8[0];
+			fVec2[1] = fVec2[0];
+			fRec9[1] = fRec9[0];
+			fRec6[1] = fRec6[0];
+			fRec5[1] = fRec5[0];
+			fVec3[1] = fVec3[0];
+			fVec4[1] = fVec4[0];
+			fVec5[1] = fVec5[0];
+			fRec4[1] = fRec4[0];
+			fRec3[1] = fRec3[0];
+			fVec6[1] = fVec6[0];
+			fVec7[1] = fVec7[0];
+			fVec8[1] = fVec8[0];
 			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfzHsh.cxx
+++ b/src/sfizz/gen/filters/sfzHsh.cxx
@@ -38,12 +38,16 @@ class faustHsh : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec1[2];
 	double fRec2[2];
-	double fRec0[3];
+	double fVec0[2];
 	double fRec3[2];
 	double fRec4[2];
+	double fVec1[2];
 	double fRec5[2];
+	double fVec2[2];
+	double fRec6[2];
+	double fRec1[2];
+	double fRec0[2];
 
  public:
 
@@ -103,22 +107,34 @@ class faustHsh : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fRec4[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+		}
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec6[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec1[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fRec0[l9] = 0.0;
 		}
 	}
 
@@ -155,28 +171,35 @@ class faustHsh : public sfzFilterDsp {
 		double fSlow6 = (fSlow3 * (fSlow1 + -1.0));
 		double fSlow7 = ((fSlow1 + fSlow5) + (1.0 - fSlow6));
 		double fSlow8 = (1.0 - fSlow0);
-		double fSlow9 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow7)) * fSlow8);
-		double fSlow10 = (((fSlow1 + (1.0 - (fSlow5 + fSlow6))) / fSlow7) * fSlow8);
-		double fSlow11 = (fSlow1 + fSlow6);
-		double fSlow12 = (((fSlow1 * ((fSlow5 + fSlow11) + 1.0)) / fSlow7) * fSlow8);
-		double fSlow13 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow1 + fSlow4) + -1.0)) / fSlow7) * fSlow8);
-		double fSlow14 = (((fSlow1 * (fSlow11 + (1.0 - fSlow5))) / fSlow7) * fSlow8);
+		double fSlow9 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow1 + fSlow4) + -1.0)) / fSlow7) * fSlow8);
+		double fSlow10 = (fSlow1 + fSlow6);
+		double fSlow11 = (((fSlow1 * ((fSlow5 + fSlow10) + 1.0)) / fSlow7) * fSlow8);
+		double fSlow12 = (((fSlow1 * (fSlow10 + (1.0 - fSlow5))) / fSlow7) * fSlow8);
+		double fSlow13 = (((fSlow1 + (1.0 - (fSlow5 + fSlow6))) / fSlow7) * fSlow8);
+		double fSlow14 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow7)) * fSlow8);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow9);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow10);
-			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow14);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
-			fRec1[1] = fRec1[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow9);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow12);
+			fVec1[0] = (fTemp0 * fRec4[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow13);
+			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow14);
+			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
-			fRec0[1] = fRec0[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
+			fVec1[1] = fVec1[0];
 			fRec5[1] = fRec5[0];
+			fVec2[1] = fVec2[0];
+			fRec6[1] = fRec6[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfzLsh.cxx
+++ b/src/sfizz/gen/filters/sfzLsh.cxx
@@ -38,12 +38,16 @@ class faustLsh : public sfzFilterDsp {
 	double fConst2;
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
-	double fRec1[2];
 	double fRec2[2];
-	double fRec0[3];
+	double fVec0[2];
 	double fRec3[2];
 	double fRec4[2];
+	double fVec1[2];
 	double fRec5[2];
+	double fVec2[2];
+	double fRec6[2];
+	double fRec1[2];
+	double fRec0[2];
 
  public:
 
@@ -103,22 +107,34 @@ class faustLsh : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fRec4[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
+			fVec1[l4] = 0.0;
 		}
 		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
 			fRec5[l5] = 0.0;
+		}
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec6[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec1[l8] = 0.0;
+		}
+		for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+			fRec0[l9] = 0.0;
 		}
 	}
 
@@ -156,27 +172,34 @@ class faustLsh : public sfzFilterDsp {
 		double fSlow7 = (fSlow1 + fSlow6);
 		double fSlow8 = ((fSlow5 + fSlow7) + 1.0);
 		double fSlow9 = (1.0 - fSlow0);
-		double fSlow10 = (((0.0 - (2.0 * ((fSlow1 + fSlow4) + -1.0))) / fSlow8) * fSlow9);
-		double fSlow11 = (((fSlow7 + (1.0 - fSlow5)) / fSlow8) * fSlow9);
-		double fSlow12 = (((fSlow1 * ((fSlow1 + fSlow5) + (1.0 - fSlow6))) / fSlow8) * fSlow9);
-		double fSlow13 = ((2.0 * ((fSlow1 * (fSlow1 + (-1.0 - fSlow4))) / fSlow8)) * fSlow9);
-		double fSlow14 = (((fSlow1 * (fSlow1 + (1.0 - (fSlow5 + fSlow6)))) / fSlow8) * fSlow9);
+		double fSlow10 = ((2.0 * ((fSlow1 * (fSlow1 + (-1.0 - fSlow4))) / fSlow8)) * fSlow9);
+		double fSlow11 = (((fSlow1 * ((fSlow1 + fSlow5) + (1.0 - fSlow6))) / fSlow8) * fSlow9);
+		double fSlow12 = (((fSlow1 * (fSlow1 + (1.0 - (fSlow5 + fSlow6)))) / fSlow8) * fSlow9);
+		double fSlow13 = (((fSlow7 + (1.0 - fSlow5)) / fSlow8) * fSlow9);
+		double fSlow14 = (((0.0 - (2.0 * ((fSlow1 + fSlow4) + -1.0))) / fSlow8) * fSlow9);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow10);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow11);
-			fRec0[0] = (fTemp0 - ((fRec1[0] * fRec0[1]) + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow14);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + (fRec4[0] * fRec0[1])) + (fRec5[0] * fRec0[2])));
-			fRec1[1] = fRec1[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow10);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow12);
+			fVec1[0] = (fTemp0 * fRec4[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow13);
+			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow14);
+			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
-			fRec0[1] = fRec0[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
+			fVec1[1] = fVec1[0];
 			fRec5[1] = fRec5[0];
+			fVec2[1] = fVec2[0];
+			fRec6[1] = fRec6[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
 		}
 	}
 

--- a/src/sfizz/gen/filters/sfzPeq.cxx
+++ b/src/sfizz/gen/filters/sfzPeq.cxx
@@ -38,11 +38,15 @@ class faustPeq : public sfzFilterDsp {
 	FAUSTFLOAT fCutoff;
 	FAUSTFLOAT fQ;
 	FAUSTFLOAT fPkShGain;
-	double fRec1[2];
 	double fRec2[2];
-	double fRec0[3];
+	double fVec0[2];
 	double fRec3[2];
 	double fRec4[2];
+	double fVec1[2];
+	double fRec5[2];
+	double fVec2[2];
+	double fRec1[2];
+	double fRec0[2];
 
  public:
 
@@ -102,19 +106,31 @@ class faustPeq : public sfzFilterDsp {
 
 	virtual void instanceClear() {
 		for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
-			fRec1[l0] = 0.0;
+			fRec2[l0] = 0.0;
 		}
 		for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
-			fRec2[l1] = 0.0;
+			fVec0[l1] = 0.0;
 		}
-		for (int l2 = 0; (l2 < 3); l2 = (l2 + 1)) {
-			fRec0[l2] = 0.0;
+		for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+			fRec3[l2] = 0.0;
 		}
 		for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
-			fRec3[l3] = 0.0;
+			fRec4[l3] = 0.0;
 		}
 		for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
-			fRec4[l4] = 0.0;
+			fVec1[l4] = 0.0;
+		}
+		for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
+			fRec5[l5] = 0.0;
+		}
+		for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+			fVec2[l6] = 0.0;
+		}
+		for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+			fRec1[l7] = 0.0;
+		}
+		for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+			fRec0[l8] = 0.0;
 		}
 	}
 
@@ -151,25 +167,31 @@ class faustPeq : public sfzFilterDsp {
 		double fSlow6 = (fSlow5 + 1.0);
 		double fSlow7 = (1.0 - fSlow0);
 		double fSlow8 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow6) * fSlow7);
-		double fSlow9 = (((1.0 - fSlow5) / fSlow6) * fSlow7);
-		double fSlow10 = (0.5 * ((fSlow2 * fSlow4) / fSlow3));
-		double fSlow11 = (((fSlow10 + 1.0) / fSlow6) * fSlow7);
-		double fSlow12 = (((1.0 - fSlow10) / fSlow6) * fSlow7);
+		double fSlow9 = (0.5 * ((fSlow2 * fSlow4) / fSlow3));
+		double fSlow10 = (((fSlow9 + 1.0) / fSlow6) * fSlow7);
+		double fSlow11 = (((1.0 - fSlow9) / fSlow6) * fSlow7);
+		double fSlow12 = (((1.0 - fSlow5) / fSlow6) * fSlow7);
 		for (int i = 0; (i < count); i = (i + 1)) {
 			double fTemp0 = double(input0[i]);
-			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow8);
-			double fTemp1 = (fRec1[0] * fRec0[1]);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow9);
-			fRec0[0] = (fTemp0 - (fTemp1 + (fRec2[0] * fRec0[2])));
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow12);
-			output0[i] = FAUSTFLOAT((((fRec0[0] * fRec3[0]) + fTemp1) + (fRec4[0] * fRec0[2])));
-			fRec1[1] = fRec1[0];
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
+			fVec0[0] = (fTemp0 * fRec2[0]);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow10);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow11);
+			fVec1[0] = (fTemp0 * fRec4[0]);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow12);
+			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
+			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec2[0] * fRec1[1]));
+			fRec0[0] = fRec1[0];
+			output0[i] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
-			fRec0[2] = fRec0[1];
-			fRec0[1] = fRec0[0];
+			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
+			fVec1[1] = fVec1[0];
+			fRec5[1] = fRec5[0];
+			fVec2[1] = fVec2[0];
+			fRec1[1] = fRec1[0];
+			fRec0[1] = fRec0[0];
 		}
 	}
 

--- a/tests/DemoFilters.cpp
+++ b/tests/DemoFilters.cpp
@@ -62,7 +62,7 @@ private:
     static constexpr float lfoRateMin = 0.1;
     static constexpr float lfoRateMax = 10.0;
 
-    static constexpr int cutoffModMin = 1;
+    static constexpr int cutoffModMin = 0;
     static constexpr int cutoffModMax = 48;
 
     int fType = sfz::kFilterNone;


### PR DESCRIPTION
#198

- Transposed biquads

This makes all biquad kinds very stable in presence of modulations.
For example, `brf2p` would easily have stability problems before. The new structure resolves this.

- SVF gain compensation

It's a gain I introduced before to make SVF and Biquad match each other.
As it turned out, the SVF of Rapture don't bother to do this compensation, so I change it to conform.

Notes:

The `brf1p` is still not much resistant to modulation, so it will need to rethink it.
(or alias to `brf2p`, the same as ARIA did)

The SVF models also don't handle the modulation well at all, but I don't intent to tackle this problem soon.