### PR TITLE
Opcode helpers

### DIFF
--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -10,7 +10,7 @@
 #include "Range.h"
 #include "SfzHelpers.h"
 #include "StringViewHelpers.h"
-#include <absl/types/optional.h>
+#include "absl/types/optional.h"
 #include "absl/meta/type_traits.h"
 #include <string_view>
 #include <vector>
@@ -50,6 +50,16 @@ struct Opcode {
     // This is to handle the integer parameters of some opcodes
     std::vector<uint16_t> parameters;
     OpcodeCategory category;
+
+    /*
+     * @brief Get the derived opcode name to convert it to another category.
+     *
+     * @param newCategory category to convert to
+     * @param number optional CC number, needed if destination is CC and source is not
+     * @return derived opcode name
+     */
+    std::string getDerivedName(OpcodeCategory newCategory, unsigned number = ~0u) const;
+
 private:
     static OpcodeCategory identifyCategory(absl::string_view name);
     LEAK_DETECTOR(Opcode);

--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -21,6 +21,22 @@
 
 namespace sfz {
 /**
+ * @brief A category which an opcode may belong to.
+ */
+enum OpcodeCategory {
+    //! An ordinary opcode
+    kOpcodeNormal,
+    //! A region opcode which matches *_onccN or *_ccN
+    kOpcodeOnCcN,
+    //! A region opcode which matches *_curveccN
+    kOpcodeCurveCcN,
+    //! A region opcode which matches *_stepccN
+    kOpcodeStepCcN,
+    //! A region opcode which matches *_smoothccN
+    kOpcodeSmoothCcN,
+};
+
+/**
  * @brief Opcode description class. The class parses the parameters
  * of the opcode on construction.
  *
@@ -33,6 +49,9 @@ struct Opcode {
     uint64_t lettersOnlyHash { Fnv1aBasis };
     // This is to handle the integer parameters of some opcodes
     std::vector<uint16_t> parameters;
+    OpcodeCategory category;
+private:
+    static OpcodeCategory identifyCategory(absl::string_view name);
     LEAK_DETECTOR(Opcode);
 };
 

--- a/tests/OpcodeT.cpp
+++ b/tests/OpcodeT.cpp
@@ -148,3 +148,13 @@ TEST_CASE("[Opcode] Categories")
     REQUIRE(sfz::Opcode("pan_stepcc44", "").category == sfz::kOpcodeStepCcN);
     REQUIRE(sfz::Opcode("noise_level_smoothcc55", "").category == sfz::kOpcodeSmoothCcN);
 }
+
+TEST_CASE("[Opcode] Derived names")
+{
+    REQUIRE(sfz::Opcode("sample", "").getDerivedName(sfz::kOpcodeNormal) == "sample");
+    REQUIRE(sfz::Opcode("cutoff_cc22", "").getDerivedName(sfz::kOpcodeNormal) == "cutoff");
+    REQUIRE(sfz::Opcode("lfo01_pitch_curvecc33", "").getDerivedName(sfz::kOpcodeOnCcN) == "lfo01_pitch_oncc33");
+    REQUIRE(sfz::Opcode("pan_stepcc44", "").getDerivedName(sfz::kOpcodeCurveCcN) == "pan_curvecc44");
+    REQUIRE(sfz::Opcode("noise_level_smoothcc55", "").getDerivedName(sfz::kOpcodeStepCcN) == "noise_level_stepcc55");
+    REQUIRE(sfz::Opcode("sample", "").getDerivedName(sfz::kOpcodeSmoothCcN, 66) == "sample_smoothcc66");
+}

--- a/tests/OpcodeT.cpp
+++ b/tests/OpcodeT.cpp
@@ -138,3 +138,13 @@ TEST_CASE("[Opcode] Note values")
     REQUIRE(noteValue);
     REQUIRE(*noteValue == 61);
 }
+
+TEST_CASE("[Opcode] Categories")
+{
+    REQUIRE(sfz::Opcode("sample", "").category == sfz::kOpcodeNormal);
+    REQUIRE(sfz::Opcode("amplitude_oncc11", "").category == sfz::kOpcodeOnCcN);
+    REQUIRE(sfz::Opcode("cutoff_cc22", "").category == sfz::kOpcodeOnCcN);
+    REQUIRE(sfz::Opcode("lfo01_pitch_curvecc33", "").category == sfz::kOpcodeCurveCcN);
+    REQUIRE(sfz::Opcode("pan_stepcc44", "").category == sfz::kOpcodeStepCcN);
+    REQUIRE(sfz::Opcode("noise_level_smoothcc55", "").category == sfz::kOpcodeSmoothCcN);
+}


### PR DESCRIPTION
This adds a few helpers needed later to process opcode names.

- get the opcode category: whether basic, _oncc, _curvecc, etc.
- get an opcode's derived name, within a target category

See below in tests.