### PR TITLE
Cc processing

### DIFF
--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -111,21 +111,17 @@ namespace Default
 	constexpr float volume { 0.0f };
 	constexpr Range<float> volumeRange { -144.0, 6.0 };
 	constexpr Range<float> volumeCCRange { -144.0, 48.0 };
-	constexpr Range<float> volumeStepRange { 0, 48.0 };
 	constexpr float amplitude { 100.0 };
 	constexpr Range<float> amplitudeRange { 0.0, 100.0 };
 	constexpr float pan { 0.0 };
 	constexpr Range<float> panRange { -100.0, 100.0 };
 	constexpr Range<float> panCCRange { -200.0, 200.0 };
-	constexpr Range<float> panStepRange { 0.0, 200.0 };
 	constexpr float position { 0.0 };
 	constexpr Range<float> positionRange { -100.0, 100.0 };
 	constexpr Range<float> positionCCRange { -200.0, 200.0 };
-	constexpr Range<float> positionStepRange { 0.0, 200.0 };
 	constexpr float width { 100.0 };
 	constexpr Range<float> widthRange { -100.0, 100.0 };
 	constexpr Range<float> widthCCRange { -200.0, 200.0 };
-	constexpr Range<float> widthStepRange { 0.0, 200.0 };
 	constexpr uint8_t ampKeycenter { 60 };
 	constexpr float ampKeytrack { 0.0 };
 	constexpr Range<float> ampKeytrackRange { -96, 12 };
@@ -200,8 +196,7 @@ namespace Default
 	constexpr Range<int> transposeRange { -127, 127 };
 	constexpr int tune { 0 };
 	constexpr Range<int> tuneRange { -9600, 9600 }; // ±100 in SFZv1, more in ARIA
-    constexpr Range<int> tuneCCRange { -9600, 9600 };
-    constexpr Range<int> tuneStepRange { 0, 9600 };
+    constexpr Range<float> tuneCCRange { -9600, 9600 };
     constexpr Range<int> bendBoundRange { -9600, 9600 };
     constexpr Range<int> bendStepRange { 1, 1200 };
     constexpr int bendUp { 200 }; // No range here because the bounds can be inverted

--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -81,6 +81,16 @@ struct Opcode {
      */
     std::string getDerivedName(OpcodeCategory newCategory, unsigned number = ~0u) const;
 
+    /**
+     * @brief Get whether the opcode categorizes as `ccN` of any kind.
+     * @return true if `ccN`, otherwise false
+     */
+    bool isAnyCcN() const
+    {
+        return category == kOpcodeOnCcN || category == kOpcodeCurveCcN ||
+            category == kOpcodeStepCcN || category == kOpcodeSmoothCcN;
+    }
+
 private:
     static OpcodeCategory identifyCategory(absl::string_view name);
     LEAK_DETECTOR(Opcode);

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -213,6 +213,16 @@ struct Region {
      * @return false
      */
     bool parseOpcode(const Opcode& opcode);
+    /**
+     * @brief Process a generic CC opcode, and fill the modulation parameters.
+     *
+     * @param opcode
+     * @param range
+     * @param ccMap
+     * @return true if the opcode was properly read and stored.
+     * @return false
+     */
+    bool processGenericCc(const Opcode& opcode, Range<float> range, CCMap<Modifier> *ccMap);
 
     void offsetAllKeys(int offset) noexcept;
 

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -262,7 +262,7 @@ void sfz::Voice::amplitudeEnvelope(absl::Span<float> modulationSpan) noexcept
     // Amplitude envelope
     applyGain<float>(baseGain, modulationSpan);
     for (const auto& mod : region->amplitudeCC) {
-        linearModifier(resources, *tempSpan, mod);
+        linearModifier(resources, *tempSpan, mod, normalizePercents<float>);
         applyGain<float>(*tempSpan, modulationSpan);
     }
 
@@ -339,7 +339,7 @@ void sfz::Voice::panStageMono(AudioSpan<float> buffer) noexcept
     // Apply panning
     fill<float>(*modulationSpan, region->pan);
     for (const auto& mod : region->panCC) {
-        linearModifier(resources, *tempSpan, mod);
+        linearModifier(resources, *tempSpan, mod, normalizePercents<float>);
         add<float>(*tempSpan, *modulationSpan);
     }
     pan<float>(*modulationSpan, leftBuffer, rightBuffer);
@@ -360,7 +360,7 @@ void sfz::Voice::panStageStereo(AudioSpan<float> buffer) noexcept
     // Apply panning
     fill<float>(*modulationSpan, region->pan);
     for (const auto& mod : region->panCC) {
-        linearModifier(resources, *tempSpan, mod);
+        linearModifier(resources, *tempSpan, mod, normalizePercents<float>);
         add<float>(*tempSpan, *modulationSpan);
     }
     pan<float>(*modulationSpan, leftBuffer, rightBuffer);
@@ -368,14 +368,14 @@ void sfz::Voice::panStageStereo(AudioSpan<float> buffer) noexcept
     // Apply the width/position process
     fill<float>(*modulationSpan, region->width);
     for (const auto& mod : region->widthCC) {
-        linearModifier(resources, *tempSpan, mod);
+        linearModifier(resources, *tempSpan, mod, normalizePercents<float>);
         add<float>(*tempSpan, *modulationSpan);
     }
     width<float>(*modulationSpan, leftBuffer, rightBuffer);
 
     fill<float>(*modulationSpan, region->position);
     for (const auto& mod : region->positionCC) {
-        linearModifier(resources, *tempSpan, mod);
+        linearModifier(resources, *tempSpan, mod, normalizePercents<float>);
         add<float>(*tempSpan, *modulationSpan);
     }
     pan<float>(*modulationSpan, leftBuffer, rightBuffer);

--- a/tests/FilesT.cpp
+++ b/tests/FilesT.cpp
@@ -351,7 +351,7 @@ TEST_CASE("[Files] wrong (overlapping) replacement for defines")
     REQUIRE( synth.getRegionView(1)->keyRange.getEnd() == 57 );
     REQUIRE(!synth.getRegionView(2)->amplitudeCC.empty());
     REQUIRE(synth.getRegionView(2)->amplitudeCC.contains(10));
-    REQUIRE(synth.getRegionView(2)->amplitudeCC.getWithDefault(10).value == 0.34f);
+    REQUIRE(synth.getRegionView(2)->amplitudeCC.getWithDefault(10).value == 34.0f);
 }
 
 TEST_CASE("[Files] Specific bug: relative path with backslashes")

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -501,7 +501,7 @@ TEST_CASE("[Region] Parsing opcodes")
         REQUIRE(region.panCC.empty());
         region.parseOpcode({ "pan_oncc45", "4.2" });
         REQUIRE(region.panCC.contains(45));
-        REQUIRE(region.panCC[45].value == 0.042_a);
+        REQUIRE(region.panCC[45].value == 4.2_a);
         region.parseOpcode({ "pan_curvecc17", "18" });
         REQUIRE(region.panCC[17].curve == 18);
         region.parseOpcode({ "pan_curvecc17", "15482" });
@@ -515,9 +515,9 @@ TEST_CASE("[Region] Parsing opcodes")
         region.parseOpcode({ "pan_smoothcc14", "-2" });
         REQUIRE(region.panCC[14].smooth == 0);
         region.parseOpcode({ "pan_stepcc120", "24" });
-        REQUIRE(region.panCC[120].step == 0.24_a);
+        REQUIRE(region.panCC[120].step == 24.0_a);
         region.parseOpcode({ "pan_stepcc120", "15482" });
-        REQUIRE(region.panCC[120].step == 2.0_a);
+        REQUIRE(region.panCC[120].step == 200.0_a);
         region.parseOpcode({ "pan_stepcc120", "-2" });
         REQUIRE(region.panCC[120].step == 0.0f);
     }
@@ -540,7 +540,7 @@ TEST_CASE("[Region] Parsing opcodes")
         REQUIRE(region.widthCC.empty());
         region.parseOpcode({ "width_oncc45", "4.2" });
         REQUIRE(region.widthCC.contains(45));
-        REQUIRE(region.widthCC[45].value == 0.042_a);
+        REQUIRE(region.widthCC[45].value == 4.2_a);
         region.parseOpcode({ "width_curvecc17", "18" });
         REQUIRE(region.widthCC[17].curve == 18);
         region.parseOpcode({ "width_curvecc17", "15482" });
@@ -554,9 +554,9 @@ TEST_CASE("[Region] Parsing opcodes")
         region.parseOpcode({ "width_smoothcc14", "-2" });
         REQUIRE(region.widthCC[14].smooth == 0);
         region.parseOpcode({ "width_stepcc120", "24" });
-        REQUIRE(region.widthCC[120].step == 0.24_a);
+        REQUIRE(region.widthCC[120].step == 24.0_a);
         region.parseOpcode({ "width_stepcc120", "15482" });
-        REQUIRE(region.widthCC[120].step == 2.0_a);
+        REQUIRE(region.widthCC[120].step == 200.0_a);
         region.parseOpcode({ "width_stepcc120", "-20" });
         REQUIRE(region.widthCC[120].step == 0.0f);
     }
@@ -579,7 +579,7 @@ TEST_CASE("[Region] Parsing opcodes")
         REQUIRE(region.positionCC.empty());
         region.parseOpcode({ "position_oncc45", "4.2" });
         REQUIRE(region.positionCC.contains(45));
-        REQUIRE(region.positionCC[45].value == 0.042_a);
+        REQUIRE(region.positionCC[45].value == 4.2_a);
         region.parseOpcode({ "position_curvecc17", "18" });
         REQUIRE(region.positionCC[17].curve == 18);
         region.parseOpcode({ "position_curvecc17", "15482" });
@@ -593,9 +593,9 @@ TEST_CASE("[Region] Parsing opcodes")
         region.parseOpcode({ "position_smoothcc14", "-2" });
         REQUIRE(region.positionCC[14].smooth == 0);
         region.parseOpcode({ "position_stepcc120", "24" });
-        REQUIRE(region.positionCC[120].step == 0.24_a);
+        REQUIRE(region.positionCC[120].step == 24.0_a);
         region.parseOpcode({ "position_stepcc120", "15482" });
-        REQUIRE(region.positionCC[120].step == 2.0_a);
+        REQUIRE(region.positionCC[120].step == 200.0_a);
         region.parseOpcode({ "position_stepcc120", "-2" });
         REQUIRE(region.positionCC[120].step == 0.0f);
     }
@@ -1533,10 +1533,10 @@ TEST_CASE("[Region] Parsing opcodes")
         REQUIRE(region.amplitudeCC.empty());
         region.parseOpcode({ "amplitude_cc1", "40" });
         REQUIRE(region.amplitudeCC.contains(1));
-        REQUIRE(region.amplitudeCC[1].value == 0.40_a);
+        REQUIRE(region.amplitudeCC[1].value == 40.0_a);
         region.parseOpcode({ "amplitude_oncc2", "30" });
         REQUIRE(region.amplitudeCC.contains(2));
-        REQUIRE(region.amplitudeCC[2].value == 0.30_a);
+        REQUIRE(region.amplitudeCC[2].value == 30.0_a);
         region.parseOpcode({ "amplitude_curvecc17", "18" });
         REQUIRE(region.amplitudeCC[17].curve == 18);
         region.parseOpcode({ "amplitude_curvecc17", "15482" });
@@ -1550,9 +1550,9 @@ TEST_CASE("[Region] Parsing opcodes")
         region.parseOpcode({ "amplitude_smoothcc14", "-2" });
         REQUIRE(region.amplitudeCC[14].smooth == 0);
         region.parseOpcode({ "amplitude_stepcc120", "24" });
-        REQUIRE(region.amplitudeCC[120].step == 0.24_a);
+        REQUIRE(region.amplitudeCC[120].step == 24.0_a);
         region.parseOpcode({ "amplitude_stepcc120", "15482" });
-        REQUIRE(region.amplitudeCC[120].step == 1.0_a);
+        REQUIRE(region.amplitudeCC[120].step == 100.0_a);
         region.parseOpcode({ "amplitude_stepcc120", "-2" });
         REQUIRE(region.amplitudeCC[120].step == 0.0f);
     }
@@ -1584,7 +1584,7 @@ TEST_CASE("[Region] Parsing opcodes")
         region.parseOpcode({ "volume_stepcc120", "24" });
         REQUIRE(region.volumeCC[120].step == 24.0f);
         region.parseOpcode({ "volume_stepcc120", "15482" });
-        REQUIRE(region.volumeCC[120].step == 48.0f);
+        REQUIRE(region.volumeCC[120].step == 144.0f);
         region.parseOpcode({ "volume_stepcc120", "-2" });
         REQUIRE(region.volumeCC[120].step == 0.0f);
     }


### PR DESCRIPTION
It's a followup on PR #212. ~~Only the last commit is relevant to the actual change.~~

This is a suggestion to add generic processing of CC opcodes, such that curve/step/smooth is managed without code repetitions.

As example, 6 opcodes are rewritten in this fashion, removing a lot of code from `Region.cpp`.

Some notes:

- I'm keeping the `oncc` values verbatim, eg. no percent normalizing.
  Perhaps this is wise in perspective in the mod matrix, but I'm not sure if necessary.
  (test failure as consequence, but let's discuss it)

- ~~it's assumed `volumeStepRange`, `tuneStepRange` are incorrect, replaced with `stepCCRange` in all cases. Is this OK?~~

  ~~Moreover, sfzformat indicates that `stepcc` default to 127 if not given.~~
  - ~~The struct `Modifier` has default step to 0, should I change it to 127?~~
  - ~~With `step=0` being invalid, should 1 be set as a minimum for stepcc?~~

  cf. https://sfzformat.com/modulations/stepccN