### PR TITLE
Improve the note stealing

### DIFF
--- a/benchmarks/BM_filterModulation.cpp
+++ b/benchmarks/BM_filterModulation.cpp
@@ -8,6 +8,7 @@
 #include "OnePoleFilter.h"
 #include "SfzFilter.h"
 #include "ScopedFTZ.h"
+#include "SfzHelpers.h"
 #include <benchmark/benchmark.h>
 #include <random>
 #include <numeric>
@@ -57,7 +58,7 @@ BENCHMARK_DEFINE_F(FilterFixture, OnePole_VA)(benchmark::State& state) {
         const auto sentinel = cutoff.data() + blockSize;
         while (cutoffPtr < sentinel)
         {
-            const auto gain = sfz::OnePoleFilter<float>::normalizedGain(*cutoffPtr, sampleRate);
+            const auto gain = sfz::vaGain(*cutoffPtr, sampleRate);
             filter.setGain(gain);
             filter.processLowpass({ inputPtr, step }, { outputPtr, step } );
             cutoffPtr += step;

--- a/lv2/sfizz.c
+++ b/lv2/sfizz.c
@@ -74,7 +74,7 @@
 #define PITCH_BUILD_AND_CENTER(first_byte, last_byte) (int)(((unsigned int)last_byte << 7) + (unsigned int)first_byte) - 8192
 #define MAX_BLOCK_SIZE 8192
 #define MAX_PATH_SIZE 1024
-#define MAX_VOICES 256
+#define MAX_VOICES 512
 #define DEFAULT_VOICES 64
 #define DEFAULT_OVERSAMPLING SFIZZ_OVERSAMPLING_X1
 #define DEFAULT_PRELOAD 8192

--- a/lv2/sfizz.c
+++ b/lv2/sfizz.c
@@ -584,7 +584,7 @@ sfizz_lv2_check_num_voices(sfizz_plugin_t* self)
         num_voices_atom.body = num_voices;
         if (self->worker->schedule_work(self->worker->handle,
                                         lv2_atom_total_size((LV2_Atom *)&num_voices_atom),
-                                        &num_voices_atom) == LV2_WORKER_SUCCESS)
+                                        &num_voices_atom) != LV2_WORKER_SUCCESS)
         {
             lv2_log_error(&self->logger, "[sfizz] There was an issue changing the number of voices\n");
         }

--- a/lv2/sfizz.ttl.in
+++ b/lv2/sfizz.ttl.in
@@ -114,7 +114,7 @@ midnam:update a lv2:Feature .
     lv2:portProperty pprop:expensive ;
     lv2:portProperty lv2:integer ;
     lv2:portProperty lv2:enumeration ;
-    lv2:default 64 ;
+    lv2:default 256 ;
     lv2:minimum 8 ;
     lv2:maximum 256 ;
     lv2:scalePoint [ rdfs:label "8 voices",
@@ -146,6 +146,11 @@ midnam:update a lv2:Feature .
       "256 voix"@fr ,
       "256 Voci"@it;
       rdf:value 256
+    ] ;
+    lv2:scalePoint [ rdfs:label "512 voices",
+      "512 voix"@fr ,
+      "512 Voci"@it;
+      rdf:value 512
     ] ;
   ] , [
     a lv2:InputPort, lv2:ControlPort ;

--- a/src/sfizz/AudioBuffer.h
+++ b/src/sfizz/AudioBuffer.h
@@ -9,6 +9,7 @@
 #include "Config.h"
 #include "Debug.h"
 #include "LeakDetector.h"
+#include "SIMDHelpers.h"
 #include "absl/types/span.h"
 #include "absl/memory/memory.h"
 #include <array>
@@ -260,6 +261,15 @@ public:
     }
 
     /**
+     * Writes zeros in the buffer
+     */
+    void clear()
+    {
+        for (size_t i = 0; i < numChannels; ++i)
+            fill<Type>(getSpan(i), Type{ 0.0 });
+    }
+
+    /**
      * @brief Add a positive number of channels to the buffer
      *
      * @param numChannels
@@ -269,6 +279,22 @@ public:
         ASSERT(this->numChannels + numChannels <= MaxChannels);
         for (size_t i = 0; i < numChannels; ++i)
             addChannel();
+    }
+
+    /**
+     * @brief Convert implicitly to a pointer of channels
+     */
+    operator const float* const*() const noexcept
+    {
+        return buffers.data();
+    }
+
+    /**
+     * @brief Convert implicitly to a pointer of channels
+     */
+    operator float* const*() noexcept
+    {
+        return buffers.data();
     }
 
 private:

--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -59,6 +59,16 @@ namespace config {
     constexpr int maxCurves { 256 };
     constexpr int chunkSize { 1024 };
     constexpr int filtersInPool { maxVoices * 2 };
+    /**
+     * @brief The threshold for age stealing.
+     *        In percentage of the voice's max age.
+     */
+    constexpr float stealingAgeCoeff { 0.5f };
+    /**
+     * @brief The threshold for envelope stealing.
+     *        In percentage of the sum of all envelopes.
+     */
+    constexpr float stealingEnvelopeCoeff { 0.5f };
     constexpr int filtersPerVoice { 2 };
     constexpr int eqsPerVoice { 3 };
     constexpr int oscillatorsPerVoice { 9 };

--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -37,9 +37,9 @@ namespace config {
     constexpr bool loggingEnabled { false };
     constexpr size_t numChannels { 2 };
     constexpr int numBackgroundThreads { 4 };
-    constexpr int numVoices { 64 };
-    constexpr unsigned maxVoices { 256 };
-    constexpr int maxFilePromises { maxVoices * 2 };
+    constexpr int numVoices { 256 };
+    constexpr unsigned maxVoices { 512 };
+    constexpr int maxFilePromises { maxVoices };
     constexpr int sustainCC { 64 };
     constexpr int allSoundOffCC { 120 };
     constexpr int resetCC { 121 };

--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -54,6 +54,7 @@ namespace config {
     constexpr Oversampling defaultOversamplingFactor { Oversampling::x1 };
     constexpr float A440 { 440.0 };
     constexpr size_t powerHistoryLength { 16 };
+    constexpr float filteredEnvelopeCutoff { 5 };
     constexpr uint16_t numCCs { 512 };
     constexpr int maxCurves { 256 };
     constexpr int chunkSize { 1024 };

--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -54,7 +54,6 @@ namespace config {
     constexpr Oversampling defaultOversamplingFactor { Oversampling::x1 };
     constexpr float A440 { 440.0 };
     constexpr size_t powerHistoryLength { 16 };
-    constexpr float voiceStealingThreshold { 0.00001f };
     constexpr uint16_t numCCs { 512 };
     constexpr int maxCurves { 256 };
     constexpr int chunkSize { 1024 };

--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -28,7 +28,7 @@ namespace config {
     constexpr float defaultSampleRate { 48000 };
     constexpr int defaultSamplesPerBlock { 1024 };
     constexpr int maxBlockSize { 8192 };
-    constexpr int bufferPoolSize { 4 };
+    constexpr int bufferPoolSize { 6 };
     constexpr int stereoBufferPoolSize { 4 };
     constexpr int indexBufferPoolSize { 2 };
     constexpr int preloadSize { 8192 };

--- a/src/sfizz/Effects.cpp
+++ b/src/sfizz/Effects.cpp
@@ -109,6 +109,17 @@ void EffectBus::addToInputs(const float* const addInput[], float addGain, unsign
     }
 }
 
+void EffectBus::applyGain(const float* gain, unsigned nframes)
+{
+    if (!gain)
+        return;
+
+    absl::Span<const float> gainSpan { gain, nframes };
+    for (unsigned c = 0; c < EffectChannels; ++c) {
+        sfz::applyGain<float>(gainSpan, _inputs.getSpan(c));
+    }
+}
+
 void EffectBus::setSampleRate(double sampleRate)
 {
     for (const auto& effectPtr : _effects)

--- a/src/sfizz/Effects.h
+++ b/src/sfizz/Effects.h
@@ -137,6 +137,11 @@ public:
     void addToInputs(const float* const addInput[], float addGain, unsigned nframes);
 
     /**
+       @brief Apply a gain to the inputs
+     */
+    void applyGain(const float* gain, unsigned nframes);
+
+    /**
        @brief Initializes all effects in the bus with the given sample rate.
      */
     void setSampleRate(double sampleRate);

--- a/src/sfizz/HistoricalBuffer.h
+++ b/src/sfizz/HistoricalBuffer.h
@@ -37,6 +37,7 @@ public:
 		buffer.resize(size);
 		fill<ValueType>(absl::MakeSpan(buffer), 0.0);
 		index = 0;
+        validMean = false;
 	}
 
     /**
@@ -46,6 +47,7 @@ public:
      */
 	void push(ValueType value)
 	{
+        validMean = false;
 		if (size > 0) {
 			buffer[index] = value;
 			if (++index == size)
@@ -60,11 +62,18 @@ public:
      */
 	ValueType getAverage() const
 	{
-		return mean<ValueType>(buffer);
+        if (!validMean) {
+            mean = sfz::mean<ValueType>(buffer);
+            validMean = true;
+        }
+
+		return mean;
 	}
 private:
 	Buffer<ValueType> buffer;
 	size_t size { 0 };
 	size_t index { 0 };
+    mutable bool validMean { true };
+    mutable ValueType mean { 0.0 };
 };
 }

--- a/src/sfizz/MathHelpers.h
+++ b/src/sfizz/MathHelpers.h
@@ -340,6 +340,66 @@ bool isValidAudio(absl::Span<Type> span)
     return true;
 }
 
+/**
+ * @brief Finds the minimum size of 2 spans
+ *
+ * @tparam T
+ * @tparam U
+ * @param span1
+ * @param span2
+ * @return constexpr size_t
+ */
+template <class T, class U>
+constexpr size_t minSpanSize(absl::Span<T>& span1, absl::Span<U>& span2)
+{
+    return min(span1.size(), span2.size());
+}
+
+/**
+ * @brief Finds the minimum size of a list of spans.
+ *
+ * @tparam T
+ * @tparam Others
+ * @param first
+ * @param others
+ * @return constexpr size_t
+ */
+template <class T, class... Others>
+constexpr size_t minSpanSize(absl::Span<T>& first, Others... others)
+{
+    return min(first.size(), minSpanSize(others...));
+}
+
+template <class T>
+constexpr bool _checkSpanSizes(size_t size, absl::Span<T>& span1)
+{
+    return span1.size() == size;
+}
+
+template <class T, class... Others>
+constexpr bool _checkSpanSizes(size_t size, absl::Span<T>& span1, Others... others)
+{
+    return span1.size() == size && _checkSpanSizes(size, others...);
+}
+
+/**
+ * @brief Check that all spans of a compile time list have the same size
+ *
+ * @tparam T
+ * @tparam Others
+ * @param first
+ * @param others
+ * @return constexpr size_t
+ */
+template <class T, class... Others>
+constexpr bool checkSpanSizes(const absl::Span<T>& span1, Others... others)
+{
+    return _checkSpanSizes(span1.size(), others...);
+}
+
+#define CHECK_SPAN_SIZES(...) ASSERT(checkSpanSizes(__VA_ARGS__))
+
+
 class ScopedRoundingMode {
 public:
     ScopedRoundingMode() = delete;

--- a/src/sfizz/OnePoleFilter.h
+++ b/src/sfizz/OnePoleFilter.h
@@ -57,18 +57,14 @@ public:
     void processLowpass(const Type* input, Type* output, unsigned size)
     {
         for (unsigned i = 0; i < size; ++i) {
-            const Type intermediate = G * (input[i] - state);
-            output[i] = intermediate + state;
-            state = output[i] + intermediate;
+            output[i] = tickLowpass(input[i]);
         }
     }
 
     void processHighpass(const Type* input, Type* output, unsigned size)
     {
         for (unsigned i = 0; i < size; ++i) {
-            const Type intermediate = G * (input[i] - state);
-            output[i] = input[i] - intermediate - state;
-            state += 2 * intermediate;
+            output[i] = tickHighpass(input[i]);
         }
     }
 
@@ -76,9 +72,7 @@ public:
     {
         for (unsigned i = 0; i < size; ++i) {
             setGain(gain[i]);
-            const Type intermediate = G * (input[i] - state);
-            output[i] = intermediate + state;
-            state = output[i] + intermediate;
+            output[i] = tickLowpass(input[i]);
         }
     }
 
@@ -86,10 +80,24 @@ public:
     {
         for (unsigned i = 0; i < size; ++i) {
             setGain(gain[i]);
-            const Type intermediate = G * (input[i] - state);
-            output[i] = input[i] - intermediate - state;
-            state += 2 * intermediate;
+            output[i] = tickHighpass(input[i]);
         }
+    }
+
+    Type tickHighpass(const Type& input)
+    {
+        const Type intermediate = G * (input - state);
+        const Type output = input - intermediate - state;
+        state += 2 * intermediate;
+        return output;
+    }
+
+    Type tickLowpass(const Type& input)
+    {
+        const Type intermediate = G * (input - state);
+        const Type output = intermediate + state;
+        state = output + intermediate;
+        return output;
     }
 
     void reset(Type value = 0.0)

--- a/src/sfizz/SfzHelpers.h
+++ b/src/sfizz/SfzHelpers.h
@@ -204,6 +204,12 @@ namespace literals {
  */
 absl::optional<uint8_t> readNoteValue(const absl::string_view& value);
 
+template <class Type>
+inline CXX14_CONSTEXPR Type vaGain(Type cutoff, Type sampleRate)
+{
+    return std::tan(cutoff / sampleRate * pi<Type>());
+}
+
 /**
  * @brief From a source view, find the next sfz header and its members and
  *          return them, while updating the source by removing this header

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -481,7 +481,7 @@ sfz::Voice* sfz::Synth::findFreeVoice() noexcept
 
     // Find voices that can be stolen
     absl::c_sort(voiceViewArray, [](Voice* lhs, Voice* rhs) {
-        return lhs->getMeanSquaredAverage() < rhs->getMeanSquaredAverage();
+        return lhs->getAverageEnvelope() < rhs->getAverageEnvelope();
     });
 
     voiceViewArray.front()->reset();

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -528,13 +528,13 @@ sfz::Voice* sfz::Synth::findFreeVoice() noexcept
             break;
         }
 
-        float sumEnvelope = ref->getAverageEnvelope();
+        float maxEnvelope = ref->getAverageEnvelope();
         while (idx < voiceViewArray.size() && sisterVoices(ref, voiceViewArray[idx])) {
-            sumEnvelope += voiceViewArray[idx]->getAverageEnvelope();
+            maxEnvelope = max(maxEnvelope, voiceViewArray[idx]->getAverageEnvelope());
             idx++;
         }
 
-        if (sumEnvelope < envThreshold) {
+        if (maxEnvelope < envThreshold) {
             returnedVoice = ref;
             // std::cout << "Killing " << idx - refIdx << " voices" << '\n';
             for (unsigned j = refIdx; j < idx; j++)

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -482,27 +482,7 @@ sfz::Voice* sfz::Synth::findFreeVoice() noexcept
         return freeVoice->get();
 
     // Find voices that can be stolen
-    absl::c_sort(voiceViewArray, [](Voice* lhs, Voice* rhs) {
-        if (lhs->getAge() > rhs->getAge())
-            return true;
-        if (lhs->getAge() < rhs->getAge())
-            return false;
-
-        if (lhs->getTriggerNumber() > rhs->getTriggerNumber())
-            return true;
-        if (lhs->getTriggerNumber() < rhs->getTriggerNumber())
-            return false;
-
-        if (lhs->getTriggerValue() > rhs->getTriggerValue())
-            return true;
-        if (lhs->getTriggerValue() < rhs->getTriggerValue())
-            return false;
-
-        if (lhs->getTriggerType() > rhs->getTriggerType())
-            return true;
-
-        return false;
-    });
+    absl::c_sort(voiceViewArray, voiceOrdering);
 
     const auto sumEnvelope = absl::c_accumulate(voiceViewArray, 0.0f, [](float sum, const Voice* v) {
         return sum + v->getAverageEnvelope();

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -490,6 +490,14 @@ private:
      */
     void resetVoices(int numVoices);
 
+    /**
+     * @brief Render the voice to its designated outputs and effect busses.
+     *
+     * @param voice
+     * @param tempSpan a temporary span used for rendering
+     */
+    void renderVoiceToOutputs(Voice& voice, AudioSpan<float>& tempSpan) noexcept;
+
     fs::file_time_type checkModificationTime();
 
     void noteOnDispatch(int delay, int noteNumber, float velocity) noexcept;

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -495,6 +495,8 @@ private:
     void noteOnDispatch(int delay, int noteNumber, float velocity) noexcept;
     void noteOffDispatch(int delay, int noteNumber, float velocity) noexcept;
 
+    unsigned killSisterVoices(const Voice* voiceToKill) noexcept;
+
     // Opcode memory; these are used to build regions, as a new region
     // will integrate opcodes from the group, master and global block
     std::vector<Opcode> globalOpcodes;

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -240,7 +240,13 @@ void sfz::Voice::renderBlock(AudioSpan<float> buffer) noexcept
 
     updateChannelPowers(buffer);
 
-    this->triggerDelay = absl::nullopt;
+    age += buffer.getNumFrames();
+    if (triggerDelay) {
+        // Should be OK but just in case;
+        age = min(age - *triggerDelay, 0);
+        triggerDelay = absl::nullopt;
+    }
+
 #if 0
     ASSERT(!hasNanInf(buffer.getConstSpan(0)));
     ASSERT(!hasNanInf(buffer.getConstSpan(1)));
@@ -629,6 +635,7 @@ void sfz::Voice::reset() noexcept
     region = nullptr;
     currentPromise.reset();
     sourcePosition = 0;
+    age = 0;
     floatPositionOffset = 0.0f;
     noteIsOff = false;
 
@@ -642,7 +649,7 @@ void sfz::Voice::reset() noexcept
     equalizers.clear();
 }
 
-float sfz::Voice::getMeanSquaredAverage() const noexcept
+float sfz::Voice::getAverageEnvelope() const noexcept
 {
     return max(channelPowers[0], channelPowers[1]);
 }

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -21,6 +21,9 @@ sfz::Voice::Voice(sfz::Resources& resources)
 
     for (WavetableOscillator& osc : waveOscillators)
         osc.init(sampleRate);
+
+    for (auto & filter : channelPowerFilters)
+        filter.setGain(vaGain(config::filteredEnvelopeCutoff, sampleRate));
 }
 
 void sfz::Voice::startVoice(Region* region, int delay, int number, float value, sfz::Voice::TriggerType triggerType) noexcept
@@ -192,6 +195,9 @@ void sfz::Voice::setSampleRate(float sampleRate) noexcept
 {
     this->sampleRate = sampleRate;
 
+    for (auto & filter : channelPowerFilters)
+        filter.setGain(vaGain(config::filteredEnvelopeCutoff, sampleRate));
+
     for (WavetableOscillator& osc : waveOscillators)
         osc.init(sampleRate);
 }
@@ -206,11 +212,6 @@ void sfz::Voice::renderBlock(AudioSpan<float> buffer) noexcept
 {
     ASSERT(static_cast<int>(buffer.getNumFrames()) <= samplesPerBlock);
     buffer.fill(0.0f);
-
-    if (state == State::idle || region == nullptr) {
-        powerHistory.push(0.0f);
-        return;
-    }
 
     const auto delay = min(static_cast<size_t>(initialDelay), buffer.getNumFrames());
     auto delayed_buffer = buffer.subspan(delay);
@@ -237,7 +238,8 @@ void sfz::Voice::renderBlock(AudioSpan<float> buffer) noexcept
     if (!egEnvelope.isSmoothing())
         reset();
 
-    powerHistory.push(buffer.meanSquared());
+    updateChannelPowers(buffer);
+
     this->triggerDelay = absl::nullopt;
 #if 0
     ASSERT(!hasNanInf(buffer.getConstSpan(0)));
@@ -629,13 +631,20 @@ void sfz::Voice::reset() noexcept
     sourcePosition = 0;
     floatPositionOffset = 0.0f;
     noteIsOff = false;
+
+    for (auto& f : channelPowerFilters)
+        f.reset();
+
+    for (auto& p : channelPowers)
+        p = 0.0f;
+
     filters.clear();
     equalizers.clear();
 }
 
 float sfz::Voice::getMeanSquaredAverage() const noexcept
 {
-    return powerHistory.getAverage();
+    return max(channelPowers[0], channelPowers[1]);
 }
 
 bool sfz::Voice::releasedOrFree() const noexcept
@@ -717,4 +726,25 @@ void sfz::Voice::setupOscillatorUnison()
             fprintf(stderr, "[%d] %10g cents, %10g dB\n", i, detunes[i], 20.0f * std::log10(waveRightGain[i]));
     }
 #endif
+}
+
+
+void sfz::Voice::updateChannelPowers(AudioSpan<float> buffer)
+{
+    assert(channelPowers.size() == channelPowerFilters.size());
+    assert(buffer.getNumFrames() <= channelPowerFilters.size());
+    if (buffer.getNumFrames() == 0)
+        return;
+
+    auto tempSpan = resources.bufferPool.getBuffer(buffer.getNumFrames());
+    if (!tempSpan)
+        return;
+
+    for (unsigned i = 0; i < channelPowers.size(); ++i) {
+        for (unsigned s = 0; s < buffer.getNumFrames(); ++s)
+            (*tempSpan)[s] = std::abs(buffer.getConstSpan(i)[s]);
+
+        channelPowerFilters[i].processLowpass(*tempSpan, *tempSpan);
+        channelPowers[i] = tempSpan->back();
+    }
 }

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -614,21 +614,6 @@ bool sfz::Voice::checkOffGroup(int delay, uint32_t group) noexcept
     return false;
 }
 
-int sfz::Voice::getTriggerNumber() const noexcept
-{
-    return triggerNumber;
-}
-
-float sfz::Voice::getTriggerValue() const noexcept
-{
-    return triggerValue;
-}
-
-sfz::Voice::TriggerType sfz::Voice::getTriggerType() const noexcept
-{
-    return triggerType;
-}
-
 void sfz::Voice::reset() noexcept
 {
     state = State::idle;
@@ -743,15 +728,9 @@ void sfz::Voice::updateChannelPowers(AudioSpan<float> buffer)
     if (buffer.getNumFrames() == 0)
         return;
 
-    auto tempSpan = resources.bufferPool.getBuffer(buffer.getNumFrames());
-    if (!tempSpan)
-        return;
-
     for (unsigned i = 0; i < channelPowers.size(); ++i) {
+        const auto input = buffer.getConstSpan(i);
         for (unsigned s = 0; s < buffer.getNumFrames(); ++s)
-            (*tempSpan)[s] = std::abs(buffer.getConstSpan(i)[s]);
-
-        channelPowerFilters[i].processLowpass(*tempSpan, *tempSpan);
-        channelPowers[i] = tempSpan->back();
+            channelPowers[i] = channelPowerFilters[i].tickLowpass(std::abs(input[s]));
     }
 }

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -638,7 +638,7 @@ float sfz::Voice::getMeanSquaredAverage() const noexcept
     return powerHistory.getAverage();
 }
 
-bool sfz::Voice::canBeStolen() const noexcept
+bool sfz::Voice::releasedOrFree() const noexcept
 {
     return state == State::idle || egEnvelope.isReleased();
 }

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -162,13 +162,13 @@ public:
      *
      * @return float
      */
-    float getTriggerValue() const noexcept  { return triggerValue; }
+    float getTriggerValue() const noexcept { return triggerValue; }
     /**
      * @brief Get the type of trigger
      *
      * @return TriggerType
      */
-    TriggerType getTriggerType() const noexcept  { return triggerType; }
+    TriggerType getTriggerType() const noexcept { return triggerType; }
 
     /**
      * @brief Reset the voice to its initial values
@@ -271,7 +271,7 @@ private:
 
     float speedRatio { 1.0 };
     float pitchRatio { 1.0 };
-    float baseVolumedB{ 0.0 };
+    float baseVolumedB { 0.0 };
     float baseGain { 1.0 };
     float baseFrequency { 440.0 };
 
@@ -298,9 +298,9 @@ private:
 
     // unison of oscillators
     unsigned waveUnisonSize { 0 };
-    float waveDetuneRatio[config::oscillatorsPerVoice] { };
-    float waveLeftGain[config::oscillatorsPerVoice] { };
-    float waveRightGain[config::oscillatorsPerVoice] { };
+    float waveDetuneRatio[config::oscillatorsPerVoice] {};
+    float waveLeftGain[config::oscillatorsPerVoice] {};
+    float waveRightGain[config::oscillatorsPerVoice] {};
 
     Duration dataDuration;
     Duration amplitudeDuration;
@@ -320,6 +320,29 @@ inline bool sisterVoices(const Voice* lhs, const Voice* rhs)
         && lhs->getTriggerNumber() == rhs->getTriggerNumber()
         && lhs->getTriggerValue() == rhs->getTriggerValue()
         && lhs->getTriggerType() == rhs->getTriggerType();
+}
+
+inline bool voiceOrdering(const Voice* lhs, const Voice* rhs)
+{
+    if (lhs->getAge() > rhs->getAge())
+        return true;
+    if (lhs->getAge() < rhs->getAge())
+        return false;
+
+    if (lhs->getTriggerNumber() > rhs->getTriggerNumber())
+        return true;
+    if (lhs->getTriggerNumber() < rhs->getTriggerNumber())
+        return false;
+
+    if (lhs->getTriggerValue() > rhs->getTriggerValue())
+        return true;
+    if (lhs->getTriggerValue() < rhs->getTriggerValue())
+        return false;
+
+    if (lhs->getTriggerType() > rhs->getTriggerType())
+        return true;
+
+    return false;
 }
 
 } // namespace sfz

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -144,12 +144,12 @@ public:
      */
     bool isFree() const noexcept;
     /**
-     * @brief Can the voice be "stolen" and reused (i.e. is it releasing)
+     * @brief Can the voice be reused (i.e. is it releasing or free)
      *
      * @return true
      * @return false
      */
-    bool canBeStolen() const noexcept;
+    bool releasedOrFree() const noexcept;
     /**
      * @brief Get the number that triggered the voice (note number or cc number)
      *

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -309,8 +309,8 @@ private:
 
     std::normal_distribution<float> noiseDist { 0, config::noiseVariance };
 
-    std::array<OnePoleFilter<float>, 2> channelPowerFilters;
-    std::array<float, 2> channelPowers;
+    std::array<OnePoleFilter<float>, 2> channelEnvelopeFilters;
+    std::array<float, 2> smoothedChannelEnvelopes;
     LEAK_DETECTOR(Voice);
 };
 

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -156,19 +156,19 @@ public:
      *
      * @return int
      */
-    constexpr int getTriggerNumber() const noexcept { return triggerNumber; }
+    int getTriggerNumber() const noexcept { return triggerNumber; }
     /**
      * @brief Get the value that triggered the voice (note velocity or cc value)
      *
      * @return float
      */
-    constexpr float getTriggerValue() const noexcept  { return triggerValue; }
+    float getTriggerValue() const noexcept  { return triggerValue; }
     /**
      * @brief Get the type of trigger
      *
      * @return TriggerType
      */
-    constexpr TriggerType getTriggerType() const noexcept  { return triggerType; }
+    TriggerType getTriggerType() const noexcept  { return triggerType; }
 
     /**
      * @brief Reset the voice to its initial values
@@ -220,7 +220,7 @@ public:
      *
      * @return
      */
-    constexpr int getAge() const noexcept { return age; }
+    int getAge() const noexcept { return age; }
 
     Duration getLastDataDuration() const noexcept { return dataDuration; }
     Duration getLastAmplitudeDuration() const noexcept { return amplitudeDuration; }
@@ -314,7 +314,7 @@ private:
     LEAK_DETECTOR(Voice);
 };
 
-constexpr bool sisterVoices(const Voice* lhs, const Voice* rhs)
+inline bool sisterVoices(const Voice* lhs, const Voice* rhs)
 {
     return lhs->getAge() == rhs->getAge()
         && lhs->getTriggerNumber() == rhs->getTriggerNumber()

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -182,7 +182,7 @@ public:
      *
      * @return float
      */
-    float getMeanSquaredAverage() const noexcept;
+    float getAverageEnvelope() const noexcept;
     /**
      * @brief Get the position of the voice in the source, in samples
      *
@@ -214,6 +214,13 @@ public:
      * @param fastRelease whether to do a normal release or cut the voice abruptly
      */
     void release(int delay, bool fastRelease = false) noexcept;
+
+    /**
+     * @brief gets the age of the Voice
+     *
+     * @return
+     */
+    int getAge() const noexcept { return age; }
 
     Duration getLastDataDuration() const noexcept { return dataDuration; }
     Duration getLastAmplitudeDuration() const noexcept { return amplitudeDuration; }
@@ -271,6 +278,7 @@ private:
     float floatPositionOffset { 0.0f };
     int sourcePosition { 0 };
     int initialDelay { 0 };
+    int age { 0 };
 
     FilePromisePtr currentPromise { nullptr };
 

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -156,19 +156,19 @@ public:
      *
      * @return int
      */
-    int getTriggerNumber() const noexcept;
+    constexpr int getTriggerNumber() const noexcept { return triggerNumber; }
     /**
      * @brief Get the value that triggered the voice (note velocity or cc value)
      *
      * @return float
      */
-    float getTriggerValue() const noexcept;
+    constexpr float getTriggerValue() const noexcept  { return triggerValue; }
     /**
      * @brief Get the type of trigger
      *
      * @return TriggerType
      */
-    TriggerType getTriggerType() const noexcept;
+    constexpr TriggerType getTriggerType() const noexcept  { return triggerType; }
 
     /**
      * @brief Reset the voice to its initial values
@@ -220,7 +220,7 @@ public:
      *
      * @return
      */
-    int getAge() const noexcept { return age; }
+    constexpr int getAge() const noexcept { return age; }
 
     Duration getLastDataDuration() const noexcept { return dataDuration; }
     Duration getLastAmplitudeDuration() const noexcept { return amplitudeDuration; }
@@ -313,5 +313,13 @@ private:
     std::array<float, 2> channelPowers;
     LEAK_DETECTOR(Voice);
 };
+
+constexpr bool sisterVoices(const Voice* lhs, const Voice* rhs)
+{
+    return lhs->getAge() == rhs->getAge()
+        && lhs->getTriggerNumber() == rhs->getTriggerNumber()
+        && lhs->getTriggerValue() == rhs->getTriggerValue()
+        && lhs->getTriggerType() == rhs->getTriggerType();
+}
 
 } // namespace sfz

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -13,6 +13,7 @@
 #include "Resources.h"
 #include "AudioSpan.h"
 #include "LeakDetector.h"
+#include "OnePoleFilter.h"
 #include "absl/types/span.h"
 #include <memory>
 #include <random>
@@ -245,6 +246,7 @@ private:
      * @brief Initialize frequency and gain coefficients for the oscillators.
      */
     void setupOscillatorUnison();
+    void updateChannelPowers(AudioSpan<float> buffer);
 
     Region* region { nullptr };
 
@@ -299,7 +301,8 @@ private:
 
     std::normal_distribution<float> noiseDist { 0, config::noiseVariance };
 
-    HistoricalBuffer<float> powerHistory { config::powerHistoryLength };
+    std::array<OnePoleFilter<float>, 2> channelPowerFilters;
+    std::array<float, 2> channelPowers;
     LEAK_DETECTOR(Voice);
 };
 

--- a/tests/FilesT.cpp
+++ b/tests/FilesT.cpp
@@ -455,7 +455,7 @@ TEST_CASE("[Files] Off by with different delays")
     REQUIRE( group1Voice->getRegion()->offBy == 2ul );
     synth.noteOn(100, 64, 63);
     synth.renderBlock(buffer);
-    REQUIRE( group1Voice->releasedOrFree() );
+    REQUIRE(group1Voice->releasedOrFree());
 }
 
 TEST_CASE("[Files] Off by with the same delays")
@@ -470,7 +470,7 @@ TEST_CASE("[Files] Off by with the same delays")
     REQUIRE( group1Voice->getRegion()->group == 1ul );
     REQUIRE( group1Voice->getRegion()->offBy == 2ul );
     synth.noteOn(0, 64, 63);
-    REQUIRE( !group1Voice->releasedOrFree() );
+    REQUIRE(!group1Voice->releasedOrFree());
 }
 
 TEST_CASE("[Files] Off by with the same notes at the same time")

--- a/tests/FilesT.cpp
+++ b/tests/FilesT.cpp
@@ -455,7 +455,7 @@ TEST_CASE("[Files] Off by with different delays")
     REQUIRE( group1Voice->getRegion()->offBy == 2ul );
     synth.noteOn(100, 64, 63);
     synth.renderBlock(buffer);
-    REQUIRE( group1Voice->canBeStolen() );
+    REQUIRE( group1Voice->releasedOrFree() );
 }
 
 TEST_CASE("[Files] Off by with the same delays")
@@ -470,7 +470,7 @@ TEST_CASE("[Files] Off by with the same delays")
     REQUIRE( group1Voice->getRegion()->group == 1ul );
     REQUIRE( group1Voice->getRegion()->offBy == 2ul );
     synth.noteOn(0, 64, 63);
-    REQUIRE( !group1Voice->canBeStolen() );
+    REQUIRE( !group1Voice->releasedOrFree() );
 }
 
 TEST_CASE("[Files] Off by with the same notes at the same time")

--- a/tests/OnePoleFilterT.cpp
+++ b/tests/OnePoleFilterT.cpp
@@ -40,12 +40,13 @@ void testFilter(const std::array<Type, N>& input, const std::array<Type, N>& exp
     std::array<Type, N> gains;
     std::fill(gains.begin(), gains.end(), gain);
 
-    sfz::OnePoleFilter<Type> filter { gain };
+    sfz::OnePoleFilter<Type> filter;
+    filter.setGain(gain);
     filter.processLowpass(input, outputSpan);
     REQUIRE(approxEqual(output, expectedLow));
 
     filter.reset();
-    filter.processLowpassVariableGain(input, outputSpan, gains);
+    filter.processLowpass(input, outputSpan, gains);
     REQUIRE(approxEqual(output, expectedLow));
 
     filter.reset();
@@ -53,7 +54,7 @@ void testFilter(const std::array<Type, N>& input, const std::array<Type, N>& exp
     REQUIRE(approxEqual(output, expectedHigh));
 
     filter.reset();
-    filter.processHighpassVariableGain(input, outputSpan, gains);
+    filter.processHighpass(input, outputSpan, gains);
     REQUIRE(approxEqual(output, expectedHigh));
 }
 

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -195,7 +195,7 @@ TEST_CASE("[Synth] Trigger=release and an envelope properly kills the voice at t
     synth.renderBlock(buffer); // Decay (0.02)
     synth.renderBlock(buffer);
     synth.renderBlock(buffer); // Release (0.1)
-    REQUIRE( synth.getVoiceView(0)->canBeStolen() );
+    REQUIRE( synth.getVoiceView(0)->releasedOrFree() );
     // Release is 0.1s
     for (int i = 0; i < 10; ++i)
         synth.renderBlock(buffer);
@@ -218,7 +218,7 @@ TEST_CASE("[Synth] Trigger=release_key and an envelope properly kills the voice 
     synth.renderBlock(buffer); // Decay (0.02)
     synth.renderBlock(buffer);
     synth.renderBlock(buffer); // Release (0.1)
-    REQUIRE( synth.getVoiceView(0)->canBeStolen() );
+    REQUIRE( synth.getVoiceView(0)->releasedOrFree() );
     // Release is 0.1s
     for (int i = 0; i < 10; ++i)
         synth.renderBlock(buffer);
@@ -241,7 +241,7 @@ TEST_CASE("[Synth] loopmode=one_shot and an envelope properly kills the voice at
     synth.renderBlock(buffer); // Decay (0.02)
     synth.renderBlock(buffer);
     synth.renderBlock(buffer); // Release (0.1)
-    REQUIRE( synth.getVoiceView(0)->canBeStolen() );
+    REQUIRE( synth.getVoiceView(0)->releasedOrFree() );
     // Release is 0.1s
     for (int i = 0; i < 10; ++i)
         synth.renderBlock(buffer);
@@ -376,11 +376,11 @@ TEST_CASE("[Synth] Self-masking")
     synth.noteOn(0, 64, 64);
     REQUIRE(synth.getNumActiveVoices() == 3); // One of these is releasing
     REQUIRE(synth.getVoiceView(0)->getTriggerValue() == 63_norm);
-    REQUIRE(!synth.getVoiceView(0)->canBeStolen());
+    REQUIRE(!synth.getVoiceView(0)->releasedOrFree());
     REQUIRE(synth.getVoiceView(1)->getTriggerValue() == 62_norm);
-    REQUIRE(synth.getVoiceView(1)->canBeStolen()); // The lowest velocity voice is the masking candidate
+    REQUIRE(synth.getVoiceView(1)->releasedOrFree()); // The lowest velocity voice is the masking candidate
     REQUIRE(synth.getVoiceView(2)->getTriggerValue() == 64_norm);
-    REQUIRE(!synth.getVoiceView(2)->canBeStolen());
+    REQUIRE(!synth.getVoiceView(2)->releasedOrFree());
 }
 
 TEST_CASE("[Synth] Not self-masking")
@@ -392,11 +392,11 @@ TEST_CASE("[Synth] Not self-masking")
     synth.noteOn(0, 66, 64);
     REQUIRE(synth.getNumActiveVoices() == 3); // One of these is releasing
     REQUIRE(synth.getVoiceView(0)->getTriggerValue() == 63_norm);
-    REQUIRE(synth.getVoiceView(0)->canBeStolen()); // The first encountered voice is the masking candidate
+    REQUIRE(synth.getVoiceView(0)->releasedOrFree()); // The first encountered voice is the masking candidate
     REQUIRE(synth.getVoiceView(1)->getTriggerValue() == 62_norm);
-    REQUIRE(!synth.getVoiceView(1)->canBeStolen());
+    REQUIRE(!synth.getVoiceView(1)->releasedOrFree());
     REQUIRE(synth.getVoiceView(2)->getTriggerValue() == 64_norm);
-    REQUIRE(!synth.getVoiceView(2)->canBeStolen());
+    REQUIRE(!synth.getVoiceView(2)->releasedOrFree());
 }
 
 TEST_CASE("[Synth] Polyphony in master")

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -195,7 +195,7 @@ TEST_CASE("[Synth] Trigger=release and an envelope properly kills the voice at t
     synth.renderBlock(buffer); // Decay (0.02)
     synth.renderBlock(buffer);
     synth.renderBlock(buffer); // Release (0.1)
-    REQUIRE( synth.getVoiceView(0)->releasedOrFree() );
+    REQUIRE(synth.getVoiceView(0)->releasedOrFree());
     // Release is 0.1s
     for (int i = 0; i < 10; ++i)
         synth.renderBlock(buffer);
@@ -218,7 +218,7 @@ TEST_CASE("[Synth] Trigger=release_key and an envelope properly kills the voice 
     synth.renderBlock(buffer); // Decay (0.02)
     synth.renderBlock(buffer);
     synth.renderBlock(buffer); // Release (0.1)
-    REQUIRE( synth.getVoiceView(0)->releasedOrFree() );
+    REQUIRE(synth.getVoiceView(0)->releasedOrFree());
     // Release is 0.1s
     for (int i = 0; i < 10; ++i)
         synth.renderBlock(buffer);
@@ -241,7 +241,7 @@ TEST_CASE("[Synth] loopmode=one_shot and an envelope properly kills the voice at
     synth.renderBlock(buffer); // Decay (0.02)
     synth.renderBlock(buffer);
     synth.renderBlock(buffer); // Release (0.1)
-    REQUIRE( synth.getVoiceView(0)->releasedOrFree() );
+    REQUIRE(synth.getVoiceView(0)->releasedOrFree());
     // Release is 0.1s
     for (int i = 0; i < 10; ++i)
         synth.renderBlock(buffer);

--- a/vst/SfizzVstState.h
+++ b/vst/SfizzVstState.h
@@ -80,6 +80,6 @@ struct SfizzParameterRange {
 };
 
 static constexpr SfizzParameterRange kParamVolumeRange(0.0, -60.0, +6.0);
-static constexpr SfizzParameterRange kParamNumVoicesRange(64.0, 1.0, 256.0);
+static constexpr SfizzParameterRange kParamNumVoicesRange(256.0, 1.0, 512.0);
 static constexpr SfizzParameterRange kParamOversamplingRange(0.0, 0.0, 3.0);
 static constexpr SfizzParameterRange kParamPreloadSizeRange(8192.0, 1024.0, 65536.0);


### PR DESCRIPTION
So the previous note stealing was very conservative. Now, we make use of the average power computed by all voices after each block to steal the voice that had the lowest mean-squared score in the last 10 blocks, without further checks. The reasoning is that most of the time under such pressure a new note will always trump an old one, and we might as well take the lowest.

Also, I put the default polyphony to 256 and increased the max to 512.

Close #187 