### PR TITLE
Make the opposing curves equal at MIDI value 64

### DIFF
--- a/src/sfizz/Curve.h
+++ b/src/sfizz/Curve.h
@@ -80,7 +80,7 @@ public:
     /**
      * @brief Build a linear curve from v1 to v2
      */
-    static Curve buildBipolar(float v1, float v2);
+    static Curve buildBipolar(float v1, float v2, bool midpointCenter);
 
     /**
      * @brief Get a linear curve from 0 to 1

--- a/src/sfizz/SfzHelpers.h
+++ b/src/sfizz/SfzHelpers.h
@@ -129,7 +129,7 @@ constexpr uint8_t denormalizeVelocity(float value)
 }
 
 template<class T>
-constexpr float normalize7Bits(T value)
+inline CXX14_CONSTEXPR float normalize7Bits(T value)
 {
     if (value < 0)
         return 0.0f;

--- a/src/sfizz/SfzHelpers.h
+++ b/src/sfizz/SfzHelpers.h
@@ -127,12 +127,12 @@ inline CXX14_CONSTEXPR T denormalize7Bits(float value)
     return T{ 64 } + static_cast<T>((value - 0.5f) * 126.0f);
 }
 
-constexpr uint8_t denormalizeCC(float value)
+inline CXX14_CONSTEXPR uint8_t denormalizeCC(float value)
 {
     return denormalize7Bits<uint8_t>(value);
 }
 
-constexpr uint8_t denormalizeVelocity(float value)
+inline CXX14_CONSTEXPR uint8_t denormalizeVelocity(float value)
 {
     return denormalize7Bits<uint8_t>(value);
 }
@@ -160,7 +160,7 @@ inline CXX14_CONSTEXPR float normalize7Bits(T value)
  * @return constexpr float
  */
 template<class T>
-constexpr float normalizeCC(T ccValue)
+inline CXX14_CONSTEXPR float normalizeCC(T ccValue)
 {
     return normalize7Bits(ccValue);
 }
@@ -173,7 +173,7 @@ constexpr float normalizeCC(T ccValue)
  * @return constexpr float
  */
 template<class T>
-constexpr float normalizeVelocity(T velocity)
+inline CXX14_CONSTEXPR float normalizeVelocity(T velocity)
 {
     return normalize7Bits(velocity);
 }

--- a/src/sfizz/SfzHelpers.h
+++ b/src/sfizz/SfzHelpers.h
@@ -131,7 +131,16 @@ constexpr uint8_t denormalizeVelocity(float value)
 template<class T>
 constexpr float normalize7Bits(T value)
 {
-    return static_cast<float>(min(max(value, T{ 0 }), T{ 127 })) / 127.0f;
+    if (value < 0)
+        return 0.0f;
+
+    if (value > 127)
+        return 1.0f;
+
+    if (value <= 64)
+        return static_cast<float>(value) * 0.0078125f;
+
+    return 0.5f + static_cast<float>(value - 64) * 0.007936508f;
 }
 
 /**
@@ -189,9 +198,6 @@ constexpr float normalizeBend(float bendValue)
 namespace literals {
     inline float operator""_norm(unsigned long long int value)
     {
-        if (value > 127)
-            value = 127;
-
         return normalize7Bits(value);
     }
 }

--- a/src/sfizz/SfzHelpers.h
+++ b/src/sfizz/SfzHelpers.h
@@ -113,9 +113,18 @@ constexpr float centsFactor(T cents, T centsPerOctave = 1200)
 }
 
 template<class T, absl::enable_if_t<std::is_integral<T>::value, int> = 0>
-constexpr T denormalize7Bits(float value)
+inline CXX14_CONSTEXPR T denormalize7Bits(float value)
 {
-    return static_cast<T>(value * 127.0f);
+    if (value < 0.0f)
+        return T { 0 };
+
+    if (value > 1.0f)
+        return T{ 127 };
+
+    if (value <= 0.5f)
+        return static_cast<T>(value * 128.0f);
+
+    return T{ 64 } + static_cast<T>((value - 0.5f) * 126.0f);
 }
 
 constexpr uint8_t denormalizeCC(float value)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SFIZZ_TEST_SOURCES
     FilesT.cpp
     MidiStateT.cpp
     OnePoleFilterT.cpp
+    SfzHelpersT.cpp
     RegionActivationT.cpp
     RegionValueComputationsT.cpp
     # If we're tweaking the curves this kind of tests does not make sense

--- a/tests/CurveT.cpp
+++ b/tests/CurveT.cpp
@@ -9,67 +9,73 @@
 #include "catch2/catch.hpp"
 #include <algorithm>
 using namespace Catch::literals;
+using namespace sfz::literals;
 
 TEST_CASE("[Curve] Bipolar 0 to 1")
 {
     auto curve = sfz::Curve::buildPredefinedCurve(0);
     REQUIRE( curve.evalCC7(0) == 0.0f );
+    REQUIRE( curve.evalCC7(64) == 0.5f );
     REQUIRE( curve.evalCC7(127) == 1.0f );
-    REQUIRE( curve.evalCC7(2) == Approx(0.0157).margin(1e-3) );
-    REQUIRE( curve.evalCC7(63) == Approx(0.496).margin(1e-3) );
-    REQUIRE( curve.evalCC7(85) == Approx(0.669).margin(1e-3) );
+    REQUIRE( curve.evalCC7(2) == Approx(2_norm).margin(1e-3) );
+    REQUIRE( curve.evalCC7(63) == Approx(63_norm).margin(1e-3) );
+    REQUIRE( curve.evalCC7(85) == Approx(85_norm).margin(1e-3) );
     REQUIRE( curve.evalNormalized(0.0f) == 0.0f );
     REQUIRE( curve.evalNormalized(1.0f) == 1.0f );
-    REQUIRE( curve.evalNormalized(0.3f) == Approx(0.299).margin(1e-3) );
+    REQUIRE( curve.evalNormalized(0.3f) == Approx(0.297).margin(1e-3) );
 }
 
 TEST_CASE("[Curve] Bipolar -1 to 1")
 {
     auto curve = sfz::Curve::buildPredefinedCurve(1);
     REQUIRE( curve.evalCC7(0) == -1.0f );
+    REQUIRE( curve.evalCC7(64) == 0.0f );
     REQUIRE( curve.evalCC7(127) == 1.0f );
-    REQUIRE( curve.evalCC7(2) == Approx(-0.9685).margin(1e-3) );
-    REQUIRE( curve.evalCC7(63) == Approx(-0.00787).margin(1e-5) );
-    REQUIRE( curve.evalCC7(85) == Approx(0.3386).margin(1e-3) );
+    REQUIRE( curve.evalCC7(2) == Approx(-1.0f + 2 * 2_norm).margin(1e-3) );
+    REQUIRE( curve.evalCC7(63) == Approx(-1.0f + 2 * 63_norm).margin(1e-3) );
+    REQUIRE( curve.evalCC7(85) == Approx(-1.0f + 2 * 85_norm).margin(1e-3) );
     REQUIRE( curve.evalNormalized(0.0f) == -1.0f );
     REQUIRE( curve.evalNormalized(1.0f) == 1.0f );
-    REQUIRE( curve.evalNormalized(0.3f) == Approx(-0.4).margin(1e-3) );
+    REQUIRE( curve.evalNormalized(0.3f) == Approx(-0.405).margin(1e-3) );
 }
 
 TEST_CASE("[Curve] Bipolar 1 to 0")
 {
     auto curve = sfz::Curve::buildPredefinedCurve(2);
     REQUIRE( curve.evalCC7(0) == 1.0f );
+    REQUIRE( curve.evalCC7(64) == 0.5f );
     REQUIRE( curve.evalCC7(127) == 0.0f );
-    REQUIRE( curve.evalCC7(2) == Approx(0.984).margin(1e-3) );
-    REQUIRE( curve.evalCC7(63) == Approx(0.504).margin(1e-3) );
-    REQUIRE( curve.evalCC7(85) == Approx(0.331).margin(1e-3) );
+    REQUIRE( curve.evalCC7(2) == Approx(1.0f - 2_norm).margin(1e-3) );
+    REQUIRE( curve.evalCC7(63) == Approx(1.0f - 63_norm).margin(1e-3) );
+    REQUIRE( curve.evalCC7(85) == Approx(1.0f - 85_norm).margin(1e-3) );
     REQUIRE( curve.evalNormalized(0.0f) == 1.0f );
     REQUIRE( curve.evalNormalized(1.0f) == 0.0f );
-    REQUIRE( curve.evalNormalized(0.3f) == Approx(0.701).margin(1e-3) );
+    REQUIRE( curve.evalNormalized(0.3f) == Approx(0.703).margin(1e-3) );
 }
 
 TEST_CASE("[Curve] Bipolar 1 to -1")
 {
     auto curve = sfz::Curve::buildPredefinedCurve(3);
     REQUIRE( curve.evalCC7(0) == 1.0f );
+    REQUIRE( curve.evalCC7(64) == 0.0f );
     REQUIRE( curve.evalCC7(127) == -1.0f );
-    REQUIRE( curve.evalCC7(2) == Approx(0.9685).margin(1e-3) );
-    REQUIRE( curve.evalCC7(63) == Approx(0.00787).margin(1e-5) );
-    REQUIRE( curve.evalCC7(85) == Approx(-0.3386).margin(1e-3) );
+    REQUIRE( curve.evalCC7(2) == Approx(1.0f - 2 * 2_norm).margin(1e-3) );
+    REQUIRE( curve.evalCC7(63) == Approx(1.0f - 2 * 63_norm).margin(1e-3) );
+    REQUIRE( curve.evalCC7(85) == Approx(1.0f - 2 * 85_norm).margin(1e-3) );
     REQUIRE( curve.evalNormalized(0.0f) == 1.0f );
     REQUIRE( curve.evalNormalized(1.0f) == -1.0f );
-    REQUIRE( curve.evalNormalized(0.3f) == Approx(0.4).margin(1e-3) );
+    REQUIRE( curve.evalNormalized(0.3f) == Approx(0.405).margin(1e-3) );
 }
 
 TEST_CASE("[Curve] x**2")
 {
     auto curve = sfz::Curve::buildPredefinedCurve(4);
     REQUIRE( curve.evalCC7(0) == 0.0f );
+    REQUIRE( curve.evalCC7(64) == Approx(0.25).margin(1e-2) );
     REQUIRE( curve.evalCC7(127) == 1.0f );
-    REQUIRE( curve.evalCC7(2) == Approx(0.000248).margin(1e-5) );
-    REQUIRE( curve.evalCC7(63) == Approx(0.246).margin(1e-3) );
-    REQUIRE( curve.evalCC7(85) == Approx(0.448).margin(1e-3) );
+    REQUIRE( curve.evalCC7(2) == Approx(2_norm * 2_norm).margin(1e-2) );
+    REQUIRE( curve.evalCC7(63) == Approx(63_norm * 63_norm).margin(1e-2) );
+    REQUIRE( curve.evalCC7(85) == Approx(85_norm * 85_norm).margin(1e-2) );
     REQUIRE( curve.evalNormalized(0.0f) == 0.0f );
     REQUIRE( curve.evalNormalized(1.0f) == 1.0f );
     REQUIRE( curve.evalNormalized(0.3f) == Approx(0.09).margin(1e-3) );
@@ -80,26 +86,28 @@ TEST_CASE("[Curve] sqrt(x)")
 {
     auto curve = sfz::Curve::buildPredefinedCurve(5);
     REQUIRE( curve.evalCC7(0) == 0.0f );
+    REQUIRE( curve.evalCC7(64) == Approx(sqrtf(2.0f) / 2.0f) );
     REQUIRE( curve.evalCC7(127) == 1.0f );
-    REQUIRE( curve.evalCC7(2) == Approx(0.125).margin(1e-3) );
-    REQUIRE( curve.evalCC7(63) == Approx(0.704).margin(1e-3) );
-    REQUIRE( curve.evalCC7(85) == Approx(0.818).margin(1e-3) );
+    REQUIRE( curve.evalCC7(2) == Approx(sqrtf(2_norm)).margin(1e-2) );
+    REQUIRE( curve.evalCC7(63) == Approx(sqrtf(63_norm)).margin(1e-2) );
+    REQUIRE( curve.evalCC7(85) == Approx(sqrtf(85_norm)).margin(1e-2) );
     REQUIRE( curve.evalNormalized(0.0f) == 0.0f );
     REQUIRE( curve.evalNormalized(1.0f) == 1.0f );
-    REQUIRE( curve.evalNormalized(0.3f) == Approx(0.5477).margin(1e-3) );
+    REQUIRE( curve.evalNormalized(0.3f) == Approx(0.54).margin(1e-2) );
 }
 
 TEST_CASE("[Curve] sqrt(1-x)")
 {
     auto curve = sfz::Curve::buildPredefinedCurve(6);
     REQUIRE( curve.evalCC7(0) == 1.0f );
+    REQUIRE( curve.evalCC7(64) == Approx(sqrtf(2.0f) / 2.0f) );
     REQUIRE( curve.evalCC7(127) == 0.0f );
-    REQUIRE( curve.evalCC7(2) == Approx(0.992).margin(1e-3) );
-    REQUIRE( curve.evalCC7(63) == Approx(0.710).margin(1e-3) );
-    REQUIRE( curve.evalCC7(85) == Approx(0.575).margin(1e-3) );
+    REQUIRE( curve.evalCC7(2) == Approx(sqrtf(1.0f - 2_norm)).margin(1e-2) );
+    REQUIRE( curve.evalCC7(63) == Approx(sqrtf(1.0f - 63_norm)).margin(1e-2) );
+    REQUIRE( curve.evalCC7(85) == Approx(sqrtf(1.0f - 85_norm)).margin(1e-2) );
     REQUIRE( curve.evalNormalized(0.0f) == 1.0f );
     REQUIRE( curve.evalNormalized(1.0f) == 0.0f );
-    REQUIRE( curve.evalNormalized(0.3f) == Approx(0.837).margin(1e-3) );
+    REQUIRE( curve.evalNormalized(0.3f) == Approx(0.84).margin(1e-2) );
 }
 
 TEST_CASE("[Curve] Custom")
@@ -216,19 +224,19 @@ TEST_CASE("[Curve] Default CurveSet")
     REQUIRE(curveSet.getNumCurves() == 7);
     REQUIRE( curveSet.getCurve(0).evalNormalized(0.0f) == 0.0f );
     REQUIRE( curveSet.getCurve(0).evalNormalized(1.0f) == 1.0f );
-    REQUIRE( curveSet.getCurve(0).evalNormalized(0.3f) == Approx(0.299).margin(1e-3) );
+    REQUIRE( curveSet.getCurve(0).evalNormalized(0.3f) == Approx(0.297).margin(1e-3) );
 
     REQUIRE( curveSet.getCurve(1).evalNormalized(0.0f) == -1.0f );
     REQUIRE( curveSet.getCurve(1).evalNormalized(1.0f) == 1.0f );
-    REQUIRE( curveSet.getCurve(1).evalNormalized(0.3f) == Approx(-0.4).margin(1e-3) );
+    REQUIRE( curveSet.getCurve(1).evalNormalized(0.3f) == Approx(-0.405).margin(1e-3) );
 
     REQUIRE( curveSet.getCurve(2).evalNormalized(0.0f) == 1.0f );
     REQUIRE( curveSet.getCurve(2).evalNormalized(1.0f) == 0.0f );
-    REQUIRE( curveSet.getCurve(2).evalNormalized(0.3f) == Approx(0.701).margin(1e-3) );
+    REQUIRE( curveSet.getCurve(2).evalNormalized(0.3f) == Approx(0.703).margin(1e-3) );
 
     REQUIRE( curveSet.getCurve(3).evalNormalized(0.0f) == 1.0f );
     REQUIRE( curveSet.getCurve(3).evalNormalized(1.0f) == -1.0f );
-    REQUIRE( curveSet.getCurve(3).evalNormalized(0.3f) == Approx(0.4).margin(1e-3) );
+    REQUIRE( curveSet.getCurve(3).evalNormalized(0.3f) == Approx(0.405).margin(1e-3) );
 
     REQUIRE( curveSet.getCurve(4).evalNormalized(0.0f) == 0.0f );
     REQUIRE( curveSet.getCurve(4).evalNormalized(1.0f) == 1.0f );
@@ -236,9 +244,9 @@ TEST_CASE("[Curve] Default CurveSet")
 
     REQUIRE( curveSet.getCurve(5).evalNormalized(0.0f) == 0.0f );
     REQUIRE( curveSet.getCurve(5).evalNormalized(1.0f) == 1.0f );
-    REQUIRE( curveSet.getCurve(5).evalNormalized(0.3f) == Approx(0.5477).margin(1e-3) );
+    REQUIRE( curveSet.getCurve(5).evalNormalized(0.3f) == Approx(0.54).margin(1e-2) );
 
     REQUIRE( curveSet.getCurve(6).evalNormalized(0.0f) == 1.0f );
     REQUIRE( curveSet.getCurve(6).evalNormalized(1.0f) == 0.0f );
-    REQUIRE( curveSet.getCurve(6).evalNormalized(0.3f) == Approx(0.837).margin(1e-3) );
+    REQUIRE( curveSet.getCurve(6).evalNormalized(0.3f) == Approx(0.83).margin(1e-2) );
 }

--- a/tests/EventEnvelopesT.cpp
+++ b/tests/EventEnvelopesT.cpp
@@ -280,14 +280,14 @@ TEST_CASE("[linearModifiers] Compare with envelopes")
         return ccData.data.value * x;
     });
     linearModifier(resources, absl::MakeSpan(output), ccData);
-    REQUIRE(approxEqual<float>(output, envelope));
+    REQUIRE(approxEqual<float>(output, envelope, 1e-1));
 
     ccData.data.curve = 1;
     linearEnvelope(resources.midiState.getCCEvents(20), absl::MakeSpan(envelope), [&ccData](float x) {
         return ccData.data.value * (2 * x - 1);
     });
     linearModifier(resources, absl::MakeSpan(output), ccData);
-    REQUIRE(approxEqual<float>(output, envelope));
+    REQUIRE(approxEqual<float>(output, envelope, 1e-1));
 
     ccData.data.curve = 3;
     ccData.data.value = 10.0f;
@@ -295,7 +295,7 @@ TEST_CASE("[linearModifiers] Compare with envelopes")
         return ccData.data.value * (1 - 2 * x);
     });
     linearModifier(resources, absl::MakeSpan(output), ccData);
-    REQUIRE(approxEqual<float>(output, envelope));
+    REQUIRE(approxEqual<float>(output, envelope, 1e-1));
 
     ccData.data.curve = 2;
     ccData.data.value = 20.0f;
@@ -304,7 +304,7 @@ TEST_CASE("[linearModifiers] Compare with envelopes")
         return ccData.data.value * (1 - x);
     }, ccData.data.step);
     linearModifier(resources, absl::MakeSpan(output), ccData);
-    REQUIRE(approxEqual<float>(output, envelope));
+    REQUIRE(approxEqual<float>(output, envelope, 1e-1));
 }
 
 TEST_CASE("[multiplicativeModifiers] Compare with envelopes")
@@ -328,7 +328,7 @@ TEST_CASE("[multiplicativeModifiers] Compare with envelopes")
     multiplicativeModifier(resources, absl::MakeSpan(output), ccData, [](float x) {
         return db2mag(x);
     });
-    REQUIRE(approxEqual<float>(output, envelope));
+    REQUIRE(approxEqual<float>(output, envelope, 1e-1));
 
     ccData.data.curve = 1;
     multiplicativeEnvelope(resources.midiState.getCCEvents(20), absl::MakeSpan(envelope), [&ccData](float x) {
@@ -337,7 +337,7 @@ TEST_CASE("[multiplicativeModifiers] Compare with envelopes")
     multiplicativeModifier(resources, absl::MakeSpan(output), ccData, [](float x) {
         return db2mag(x);
     });
-    REQUIRE(approxEqual<float>(output, envelope));
+    REQUIRE(approxEqual<float>(output, envelope, 1e-1));
 
     ccData.data.curve = 3;
     ccData.data.value = 10.0f;
@@ -347,7 +347,7 @@ TEST_CASE("[multiplicativeModifiers] Compare with envelopes")
     multiplicativeModifier(resources, absl::MakeSpan(output), ccData, [](float x) {
         return db2mag(x);
     });
-    REQUIRE(approxEqual<float>(output, envelope));
+    REQUIRE(approxEqual<float>(output, envelope, 1e-1));
 
     ccData.data.curve = 2;
     ccData.data.value = 20.0f;
@@ -358,6 +358,6 @@ TEST_CASE("[multiplicativeModifiers] Compare with envelopes")
     multiplicativeModifier(resources, absl::MakeSpan(output), ccData, [](float x) {
         return db2mag(x);
     });
-    REQUIRE(approxEqual<float>(output, envelope));
+    REQUIRE(approxEqual<float>(output, envelope, 1e-1));
 }
 

--- a/tests/SfzHelpersT.cpp
+++ b/tests/SfzHelpersT.cpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "sfizz/SfzHelpers.h"
+#include "catch2/catch.hpp"
+using namespace Catch::literals;
+using namespace sfz::literals;
+
+TEST_CASE("[SfzHelpers] Normalize values")
+{
+    REQUIRE(sfz::normalize7Bits(0) == 0.0f);
+    REQUIRE(sfz::normalize7Bits(127) == 1.0f);
+    REQUIRE(sfz::normalize7Bits(128) == 1.0f);
+    REQUIRE(sfz::normalize7Bits(64) == 0.5f);
+}
+
+TEST_CASE("[SfzHelpers] Denormalize values")
+{
+    REQUIRE(sfz::denormalize7Bits<uint8_t>(-3.0f) == 0);
+    REQUIRE(sfz::denormalize7Bits<uint8_t>(0.0f) == 0);
+    REQUIRE(sfz::denormalize7Bits<uint8_t>(1.0f) == 127);
+    REQUIRE(sfz::denormalize7Bits<uint8_t>(1.1f) == 127);
+    REQUIRE(sfz::denormalize7Bits<uint8_t>(0.5f) == 64);
+}
+
+TEST_CASE("[SfzHelpers] Literals")
+{
+    REQUIRE(0_norm == 0.0f);
+    REQUIRE(127_norm == 1.0f);
+    REQUIRE(128_norm == 1.0f);
+    REQUIRE(64_norm == 0.5f);
+}


### PR DESCRIPTION
Make the opposing curves equal at MIDI value 64, defined as center by MIDI specs.
- [0,1] should have center at 0.5
- [-1,1] should have center at 0
- Xfades should have center at 1/√2

TODO: the tests