### PR TITLE
Changes to the worker messages

### DIFF
--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -726,7 +726,7 @@ void sfz::Voice::setupOscillatorUnison()
 void sfz::Voice::updateChannelPowers(AudioSpan<float> buffer)
 {
     assert(smoothedChannelEnvelopes.size() == channelEnvelopeFilters.size());
-    assert(buffer.getNumFrames() <= channelEnvelopeFilters.size());
+    assert(buffer.getNumChannels() <= channelEnvelopeFilters.size());
     if (buffer.getNumFrames() == 0)
         return;
 


### PR DESCRIPTION
Checking for file changes or loading disables future file change checks
The worker only responds to reactivate the file change checks
Upon parameter change, the new value is stored immediately so only one message is sent to the worker
Removed the changing_state bool and let the sfizz internal lock protect the state