### PR TITLE
Build the AU using VST wrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ compile_commands.json
 clients/sfizz_jack
 clients/sfzprint
 
+/vst/download/
+
 # gh-pages unstaged files:
 _api/
 _site/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: cpp
 os: linux
 dist: bionic
 
+cache:
+  directories:
+  - vst/download/
+
 jobs:
   include:
   - name: "clang-tidy checks"

--- a/.travis/prepare_osx.sh
+++ b/.travis/prepare_osx.sh
@@ -23,6 +23,11 @@ cd "${INSTALL_DIR}"/Library/Audio/Plug-Ins/VST3
 dylibbundler -od -b -x sfizz.vst3/Contents/MacOS/sfizz -d sfizz.vst3/Contents/libs/ -p @loader_path/../libs/
 cd "${TRAVIS_BUILD_DIR}/build"
 
+# Bundle AU dependencies
+cd "${INSTALL_DIR}"/Library/Audio/Plug-Ins/Components
+dylibbundler -od -b -x sfizz.component/Contents/Resources/plugin.vst3/Contents/MacOS/sfizz -d sfizz.component/Contents/Resources/plugin.vst3/Contents/libs/ -p @loader_path/../libs/
+cd "${TRAVIS_BUILD_DIR}/build"
+
 #
 tar -zcvf "${INSTALL_DIR}.tar.gz" ${INSTALL_DIR}
 

--- a/.travis/script_osx.sh
+++ b/.travis/script_osx.sh
@@ -4,10 +4,12 @@ set -ex
 mkdir -p build/${INSTALL_DIR} && cd build
 cmake -DCMAKE_BUILD_TYPE=Release \
       -DSFIZZ_VST=ON \
+      -DSFIZZ_AU=ON \
       -DSFIZZ_TESTS=OFF \
       -DCMAKE_CXX_STANDARD=17 \
       -DLV2PLUGIN_INSTALL_DIR=/Library/Audio/Plug-Ins/LV2 \
       -DVSTPLUGIN_INSTALL_DIR=/Library/Audio/Plug-Ins/VST3 \
+      -DAUPLUGIN_INSTALL_DIR=/Library/Audio/Plug-Ins/Components \
       ..
 make -j$(sysctl -n hw.ncpu)
 # Xcode not currently supported, see https://gitlab.kitware.com/cmake/cmake/issues/18088

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ option (SFIZZ_JACK              "Enable JACK stand-alone build [default: ON]" ON
 option (SFIZZ_RENDER            "Enable renderer of SMF files [default: ON]" ON)
 option (SFIZZ_LV2               "Enable LV2 plug-in build [default: ON]" ON)
 option (SFIZZ_VST               "Enable VST plug-in build [default: OFF]" OFF)
+option (SFIZZ_AU                "Enable AU plug-in build [default: OFF]" OFF)
 option (SFIZZ_BENCHMARKS        "Enable benchmarks build [default: OFF]" OFF)
 option (SFIZZ_TESTS             "Enable tests build [default: OFF]" OFF)
 option (SFIZZ_DEVTOOLS          "Enable developer tools build [default: OFF]" OFF)

--- a/cmake/SfizzConfig.cmake
+++ b/cmake/SfizzConfig.cmake
@@ -105,6 +105,7 @@ Build as shared library:       ${SFIZZ_SHARED}
 Build JACK stand-alone client: ${SFIZZ_JACK}
 Build LV2 plug-in:             ${SFIZZ_LV2}
 Build VST plug-in:             ${SFIZZ_VST}
+Build AU plug-in:              ${SFIZZ_AU}
 Build benchmarks:              ${SFIZZ_BENCHMARKS}
 Build tests:                   ${SFIZZ_TESTS}
 Use vcpkg:                     ${SFIZZ_USE_VCPKG}

--- a/vst/CMakeLists.txt
+++ b/vst/CMakeLists.txt
@@ -146,9 +146,24 @@ elseif(SFIZZ_AU)
         OUTPUT_NAME "${PROJECT_NAME}"
         PREFIX "")
 
-    # Add Core Audio utility classes
+    # Get Core Audio utility classes if missing
     set(CA_UTILITY_BASEDIR
         "${CMAKE_CURRENT_SOURCE_DIR}/external/CoreAudioUtilityClasses")
+    if(NOT EXISTS "${CA_UTILITY_BASEDIR}")
+        set(CA_UTILITY_VERSION "1.1")
+        set(CA_UTILITY_ARCHIVE "CoreAudioUtilityClasses-${CA_UTILITY_VERSION}.tar.gz")
+        set(CA_UTILITY_DOWNLOAD_URL "https://github.com/sfztools/CoreAudioUtilityClasses/releases/download/v${CA_UTILITY_VERSION}/${CA_UTILITY_ARCHIVE}")
+        if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/download/${CA_UTILITY_ARCHIVE}")
+            file(MAKE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/download")
+            file(DOWNLOAD "${CA_UTILITY_DOWNLOAD_URL}"
+                "${CMAKE_CURRENT_SOURCE_DIR}/download/${CA_UTILITY_ARCHIVE}")
+        endif()
+        execute_process(COMMAND "${CMAKE_COMMAND}" "-E" "tar" "xvf"
+            "${CMAKE_CURRENT_SOURCE_DIR}/download/${CA_UTILITY_ARCHIVE}"
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/external")
+    endif()
+
+    # Add Core Audio utility classes
     target_include_directories(${AUPLUGIN_PRJ_NAME} PRIVATE
         "${CA_UTILITY_BASEDIR}/CoreAudio"
         "${CA_UTILITY_BASEDIR}/CoreAudio/AudioUnits"
@@ -221,26 +236,28 @@ elseif(SFIZZ_AU)
         DESTINATION "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}")
 
     # Add the resource fork
-    execute_process(COMMAND "xcrun" "--find" "Rez"
-        OUTPUT_VARIABLE OSX_REZ_COMMAND OUTPUT_STRIP_TRAILING_WHITESPACE)
-    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mac/audiounitconfig.h.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/include/audiounitconfig.h" @ONLY)
-    add_custom_command(TARGET ${AUPLUGIN_PRJ_NAME} POST_BUILD COMMAND
-        "${OSX_REZ_COMMAND}"
-        "-d" "SystemSevenOrLater=1"
-        "-script" "Roman"
-        "-d" "i386_YES"
-        "-d" "x86_64_YES"
-        "-is" "${CMAKE_OSX_SYSROOT}"
-        "-I" "${CMAKE_OSX_SYSROOT}/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Versions/A/Headers"
-        "-I" "/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Versions/A/Headers"
-        "-I" "/System/Library/Frameworks/AudioUnit.framework/Versions/A/Headers/"
-        "-I" "${CA_UTILITY_BASEDIR}/CoreAudio/AudioUnits/AUPublic/AUBase"
-        "-I" "${CMAKE_CURRENT_BINARY_DIR}/include" # generated audiounitconfig.h
-        "-o" "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources/${PROJECT_NAME}.rsrc"
-        "-useDF"
-        "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper/auresource.r")
+    if (FALSE) # optional, disabled because broken on CI
+        execute_process(COMMAND "xcrun" "--find" "Rez"
+            OUTPUT_VARIABLE OSX_REZ_COMMAND OUTPUT_STRIP_TRAILING_WHITESPACE)
+        file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
+        configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mac/audiounitconfig.h.in"
+            "${CMAKE_CURRENT_BINARY_DIR}/include/audiounitconfig.h" @ONLY)
+        add_custom_command(TARGET ${AUPLUGIN_PRJ_NAME} POST_BUILD COMMAND
+            "${OSX_REZ_COMMAND}"
+            "-d" "SystemSevenOrLater=1"
+            "-script" "Roman"
+            "-d" "i386_YES"
+            "-d" "x86_64_YES"
+            "-is" "${CMAKE_OSX_SYSROOT}"
+            "-I" "${CMAKE_OSX_SYSROOT}/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Versions/A/Headers"
+            "-I" "/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Versions/A/Headers"
+            "-I" "/System/Library/Frameworks/AudioUnit.framework/Versions/A/Headers/"
+            "-I" "${CA_UTILITY_BASEDIR}/CoreAudio/AudioUnits/AUPublic/AUBase"
+            "-I" "${CMAKE_CURRENT_BINARY_DIR}/include" # generated audiounitconfig.h
+            "-o" "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources/${PROJECT_NAME}.rsrc"
+            "-useDF"
+            "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper/auresource.r")
+    endif()
 
     # Copy VST3 in the bundle
     add_custom_command(TARGET ${VSTPLUGIN_PRJ_NAME} POST_BUILD COMMAND
@@ -260,5 +277,12 @@ elseif(SFIZZ_AU)
             "-Wno-unused-function"
             "-Wno-unused-parameter"
             "-Wno-unused-variable")
+    endif()
+
+    # Installation
+    if(AUPLUGIN_INSTALL_DIR)
+        install(DIRECTORY "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}"
+            DESTINATION "${AUPLUGIN_INSTALL_DIR}"
+            COMPONENT "au")
     endif()
 endif()

--- a/vst/CMakeLists.txt
+++ b/vst/CMakeLists.txt
@@ -12,7 +12,7 @@ configure_file (VstPluginDefs.h.in "${CMAKE_CURRENT_BINARY_DIR}/VstPluginDefs.h"
 include("cmake/Vst3.cmake")
 
 # Build the plugin
-add_library(${VSTPLUGIN_PRJ_NAME} MODULE
+set(VSTPLUGIN_SOURCES
     SfizzVstProcessor.cpp
     SfizzVstController.cpp
     SfizzVstEditor.cpp
@@ -20,6 +20,12 @@ add_library(${VSTPLUGIN_PRJ_NAME} MODULE
     GUIComponents.cpp
     VstPluginFactory.cpp
     X11RunLoop.cpp)
+
+set(VSTPLUGIN_RESOURCES
+    logo.png)
+
+add_library(${VSTPLUGIN_PRJ_NAME} MODULE
+    ${VSTPLUGIN_SOURCES})
 
 if(WIN32)
     target_sources(${VSTPLUGIN_PRJ_NAME} PRIVATE vst3.def)
@@ -51,8 +57,10 @@ endif()
 # Create the bundle (see "VST 3 Locations / Format")
 execute_process (
     COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/Resources")
-file (COPY "${CMAKE_CURRENT_SOURCE_DIR}/resources/logo.png"
-    DESTINATION "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/Resources")
+foreach(res ${VSTPLUGIN_RESOURCES})
+    file (COPY "${CMAKE_CURRENT_SOURCE_DIR}/resources/${res}"
+        DESTINATION "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/Resources")
+endforeach()
 if(WIN32)
     set_target_properties(${VSTPLUGIN_PRJ_NAME} PROPERTIES
         SUFFIX ".vst3"
@@ -73,7 +81,7 @@ elseif(APPLE)
         DESTINATION "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents")
     set(SFIZZ_VST3_BUNDLE_EXECUTABLE "${PROJECT_NAME}")
     set(SFIZZ_VST3_BUNDLE_VERSION "${PROJECT_VERSION}")
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mac/Info.plist"
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mac/Info.vst3.plist"
         "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/Info.plist" @ONLY)
     file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/mac/Plugin.icns"
         DESTINATION "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/Resources")
@@ -108,4 +116,149 @@ if (NOT MSVC)
     install (DIRECTORY "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}"
         DESTINATION "${VSTPLUGIN_INSTALL_DIR}"
         COMPONENT "vst")
+endif()
+
+# --- Audio Unit wrapper --- #
+
+if(SFIZZ_AU AND NOT APPLE)
+    message(WARNING "Audio Unit is available only for macOS builds")
+elseif(SFIZZ_AU)
+    set(AUPLUGIN_PRJ_NAME "${PROJECT_NAME}_au")
+    set(AUPLUGIN_BUNDLE_NAME "${PROJECT_NAME}.component")
+
+    add_library(${AUPLUGIN_PRJ_NAME} MODULE
+        "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper/aucarbonview.mm"
+        "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper/aucocoaview.mm"
+        "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper/ausdk.mm"
+        "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper/auwrapper.mm"
+        "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper/NSDataIBStream.mm")
+    target_include_directories(${AUPLUGIN_PRJ_NAME} PRIVATE
+        "${VST3SDK_BASEDIR}")
+    target_link_libraries(${AUPLUGIN_PRJ_NAME} PRIVATE
+        "${APPLE_FOUNDATION_LIBRARY}"
+        "${APPLE_COCOA_LIBRARY}"
+        "${APPLE_CARBON_LIBRARY}"
+        "${APPLE_AUDIOTOOLBOX_LIBRARY}"
+        "${APPLE_COREAUDIO_LIBRARY}"
+        "${APPLE_COREMIDI_LIBRARY}")
+
+    set_target_properties(${AUPLUGIN_PRJ_NAME} PROPERTIES
+        OUTPUT_NAME "${PROJECT_NAME}"
+        PREFIX "")
+
+    # Add Core Audio utility classes
+    set(CA_UTILITY_BASEDIR
+        "${CMAKE_CURRENT_SOURCE_DIR}/external/CoreAudioUtilityClasses")
+    target_include_directories(${AUPLUGIN_PRJ_NAME} PRIVATE
+        "${CA_UTILITY_BASEDIR}/CoreAudio"
+        "${CA_UTILITY_BASEDIR}/CoreAudio/AudioUnits"
+        "${CA_UTILITY_BASEDIR}/CoreAudio/AudioUnits/AUPublic/AUBase"
+        "${CA_UTILITY_BASEDIR}/CoreAudio/AudioUnits/AUPublic/Utility"
+        "${CA_UTILITY_BASEDIR}/CoreAudio/PublicUtility")
+
+    # Add VST base classes
+    target_sources(${AUPLUGIN_PRJ_NAME} PRIVATE
+        "${VST3SDK_BASEDIR}/base/source/baseiids.cpp"
+        "${VST3SDK_BASEDIR}/base/source/fbuffer.cpp"
+        "${VST3SDK_BASEDIR}/base/source/fdebug.cpp"
+        "${VST3SDK_BASEDIR}/base/source/fdynlib.cpp"
+        "${VST3SDK_BASEDIR}/base/source/fobject.cpp"
+        "${VST3SDK_BASEDIR}/base/source/fstreamer.cpp"
+        "${VST3SDK_BASEDIR}/base/source/fstring.cpp"
+        "${VST3SDK_BASEDIR}/base/source/timer.cpp"
+        "${VST3SDK_BASEDIR}/base/source/updatehandler.cpp"
+        "${VST3SDK_BASEDIR}/base/thread/source/fcondition.cpp"
+        "${VST3SDK_BASEDIR}/base/thread/source/flock.cpp"
+        "${VST3SDK_BASEDIR}/pluginterfaces/base/conststringtable.cpp"
+        "${VST3SDK_BASEDIR}/pluginterfaces/base/coreiids.cpp"
+        "${VST3SDK_BASEDIR}/pluginterfaces/base/funknown.cpp"
+        "${VST3SDK_BASEDIR}/pluginterfaces/base/ustring.cpp"
+        "${VST3SDK_BASEDIR}/public.sdk/source/vst/vstinitiids.cpp")
+
+    # Add VST hosting classes
+    target_sources(${AUPLUGIN_PRJ_NAME} PRIVATE
+        "${VST3SDK_BASEDIR}/public.sdk/source/vst/hosting/eventlist.cpp"
+        "${VST3SDK_BASEDIR}/public.sdk/source/vst/hosting/hostclasses.cpp"
+        "${VST3SDK_BASEDIR}/public.sdk/source/vst/hosting/parameterchanges.cpp"
+        "${VST3SDK_BASEDIR}/public.sdk/source/vst/hosting/pluginterfacesupport.cpp"
+        "${VST3SDK_BASEDIR}/public.sdk/source/vst/hosting/processdata.cpp")
+
+    # Add generated source
+    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
+    target_include_directories(${AUPLUGIN_PRJ_NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/include")
+    string(TIMESTAMP SFIZZ_AU_CLASS_PREFIX_NUMBER "%s" UTC)
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/include/aucocoaclassprefix.h"
+        "#define SMTG_AU_NAMESPACE SMTGAUCocoa${SFIZZ_AU_CLASS_PREFIX_NUMBER}_")
+
+    sfizz_enable_lto_if_needed (${AUPLUGIN_PRJ_NAME})
+
+    # Create the bundle
+    execute_process(
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources")
+    set_target_properties(${AUPLUGIN_PRJ_NAME} PROPERTIES
+        SUFFIX ""
+        LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/MacOS")
+    file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/mac/PkgInfo"
+        DESTINATION "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents")
+    set(SFIZZ_AU_BUNDLE_EXECUTABLE "${PROJECT_NAME}")
+    set(SFIZZ_AU_BUNDLE_VERSION "${PROJECT_VERSION}")
+    set(SFIZZ_AU_BUNDLE_IDENTIFIER "tools.sfz.sfizz.au")
+    set(SFIZZ_AU_BUNDLE_TYPE "aumu")
+    set(SFIZZ_AU_BUNDLE_SUBTYPE "samp")
+    set(SFIZZ_AU_BUNDLE_MANUFACTURER "Sfzt")
+    math(EXPR SFIZZ_AU_DECIMAL_VERSION
+        "${PROJECT_VERSION_MAJOR}*10000 + ${PROJECT_VERSION_MINOR}*100 + ${PROJECT_VERSION_PATCH}")
+    execute_process(
+        COMMAND "sh" "-c" "echo 'obase=16;${SFIZZ_AU_DECIMAL_VERSION}' | bc"
+        OUTPUT_VARIABLE SFIZZ_AU_HEXADECIMAL_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mac/Info.au.plist"
+        "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Info.plist" @ONLY)
+    file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/mac/Plugin.icns"
+        DESTINATION "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources")
+
+    file(COPY "gpl-3.0.txt"
+        DESTINATION "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}")
+
+    # Add the resource fork
+    execute_process(COMMAND "xcrun" "--find" "Rez"
+        OUTPUT_VARIABLE OSX_REZ_COMMAND OUTPUT_STRIP_TRAILING_WHITESPACE)
+    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mac/audiounitconfig.h.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/include/audiounitconfig.h" @ONLY)
+    add_custom_command(TARGET ${AUPLUGIN_PRJ_NAME} POST_BUILD COMMAND
+        "${OSX_REZ_COMMAND}"
+        "-d" "SystemSevenOrLater=1"
+        "-script" "Roman"
+        "-d" "i386_YES"
+        "-d" "x86_64_YES"
+        "-is" "${CMAKE_OSX_SYSROOT}"
+        "-I" "${CMAKE_OSX_SYSROOT}/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Versions/A/Headers"
+        "-I" "/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Versions/A/Headers"
+        "-I" "/System/Library/Frameworks/AudioUnit.framework/Versions/A/Headers/"
+        "-I" "${CA_UTILITY_BASEDIR}/CoreAudio/AudioUnits/AUPublic/AUBase"
+        "-I" "${CMAKE_CURRENT_BINARY_DIR}/include" # generated audiounitconfig.h
+        "-o" "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources/${PROJECT_NAME}.rsrc"
+        "-useDF"
+        "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper/auresource.r")
+
+    # Copy VST3 in the bundle
+    add_custom_command(TARGET ${VSTPLUGIN_PRJ_NAME} POST_BUILD COMMAND
+        "${CMAKE_COMMAND}" "-E"
+        "copy_directory"
+        "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}"
+        "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources/plugin.vst3")
+
+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(${AUPLUGIN_PRJ_NAME} PRIVATE
+            "-Wno-extra"
+            "-Wno-multichar"
+            "-Wno-reorder"
+            "-Wno-class-memaccess"
+            "-Wno-ignored-qualifiers"
+            "-Wno-unknown-pragmas"
+            "-Wno-unused-function"
+            "-Wno-unused-parameter"
+            "-Wno-unused-variable")
+    endif()
 endif()

--- a/vst/cmake/Vst3.cmake
+++ b/vst/cmake/Vst3.cmake
@@ -203,18 +203,26 @@ function(plugin_add_vstgui NAME)
         endif()
     elseif(APPLE)
         find_library(APPLE_COREFOUNDATION_LIBRARY "CoreFoundation")
+        find_library(APPLE_FOUNDATION_LIBRARY "Foundation")
         find_library(APPLE_COCOA_LIBRARY "Cocoa")
         find_library(APPLE_OPENGL_LIBRARY "OpenGL")
         find_library(APPLE_ACCELERATE_LIBRARY "Accelerate")
         find_library(APPLE_QUARTZCORE_LIBRARY "QuartzCore")
         find_library(APPLE_CARBON_LIBRARY "Carbon")
+        find_library(APPLE_AUDIOTOOLBOX_LIBRARY "AudioToolbox")
+        find_library(APPLE_COREAUDIO_LIBRARY "CoreAudio")
+        find_library(APPLE_COREMIDI_LIBRARY "CoreMIDI")
         target_link_libraries("${NAME}" PRIVATE
             "${APPLE_COREFOUNDATION_LIBRARY}"
+            "${APPLE_FOUNDATION_LIBRARY}"
             "${APPLE_COCOA_LIBRARY}"
             "${APPLE_OPENGL_LIBRARY}"
             "${APPLE_ACCELERATE_LIBRARY}"
             "${APPLE_QUARTZCORE_LIBRARY}"
-            "${APPLE_CARBON_LIBRARY}")
+            "${APPLE_CARBON_LIBRARY}"
+            "${APPLE_AUDIOTOOLBOX_LIBRARY}"
+            "${APPLE_COREAUDIO_LIBRARY}"
+            "${APPLE_COREMIDI_LIBRARY}")
     else()
         find_package(X11 REQUIRED)
         find_package(Freetype REQUIRED)

--- a/vst/mac/Info.au.plist
+++ b/vst/mac/Info.au.plist
@@ -30,7 +30,7 @@
             <key>factoryFunction</key>
             <string>AUWrapperFactory</string>
             <key>manufacturer</key>
-            <string>@SFIZZ_AU_BUNDLE_MANUFACTURER@</string> <!-- TODO: register me -->
+            <string>@SFIZZ_AU_BUNDLE_MANUFACTURER@</string>
             <key>name</key>
             <string>@SFIZZ_AU_BUNDLE_MANUFACTURER@: @PROJECT_NAME@</string>
             <key>sandboxSafe</key>

--- a/vst/mac/Info.au.plist
+++ b/vst/mac/Info.au.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundleExecutable</key>
+    <string>@SFIZZ_AU_BUNDLE_EXECUTABLE@</string>
+    <key>CFBundleIconFile</key>
+    <string>Plugin.icns</string>
+    <key>CFBundleIdentifier</key>
+    <string>@SFIZZ_AU_BUNDLE_IDENTIFIER@</string>
+    <key>CFBundleName</key>
+    <string>sfizz</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleVersion</key>
+    <string>@SFIZZ_AU_BUNDLE_VERSION@</string>
+    <key>CSResourcesFileMapped</key>
+    <true/>
+    <key>AudioComponents</key>
+    <array>
+        <dict>
+            <key>description</key>
+            <string>@PROJECT_NAME@</string>
+            <key>factoryFunction</key>
+            <string>AUWrapperFactory</string>
+            <key>manufacturer</key>
+            <string>@SFIZZ_AU_BUNDLE_MANUFACTURER@</string> <!-- TODO: register me -->
+            <key>name</key>
+            <string>@SFIZZ_AU_BUNDLE_MANUFACTURER@: @PROJECT_NAME@</string>
+            <key>sandboxSafe</key>
+            <true/>
+            <key>type</key>
+            <string>@SFIZZ_AU_BUNDLE_TYPE@</string>
+            <key>subtype</key>
+            <string>@SFIZZ_AU_BUNDLE_SUBTYPE@</string>
+            <key>tags</key>
+            <array>
+                <string>Sampler</string>
+                <string>Synthesizer</string>
+            </array>
+            <key>version</key>
+            <integer>@SFIZZ_AU_DECIMAL_VERSION@</integer>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/vst/mac/Info.vst3.plist
+++ b/vst/mac/Info.vst3.plist
@@ -9,7 +9,9 @@
     <key>CFBundleIconFile</key>
     <string>Plugin.icns</string>
     <key>CFBundleIdentifier</key>
-    <string>tools.sfz.sfizz</string>
+    <string>tools.sfz.sfizz.vst</string>
+    <key>CFBundleName</key>
+    <string>sfizz</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundlePackageType</key>

--- a/vst/mac/audiounitconfig.h.in
+++ b/vst/mac/audiounitconfig.h.in
@@ -1,0 +1,15 @@
+#define kAudioUnitBundleIdentifier @SFIZZ_AU_BUNDLE_IDENTIFIER@
+#define kAudioUnitVersion 0x@SFIZZ_AU_HEXADECIMAL_VERSION@
+#define kAUPluginName  @SFIZZ_AU_BUNDLE_MANUFACTURER@: @PROJECT_NAME@
+#define kAUPluginDescription  @PROJECT_NAME@
+#define kAUPluginType  @SFIZZ_AU_BUNDLE_TYPE@
+#define kAUPluginSubType  @SFIZZ_AU_BUNDLE_SUBTYPE@
+#define kAUPluginManufacturer  @SFIZZ_AU_BUNDLE_MANUFACTURER@
+
+#define kAudioUnitName "@SFIZZ_AU_BUNDLE_MANUFACTURER@: @PROJECT_NAME@"
+#define kAudioUnitDescription "@PROJECT_NAME@"
+#define kAudioUnitType '@SFIZZ_AU_BUNDLE_TYPE@'
+#define kAudioUnitComponentSubType '@SFIZZ_AU_BUNDLE_SUBTYPE@'
+#define kAudioUnitComponentManuf '@SFIZZ_AU_BUNDLE_MANUFACTURER@'
+
+#define kAudioUnitCarbonView 1


### PR DESCRIPTION
This allows to build the Audio Unit.

It's using the Steinberg wrapper.
The solutions consists in making a AU wrapping bundle containing the VST3.

It needs to extract `CoreAudioUtilityClasses` into `vst/external`.

~~TODO: register the manufacturer code to Apple~~