### PR TITLE
parser: dollar expansions and multiple #define on the same line

### DIFF
--- a/src/sfizz/parser/Parser.cpp
+++ b/src/sfizz/parser/Parser.cpp
@@ -295,7 +295,7 @@ void Parser::processOpcode()
             bool stop = false;
 
             // consume space characters following
-            while (i < valueSize && isSpaceChar(valueRaw[endPosition + 1]))
+            while (i < valueSize && isSpaceChar(valueRaw[i]))
                 ++i;
 
             // if there aren't non-space characters following, do not extract

--- a/src/sfizz/parser/Parser.cpp
+++ b/src/sfizz/parser/Parser.cpp
@@ -163,7 +163,18 @@ void Parser::processDirective()
 
         std::string value;
         extractToEol(reader, &value);
+
+#if 1
+        // ARIA/not Cakewalk: cut the value after the first word
+        size_t position = value.find_first_of(" \t");
+        if (position != value.npos) {
+            absl::string_view excess(&value[position], value.size() - position);
+            reader.putBackChars(excess);
+            value.resize(position);
+        }
+#else
         trimRight(value);
+#endif
 
         addDefinition(id, value);
     }
@@ -457,21 +468,25 @@ std::string Parser::expandDollarVars(const SourceRange& range, absl::string_view
             std::string name;
             name.reserve(64);
 
-            while (i < n && isIdentifierChar(src[i]))
+            // ARIA: we will accumulate any chars after $, until this is the
+            //       name of a known variable
+            auto def = _currentDefinitions.end();
+            while (i < n && isIdentifierChar(src[i]) && def == _currentDefinitions.end()) {
                 name.push_back(src[i++]);
+                def = _currentDefinitions.find(name);
+            }
 
             if (name.empty()) {
                 emitWarning(range, "Expected variable name after $.");
                 continue;
             }
 
-            auto it = _currentDefinitions.find(name);
-            if (it == _currentDefinitions.end()) {
+            if (def == _currentDefinitions.end()) {
                 emitWarning(range, "The variable `" + name + "` is not defined.");
                 continue;
             }
 
-            dst.append(it->second);
+            dst.append(def->second);
         }
     }
 

--- a/tests/FilesT.cpp
+++ b/tests/FilesT.cpp
@@ -339,14 +339,22 @@ TEST_CASE("[Files] sw_default and playing with switches")
     REQUIRE( synth.getRegionView(3)->isSwitchedOn() );
 }
 
-
 TEST_CASE("[Files] wrong (overlapping) replacement for defines")
 {
     sfz::Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/SpecificBugs/wrong-replacements.sfz");
+
     REQUIRE( synth.getNumRegions() == 3 );
+
+#if 0
+    // Note: test checked to be wrong under Sforzando 1.961
+    //       It is the shorter matching $-variable which matches among both.
+    //       The rest of the variable name creates some trailing junk text
+    //       which Sforzando accepts without warning. (eg. `key=52Edge`)
     REQUIRE( synth.getRegionView(0)->keyRange.getStart() == 52 );
     REQUIRE( synth.getRegionView(0)->keyRange.getEnd() == 52 );
+#endif
+
     REQUIRE( synth.getRegionView(1)->keyRange.getStart() == 57 );
     REQUIRE( synth.getRegionView(1)->keyRange.getEnd() == 57 );
     REQUIRE(!synth.getRegionView(2)->amplitudeCC.empty());

--- a/tests/ParsingT.cpp
+++ b/tests/ParsingT.cpp
@@ -621,3 +621,34 @@ R"(#define $B foo-$A-baz
         REQUIRE(mock.fullBlockHeaders == expectedHeaders);
         REQUIRE(mock.fullBlockMembers == expectedMembers);
 }
+
+TEST_CASE("[Parsing] Opcode value special character")
+{
+        sfz::Parser parser;
+        ParsingMocker mock;
+        parser.setListener(&mock);
+        parser.parseString("/opcodeValueSpecialCharacter.sfz",
+R"(<region>
+sample=Alto-Flute-sus-C#4-PB-loop.wav)");
+
+        std::vector<std::vector<sfz::Opcode>> expectedMembers = {
+            {{"sample", "Alto-Flute-sus-C#4-PB-loop.wav"}},
+        };
+        std::vector<std::string> expectedHeaders = {
+            "region"
+        };
+        std::vector<sfz::Opcode> expectedOpcodes;
+
+        for (auto& members: expectedMembers)
+            for (auto& opcode: members)
+                expectedOpcodes.push_back(opcode);
+
+        REQUIRE(mock.beginnings == 1);
+        REQUIRE(mock.endings == 1);
+        REQUIRE(mock.errors.empty());
+        REQUIRE(mock.warnings.empty());
+        REQUIRE(mock.opcodes == expectedOpcodes);
+        REQUIRE(mock.headers == expectedHeaders);
+        REQUIRE(mock.fullBlockHeaders == expectedHeaders);
+        REQUIRE(mock.fullBlockMembers == expectedMembers);
+}

--- a/tests/ParsingT.cpp
+++ b/tests/ParsingT.cpp
@@ -589,3 +589,35 @@ R"(#define $a foo #define $b bar <region> sample=$a-$b.wav
         REQUIRE(mock.fullBlockHeaders == expectedHeaders);
         REQUIRE(mock.fullBlockMembers == expectedMembers);
 }
+
+TEST_CASE("[Parsing] Recursive expansion")
+{
+        sfz::Parser parser;
+        ParsingMocker mock;
+        parser.setListener(&mock);
+        parser.parseString("/recursiveExpansion.sfz",
+R"(#define $B foo-$A-baz
+#define $A bar
+<region> sample=$B.wav)");
+
+        std::vector<std::vector<sfz::Opcode>> expectedMembers = {
+            {{"sample", "foo-bar-baz.wav"}},
+        };
+        std::vector<std::string> expectedHeaders = {
+            "region"
+        };
+        std::vector<sfz::Opcode> expectedOpcodes;
+
+        for (auto& members: expectedMembers)
+            for (auto& opcode: members)
+                expectedOpcodes.push_back(opcode);
+
+        REQUIRE(mock.beginnings == 1);
+        REQUIRE(mock.endings == 1);
+        REQUIRE(mock.errors.empty());
+        REQUIRE(mock.warnings.empty());
+        REQUIRE(mock.opcodes == expectedOpcodes);
+        REQUIRE(mock.headers == expectedHeaders);
+        REQUIRE(mock.fullBlockHeaders == expectedHeaders);
+        REQUIRE(mock.fullBlockMembers == expectedMembers);
+}

--- a/tests/ParsingT.cpp
+++ b/tests/ParsingT.cpp
@@ -685,3 +685,34 @@ R"(<region>#define $VEL v1 sample=$VEL.wav #define $FOO bar)");
         REQUIRE(mock.fullBlockHeaders == expectedHeaders);
         REQUIRE(mock.fullBlockMembers == expectedMembers);
 }
+
+TEST_CASE("[Parsing] Opcode value with multiple consecutive spaces")
+{
+        sfz::Parser parser;
+        ParsingMocker mock;
+        parser.setListener(&mock);
+        parser.parseString("/opcodeValueWithMultipleConsecutiveSpaces.sfz",
+R"(<region>  sample=foo  bar  baz  .wav   key=69  )");
+
+        std::vector<std::vector<sfz::Opcode>> expectedMembers = {
+            {{"sample", "foo  bar  baz  .wav"},
+             {"key", "69"}},
+        };
+        std::vector<std::string> expectedHeaders = {
+            "region"
+        };
+        std::vector<sfz::Opcode> expectedOpcodes;
+
+        for (auto& members: expectedMembers)
+            for (auto& opcode: members)
+                expectedOpcodes.push_back(opcode);
+
+        REQUIRE(mock.beginnings == 1);
+        REQUIRE(mock.endings == 1);
+        REQUIRE(mock.errors.empty());
+        REQUIRE(mock.warnings.empty());
+        REQUIRE(mock.opcodes == expectedOpcodes);
+        REQUIRE(mock.headers == expectedHeaders);
+        REQUIRE(mock.fullBlockHeaders == expectedHeaders);
+        REQUIRE(mock.fullBlockMembers == expectedMembers);
+}


### PR DESCRIPTION
This fixes some parsing problems, preventing some real files being read correctly.
Tests included.

- in case of a possibly ambiguous `$` expansion, the shorter existing variable name wins (ARIA)
- support of `#define $foo 1 #define $bar 2` all on the same line
  ~~this is done by factorizing the code which extracts the opcode value with look-ahead, and this does the same work in presence of `#define`~~
  did the same as ARIA, which consists in extracting only the first word