### PR TITLE
Off by

### DIFF
--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -132,7 +132,10 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
         setValueFromOpcode(opcode, group, Default::groupRange);
         break;
     case hash("off_by"): // also offby
-        setValueFromOpcode(opcode, offBy, Default::groupRange);
+        if (opcode.value == "-1")
+            offBy.reset();
+        else
+            setValueFromOpcode(opcode, offBy, Default::groupRange);
         break;
     case hash("off_mode"): // also offmode
         switch (hash(opcode.value)) {

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -180,8 +180,7 @@ TEST_CASE("[Region] Parsing opcodes")
         REQUIRE(region.offBy);
         REQUIRE(*region.offBy == 5);
         region.parseOpcode({ "off_by", "-1" });
-        REQUIRE(region.offBy);
-        REQUIRE(*region.offBy == 0);
+        REQUIRE(!region.offBy);
     }
 
     SECTION("off_mode")


### PR DESCRIPTION
The code `off_by=-1` is supposed to reset it as if undefined. (ARIA)
Fix + test

There may be some other `absl::optional` opcodes in the same case as this.