### PR TITLE
Add the API to receive hdcc values

### DIFF
--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -192,6 +192,19 @@ SFIZZ_EXPORTED_API void sfizz_send_note_off(sfizz_synth_t* synth, int delay, int
 SFIZZ_EXPORTED_API void sfizz_send_cc(sfizz_synth_t* synth, int delay, int cc_number, char cc_value);
 
 /**
+ * @brief      Send a high precision CC event to the synth. As with all MIDI
+ *             events, this needs to happen before the call to
+ *             sfizz_render_block in each block and should appear in order of
+ *             the delays.
+ *
+ * @param      synth      The synth.
+ * @param      delay      The delay of the event in the block, in samples.
+ * @param      cc_number  The MIDI CC number.
+ * @param      norm_value  The normalized CC value, in domain 0 to 1.
+ */
+SFIZZ_EXPORTED_API void sfizz_send_hdcc(sfizz_synth_t* synth, int delay, int cc_number, float norm_value);
+
+/**
  * @brief      Send a pitch wheel event. As with all MIDI events, this needs
  *             to happen before the call to sfizz_render_block in each block and
  *             should appear in order of the delays.

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -164,6 +164,16 @@ public:
     void cc(int delay, int ccNumber, uint8_t ccValue) noexcept;
 
     /**
+     * @brief Send a high precision CC event to the synth
+     *
+     * @param delay the delay at which the event occurs; this should be lower than the size of
+     *              the block in the next call to renderBlock().
+     * @param ccNumber the cc number.
+     * @param normValue the normalized cc value, in domain 0 to 1.
+     */
+    void hdcc(int delay, int ccNumber, float normValue) noexcept;
+
+    /**
      * @brief Send a pitch bend event to the synth
      *
      * @param delay the delay at which the event occurs; this should be lower

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -237,6 +237,15 @@ public:
      */
     void cc(int delay, int ccNumber, uint8_t ccValue) noexcept;
     /**
+     * @brief Send a high precision CC event to the synth
+     *
+     * @param delay the delay at which the event occurs; this should be lower than the size of
+     *              the block in the next call to renderBlock().
+     * @param ccNumber the cc number
+     * @param normValue the normalized cc value, in domain 0 to 1
+     */
+    void hdcc(int delay, int ccNumber, float normValue) noexcept;
+    /**
      * @brief Send a pitch bend event to the synth
      *
      * @param delay the delay at which the event occurs; this should be lower

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -93,6 +93,11 @@ void sfz::Sfizz::cc(int delay, int ccNumber, uint8_t ccValue) noexcept
     synth->cc(delay, ccNumber, ccValue);
 }
 
+void sfz::Sfizz::hdcc(int delay, int ccNumber, float normValue) noexcept
+{
+    synth->hdcc(delay, ccNumber, normValue);
+}
+
 void sfz::Sfizz::pitchWheel(int delay, int pitch) noexcept
 {
     synth->pitchWheel(delay, pitch);

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -98,6 +98,11 @@ void sfizz_send_cc(sfizz_synth_t* synth, int delay, int cc_number, char cc_value
     auto self = reinterpret_cast<sfz::Synth*>(synth);
     self->cc(delay, cc_number, cc_value);
 }
+void sfizz_send_hdcc(sfizz_synth_t* synth, int delay, int cc_number, float norm_value)
+{
+    auto self = reinterpret_cast<sfz::Synth*>(synth);
+    self->hdcc(delay, cc_number, norm_value);
+}
 void sfizz_send_pitch_wheel(sfizz_synth_t* synth, int delay, int pitch)
 {
     auto self = reinterpret_cast<sfz::Synth*>(synth);


### PR DESCRIPTION
This is so synth UIs can manipulate sfizz controllers with full precision.
New API: `sfizz_send_hdcc`

@rghvdberg