### PR TITLE
Voice lifecycle

### DIFF
--- a/benchmarks/BM_ADSR.cpp
+++ b/benchmarks/BM_ADSR.cpp
@@ -35,7 +35,7 @@ public:
     }
 
     sfz::MidiState midiState;
-    sfz::Region region{midiState};
+    sfz::Region region{0, midiState};
     sfz::ADSREnvelope<float> envelope;
     std::vector<float> output;
 };

--- a/src/sfizz/NumericId.h
+++ b/src/sfizz/NumericId.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+
+/**
+ * @brief Numeric identifier
+ *
+ * It is a generic numeric identifier. The template wrapper serves to enforce a
+ * stronger compile-time check, such that one kind of identifier can't be
+ * mistaken for another kind, or for an unrelated integer such as an index.
+ */
+template <class T>
+struct NumericId {
+    constexpr NumericId() = default;
+
+    explicit constexpr NumericId(int number)
+        : number(number)
+    {
+    }
+
+    constexpr bool valid() const noexcept
+    {
+        return number != -1;
+    }
+
+    const int number = -1;
+};

--- a/src/sfizz/NumericId.h
+++ b/src/sfizz/NumericId.h
@@ -27,5 +27,15 @@ struct NumericId {
         return number != -1;
     }
 
+    constexpr bool operator==(NumericId other) const noexcept
+    {
+        return number == other.number;
+    }
+
+    constexpr bool operator!=(NumericId other) const noexcept
+    {
+        return number != other.number;
+    }
+
     const int number = -1;
 };

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -16,6 +16,7 @@
 #include "AudioBuffer.h"
 #include "MidiState.h"
 #include "FileId.h"
+#include "NumericId.h"
 #include "absl/types/optional.h"
 #include <bitset>
 #include <string>
@@ -36,7 +37,7 @@ namespace sfz {
  */
 struct Region {
     Region(int regionNumber, const MidiState& midiState, absl::string_view defaultPath = "")
-    : regionNumber(regionNumber), midiState(midiState), defaultPath(std::move(defaultPath))
+    : id{regionNumber}, midiState(midiState), defaultPath(std::move(defaultPath))
     {
         ccSwitched.set();
 
@@ -49,9 +50,9 @@ struct Region {
     /**
      * @brief Get the number which identifies this region
      */
-    int getIdNumber() const noexcept
+    NumericId<Region> getId() const noexcept
     {
-        return regionNumber;
+        return id;
     }
 
     /**
@@ -246,7 +247,7 @@ struct Region {
      */
     float getGainToEffectBus(unsigned number) const noexcept;
 
-    const int regionNumber { -1 };
+    const NumericId<Region> id;
 
     // Sound source: sample playback
     FileId sampleId {}; // Sample

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -35,8 +35,8 @@ namespace sfz {
  *
  */
 struct Region {
-    Region(const MidiState& midiState, absl::string_view defaultPath = "")
-    : midiState(midiState), defaultPath(std::move(defaultPath))
+    Region(int regionNumber, const MidiState& midiState, absl::string_view defaultPath = "")
+    : regionNumber(regionNumber), midiState(midiState), defaultPath(std::move(defaultPath))
     {
         ccSwitched.set();
 
@@ -45,6 +45,14 @@ struct Region {
     }
     Region(const Region&) = default;
     ~Region() = default;
+
+    /**
+     * @brief Get the number which identifies this region, also its index
+     */
+    int getIdNumber() const noexcept
+    {
+        return regionNumber;
+    }
 
     /**
      * @brief Triggers on release?
@@ -237,6 +245,8 @@ struct Region {
      *        effect bus
      */
     float getGainToEffectBus(unsigned number) const noexcept;
+
+    const int regionNumber {};
 
     // Sound source: sample playback
     FileId sampleId {}; // Sample

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -47,7 +47,7 @@ struct Region {
     ~Region() = default;
 
     /**
-     * @brief Get the number which identifies this region, also its index
+     * @brief Get the number which identifies this region
      */
     int getIdNumber() const noexcept
     {
@@ -246,7 +246,7 @@ struct Region {
      */
     float getGainToEffectBus(unsigned number) const noexcept;
 
-    const int regionNumber {};
+    const int regionNumber { -1 };
 
     // Sound source: sample playback
     FileId sampleId {}; // Sample

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1056,6 +1056,40 @@ const sfz::EffectBus* sfz::Synth::getEffectBusView(int idx) const noexcept
     return (size_t)idx < effectBuses.size() ? effectBuses[idx].get() : nullptr;
 }
 
+const sfz::Region* sfz::Synth::getRegionById(NumericId<Region> id) const noexcept
+{
+    const size_t size = regions.size();
+
+    if (size == 0 || !id.valid())
+        return nullptr;
+
+    // search a sequence of ordered identifiers with potential gaps
+    size_t index = static_cast<size_t>(id.number);
+    index = std::min(index, size - 1);
+
+    while (index > 0 && regions[index]->getId().number > id.number)
+        --index;
+
+    return (regions[index]->getId() == id) ? regions[index].get() : nullptr;
+}
+
+const sfz::Voice* sfz::Synth::getVoiceById(NumericId<Voice> id) const noexcept
+{
+    const size_t size = voices.size();
+
+    if (size == 0 || !id.valid())
+        return nullptr;
+
+    // search a sequence of ordered identifiers with potential gaps
+    size_t index = static_cast<size_t>(id.number);
+    index = std::min(index, size - 1);
+
+    while (index > 0 && voices[index]->getId().number > id.number)
+        --index;
+
+    return (voices[index]->getId() == id) ? voices[index].get() : nullptr;
+}
+
 const sfz::Voice* sfz::Synth::getVoiceView(int idx) const noexcept
 {
     return (size_t)idx < voices.size() ? voices[idx].get() : nullptr;

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -44,6 +44,13 @@ sfz::Synth::~Synth()
     resources.filePool.emptyFileLoadingQueues();
 }
 
+void sfz::Synth::onVoiceStateChanged(int idNumber, Voice::State state)
+{
+    (void)idNumber;
+    (void)state;
+    DBG("Voice " << idNumber << ": state " << static_cast<int>(state));
+}
+
 void sfz::Synth::onParseFullBlock(const std::string& header, const std::vector<Opcode>& members)
 {
     switch (hash(header)) {
@@ -1094,8 +1101,11 @@ void sfz::Synth::resetVoices(int numVoices)
     voices.clear();
     voices.reserve(numVoices);
 
-    for (int i = 0; i < numVoices; ++i)
-        voices.push_back(absl::make_unique<Voice>(i, resources));
+    for (int i = 0; i < numVoices; ++i) {
+        auto voice = absl::make_unique<Voice>(i, resources);
+        voice->setStateListener(this);
+        voices.emplace_back(std::move(voice));
+    }
 
     voiceViewArray.clear();
     voiceViewArray.reserve(numVoices);

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -44,11 +44,11 @@ sfz::Synth::~Synth()
     resources.filePool.emptyFileLoadingQueues();
 }
 
-void sfz::Synth::onVoiceStateChanged(int idNumber, Voice::State state)
+void sfz::Synth::onVoiceStateChanged(NumericId<Voice> id, Voice::State state)
 {
-    (void)idNumber;
+    (void)id;
     (void)state;
-    DBG("Voice " << idNumber << ": state " << static_cast<int>(state));
+    DBG("Voice " << id.number << ": state " << static_cast<int>(state));
 }
 
 void sfz::Synth::onParseFullBlock(const std::string& header, const std::vector<Opcode>& members)

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -95,7 +95,8 @@ void sfz::Synth::onParseWarning(const SourceRange& range, const std::string& mes
 
 void sfz::Synth::buildRegion(const std::vector<Opcode>& regionOpcodes)
 {
-    auto lastRegion = absl::make_unique<Region>(resources.midiState, defaultPath);
+    int regionNumber = static_cast<int>(regions.size());
+    auto lastRegion = absl::make_unique<Region>(regionNumber, resources.midiState, defaultPath);
 
     auto parseOpcodes = [&](const std::vector<Opcode>& opcodes) {
         for (auto& opcode : opcodes) {
@@ -1094,7 +1095,7 @@ void sfz::Synth::resetVoices(int numVoices)
     voices.reserve(numVoices);
 
     for (int i = 0; i < numVoices; ++i)
-        voices.push_back(absl::make_unique<Voice>(resources));
+        voices.push_back(absl::make_unique<Voice>(i, resources));
 
     voiceViewArray.clear();
     voiceViewArray.reserve(numVoices);

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -179,6 +179,20 @@ public:
      */
     std::string exportMidnam(absl::string_view model = {}) const;
     /**
+     * @brief Find the region which is associated with the given identifier.
+     *
+     * @param id
+     * @return const Region*
+     */
+    const Region* getRegionById(NumericId<Region> id) const noexcept;
+    /**
+     * @brief Find the voice which is associated with the given identifier.
+     *
+     * @param id
+     * @return const Voice*
+     */
+    const Voice* getVoiceById(NumericId<Voice> id) const noexcept;
+    /**
      * @brief Get a raw view into a specific region. This is mostly used
      * for testing.
      *

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -60,7 +60,7 @@ namespace sfz {
  * The jack_client.cpp file contains examples of the most classical usage of the
  * synth and can be used as a reference.
  */
-class Synth final : public Parser::Listener {
+class Synth final : public Voice::StateListener, public Parser::Listener {
 public:
     /**
      * @brief Construct a new Synth object with no voices. If you want sound
@@ -492,6 +492,12 @@ public:
      * @return const std::vector<NoteNamePair>&
      */
     const std::vector<CCNamePair>& getCCLabels() const noexcept { return ccLabels; }
+
+protected:
+    /**
+     * @brief The voice callback which is called during a change of state.
+     */
+    void onVoiceStateChanged(int idNumber, Voice::State state) override;
 
 protected:
     /**

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -497,7 +497,7 @@ protected:
     /**
      * @brief The voice callback which is called during a change of state.
      */
-    void onVoiceStateChanged(int idNumber, Voice::State state) override;
+    void onVoiceStateChanged(NumericId<Voice> idNumber, Voice::State state) override;
 
 protected:
     /**

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -14,8 +14,8 @@
 #include "Interpolators.h"
 #include "absl/algorithm/container.h"
 
-sfz::Voice::Voice(sfz::Resources& resources)
-: resources(resources)
+sfz::Voice::Voice(int voiceNumber, sfz::Resources& resources)
+: voiceNumber(voiceNumber), resources(resources)
 {
     filters.reserve(config::filtersPerVoice);
     equalizers.reserve(config::eqsPerVoice);

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -15,7 +15,7 @@
 #include "absl/algorithm/container.h"
 
 sfz::Voice::Voice(int voiceNumber, sfz::Resources& resources)
-: voiceNumber(voiceNumber), stateListener(nullptr), resources(resources)
+: id{voiceNumber}, stateListener(nullptr), resources(resources)
 {
     filters.reserve(config::filtersPerVoice);
     equalizers.reserve(config::eqsPerVoice);
@@ -773,6 +773,6 @@ void sfz::Voice::switchState(State s)
     if (s != state) {
         state = s;
         if (stateListener)
-            stateListener->onVoiceStateChanged(voiceNumber, s);
+            stateListener->onVoiceStateChanged(id, s);
     }
 }

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -14,6 +14,7 @@
 #include "AudioSpan.h"
 #include "LeakDetector.h"
 #include "OnePoleFilter.h"
+#include "NumericId.h"
 #include "absl/types/span.h"
 #include <memory>
 #include <random>
@@ -41,12 +42,13 @@ public:
         NoteOff,
         CC
     };
+
     /**
-     * @brief Get the number which identifies this voice
+     * @brief Get the unique identifier of this voice in a synth
      */
-    int getIdNumber() const noexcept
+    NumericId<Voice> getId() const noexcept
     {
-        return voiceNumber;
+        return id;
     }
 
     enum class State {
@@ -56,7 +58,7 @@ public:
 
     class StateListener {
     public:
-        virtual void onVoiceStateChanged(int /*idNumber*/, State /*state*/) {}
+        virtual void onVoiceStateChanged(NumericId<Voice> /*id*/, State /*state*/) {}
     };
 
     /**
@@ -299,7 +301,7 @@ private:
      */
     void switchState(State s);
 
-    const int voiceNumber { -1 };
+    const NumericId<Voice> id;
     StateListener* stateListener = nullptr;
 
     Region* region { nullptr };

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -48,6 +48,22 @@ public:
     {
         return voiceNumber;
     }
+
+    enum class State {
+        idle,
+        playing
+    };
+
+    class StateListener {
+    public:
+        virtual void onVoiceStateChanged(int /*idNumber*/, State /*state*/) {}
+    };
+
+    /**
+     * @brief Sets the listener which is called when the voice state changes.
+     */
+    void setStateListener(StateListener *l) noexcept { stateListener = l; }
+
     /**
      * @brief Change the sample rate of the voice. This is used to compute all
      * pitch related transformations so it needs to be propagated from the synth
@@ -278,14 +294,16 @@ private:
     void setupOscillatorUnison();
     void updateChannelPowers(AudioSpan<float> buffer);
 
+    /**
+     * @brief Modify the voice state and notify any listeners.
+     */
+    void switchState(State s);
+
     const int voiceNumber {};
+    StateListener* stateListener = nullptr;
 
     Region* region { nullptr };
 
-    enum class State {
-        idle,
-        playing
-    };
     State state { State::idle };
     bool noteIsOff { false };
 

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -32,14 +32,22 @@ public:
     /**
      * @brief Construct a new voice with the midistate singleton
      *
+     * @param voiceNumber
      * @param midiState
      */
-    Voice(Resources& resources);
+    Voice(int voiceNumber, Resources& resources);
     enum class TriggerType {
         NoteOn,
         NoteOff,
         CC
     };
+    /**
+     * @brief Get the number which identifies this voice, its index
+     */
+    int getIdNumber() const noexcept
+    {
+        return voiceNumber;
+    }
     /**
      * @brief Change the sample rate of the voice. This is used to compute all
      * pitch related transformations so it needs to be propagated from the synth
@@ -269,6 +277,8 @@ private:
      */
     void setupOscillatorUnison();
     void updateChannelPowers(AudioSpan<float> buffer);
+
+    const int voiceNumber {};
 
     Region* region { nullptr };
 

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -42,7 +42,7 @@ public:
         CC
     };
     /**
-     * @brief Get the number which identifies this voice, its index
+     * @brief Get the number which identifies this voice
      */
     int getIdNumber() const noexcept
     {
@@ -299,7 +299,7 @@ private:
      */
     void switchState(State s);
 
-    const int voiceNumber {};
+    const int voiceNumber { -1 };
     StateListener* stateListener = nullptr;
 
     Region* region { nullptr };

--- a/tests/RegionActivationT.cpp
+++ b/tests/RegionActivationT.cpp
@@ -13,7 +13,7 @@ using namespace sfz::literals;
 TEST_CASE("Region activation", "Region tests")
 {
     sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
 
     region.parseOpcode({ "sample", "*sine" });
     SECTION("Basic state")

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -14,7 +14,7 @@ using namespace sfz::literals;
 TEST_CASE("[Region] Parsing opcodes")
 {
     sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
 
     SECTION("sample")
     {
@@ -1672,7 +1672,7 @@ TEST_CASE("[Region] Parsing opcodes")
 TEST_CASE("[Region] Non-conforming floating point values in integer opcodes")
 {
     sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "offset", "2014.5" });
     REQUIRE(region.offset == 2014);
     region.parseOpcode({ "pitch_keytrack", "-2.1" });

--- a/tests/RegionTriggersT.cpp
+++ b/tests/RegionTriggersT.cpp
@@ -13,7 +13,7 @@ using namespace sfz::literals;
 TEST_CASE("Basic triggers", "Region triggers")
 {
     sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
 
     region.parseOpcode({ "sample", "*sine" });
     SECTION("key")
@@ -130,7 +130,7 @@ TEST_CASE("Basic triggers", "Region triggers")
 TEST_CASE("Legato triggers", "Region triggers")
 {
     sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     SECTION("First note playing")
     {

--- a/tests/RegionValueComputationsT.cpp
+++ b/tests/RegionValueComputationsT.cpp
@@ -17,7 +17,7 @@ constexpr int numRandomTests { 64 };
 TEST_CASE("[Region] Crossfade in on key")
 {
 	sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "xfin_lokey", "1" });
     region.parseOpcode({ "xfin_hikey", "3" });
@@ -29,7 +29,7 @@ TEST_CASE("[Region] Crossfade in on key")
 TEST_CASE("[Region] Crossfade in on key - 2")
 {
 	sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "xfin_lokey", "1" });
     region.parseOpcode({ "xfin_hikey", "5" });
@@ -44,7 +44,7 @@ TEST_CASE("[Region] Crossfade in on key - 2")
 TEST_CASE("[Region] Crossfade in on key - gain")
 {
 	sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "xfin_lokey", "1" });
     region.parseOpcode({ "xfin_hikey", "5" });
@@ -59,7 +59,7 @@ TEST_CASE("[Region] Crossfade in on key - gain")
 TEST_CASE("[Region] Crossfade out on key")
 {
 	sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "xfout_lokey", "51" });
     region.parseOpcode({ "xfout_hikey", "55" });
@@ -75,7 +75,7 @@ TEST_CASE("[Region] Crossfade out on key")
 TEST_CASE("[Region] Crossfade out on key - gain")
 {
 	sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "xfout_lokey", "51" });
     region.parseOpcode({ "xfout_hikey", "55" });
@@ -92,7 +92,7 @@ TEST_CASE("[Region] Crossfade out on key - gain")
 TEST_CASE("[Region] Crossfade in on velocity")
 {
 	sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "xfin_lovel", "20" });
     region.parseOpcode({ "xfin_hivel", "24" });
@@ -109,7 +109,7 @@ TEST_CASE("[Region] Crossfade in on velocity")
 TEST_CASE("[Region] Crossfade in on vel - gain")
 {
 	sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "xfin_lovel", "20" });
     region.parseOpcode({ "xfin_hivel", "24" });
@@ -127,7 +127,7 @@ TEST_CASE("[Region] Crossfade in on vel - gain")
 TEST_CASE("[Region] Crossfade out on vel")
 {
 	sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "xfout_lovel", "51" });
     region.parseOpcode({ "xfout_hivel", "55" });
@@ -144,7 +144,7 @@ TEST_CASE("[Region] Crossfade out on vel")
 TEST_CASE("[Region] Crossfade out on vel - gain")
 {
 	sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "xfout_lovel", "51" });
     region.parseOpcode({ "xfout_hivel", "55" });
@@ -162,7 +162,7 @@ TEST_CASE("[Region] Crossfade out on vel - gain")
 TEST_CASE("[Region] Crossfade in on CC")
 {
 	sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "xfin_locc24", "20" });
     region.parseOpcode({ "xfin_hicc24", "24" });
@@ -186,7 +186,7 @@ TEST_CASE("[Region] Crossfade in on CC")
 TEST_CASE("[Region] Crossfade in on CC - gain")
 {
 	sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "xfin_locc24", "20" });
     region.parseOpcode({ "xfin_hicc24", "24" });
@@ -210,7 +210,7 @@ TEST_CASE("[Region] Crossfade in on CC - gain")
 TEST_CASE("[Region] Crossfade out on CC")
 {
 	sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "xfout_locc24", "20" });
     region.parseOpcode({ "xfout_hicc24", "24" });
@@ -234,7 +234,7 @@ TEST_CASE("[Region] Crossfade out on CC")
 TEST_CASE("[Region] Crossfade out on CC - gain")
 {
 	sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "xfout_locc24", "20" });
     region.parseOpcode({ "xfout_hicc24", "24" });
@@ -259,7 +259,7 @@ TEST_CASE("[Region] Crossfade out on CC - gain")
 TEST_CASE("[Region] Velocity bug for extreme values - veltrack at 0")
 {
     sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "amp_veltrack", "0" });
     REQUIRE(region.getNoteGain(64, 127_norm) == 1.0_a);
@@ -270,7 +270,7 @@ TEST_CASE("[Region] Velocity bug for extreme values - veltrack at 0")
 TEST_CASE("[Region] Velocity bug for extreme values - positive veltrack")
 {
     sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "amp_veltrack", "100" });
     REQUIRE(region.getNoteGain(64, 127_norm) == 1.0_a);
@@ -280,7 +280,7 @@ TEST_CASE("[Region] Velocity bug for extreme values - positive veltrack")
 TEST_CASE("[Region] Velocity bug for extreme values - negative veltrack")
 {
     sfz::MidiState midiState;
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "amp_veltrack", "-100" });
     REQUIRE(region.getNoteGain(64, 127_norm) == Approx(0.0).margin(0.0001));
@@ -291,7 +291,7 @@ TEST_CASE("[Region] rt_decay")
 {
     sfz::MidiState midiState;
     midiState.setSampleRate(1000);
-    sfz::Region region { midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "trigger", "release" });
     region.parseOpcode({ "rt_decay", "10" });
@@ -311,7 +311,7 @@ TEST_CASE("[Region] rt_decay")
 TEST_CASE("[Region] Base delay")
 {
     sfz::MidiState midiState;
-    sfz::Region region{ midiState };
+    sfz::Region region { 0, midiState };
     region.parseOpcode({ "sample", "*sine" });
     region.parseOpcode({ "delay", "10" });
     REQUIRE( region.getDelay() == 10.0f );

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -6,6 +6,7 @@
 
 #include "sfizz/Synth.h"
 #include "sfizz/SfzHelpers.h"
+#include "sfizz/NumericId.h"
 #include "catch2/catch.hpp"
 using namespace Catch::literals;
 using namespace sfz::literals;
@@ -461,4 +462,27 @@ TEST_CASE("[Synth] velcurve")
     REQUIRE( synth.getRegionView(1)->velocityCurve(64_norm) == 1.0_a );
     REQUIRE( synth.getRegionView(1)->velocityCurve(96_norm) == Approx(0.5f).margin(1e-2) );
     REQUIRE( synth.getRegionView(1)->velocityCurve(127_norm) == 0.0_a );
+}
+
+TEST_CASE("[Synth] Region by identifier")
+{
+    sfz::Synth synth;
+    synth.loadSfzString("regionByIdentifier.sfz", R"(
+<region>sample=*sine
+<region>sample=*sine
+<region>sample=doesNotExist.wav
+<region>sample=*sine
+<region>sample=doesNotExist.wav
+<region>sample=*sine
+)");
+
+    REQUIRE(synth.getNumRegions() == 4);
+    REQUIRE(synth.getRegionView(0) == synth.getRegionById(NumericId<sfz::Region>{0}));
+    REQUIRE(synth.getRegionView(1) == synth.getRegionById(NumericId<sfz::Region>{1}));
+    REQUIRE(nullptr == synth.getRegionById(NumericId<sfz::Region>{2}));
+    REQUIRE(synth.getRegionView(2) == synth.getRegionById(NumericId<sfz::Region>{3}));
+    REQUIRE(nullptr == synth.getRegionById(NumericId<sfz::Region>{4}));
+    REQUIRE(synth.getRegionView(3) == synth.getRegionById(NumericId<sfz::Region>{5}));
+    REQUIRE(nullptr == synth.getRegionById(NumericId<sfz::Region>{6}));
+    REQUIRE(nullptr == synth.getRegionById(NumericId<sfz::Region>{}));
 }


### PR DESCRIPTION
Follow up on the numbering PR #245
It's a suggestion to be able to track the lifecycle of voices globally.

The purpose is to allocate and free voice-specific resources in relation with the mod matrix.