### PR TITLE
Set a default build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set (PROJECT_DESCRIPTION "A library to load SFZ description files and use them t
 
 # External configuration CMake scripts
 set (CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include (BuildType)
 include (SfizzConfig)
 
 # Build Options

--- a/cmake/BuildType.cmake
+++ b/cmake/BuildType.cmake
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: BSD-3-Clause                                        #
+# Copyright (c) 2015-2017 Marcus D. Hanwell                                    #
+# Copyright (c) 2020      Jean Pierre Cimalando                                #
+#------------------------------------------------------------------------------#
+
+# Set a default build type if none was specified
+set(default_build_type "RelWithDebInfo")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+        STRING "Choose the type of build." FORCE)
+endif()
+
+# Set the possible values of build type for cmake-gui
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+    "MinSizeRel" "RelWithDebInfo")


### PR DESCRIPTION
Set a default build type.
If not set, the value will be `RelWithDebInfo`.

Motivation
- users don't get accidental Debug builds and the degraded sfizz experience from it
- benign asserts don't crash DAWs, such as size mismatchs which are corrected by `std::min`
- it's still a debuggable build that is able to provide helpful info
