### PR TITLE
GCSW drumkit bugs

### DIFF
--- a/src/sfizz/Curve.cpp
+++ b/src/sfizz/Curve.cpp
@@ -58,7 +58,7 @@ Curve Curve::buildCurveFromHeader(
 }
 
 Curve Curve::buildFromVelcurvePoints(
-    const std::vector<std::pair<uint8_t, float>>& points,
+    absl::Span<const std::pair<uint8_t, float>> points,
     Interpolator itp, bool invert)
 {
     Curve curve;

--- a/src/sfizz/Curve.cpp
+++ b/src/sfizz/Curve.cpp
@@ -57,6 +57,35 @@ Curve Curve::buildCurveFromHeader(
     return curve;
 }
 
+Curve Curve::buildFromVelcurvePoints(
+    const std::vector<std::pair<uint8_t, float>>& points,
+    Interpolator itp, bool invert)
+{
+    Curve curve;
+    bool fillStatus[NumValues] = {};
+    const Range<float> fullRange { -HUGE_VALF, +HUGE_VALF };
+
+    auto setPoint = [&curve, &fillStatus](int i, float x) {
+        curve._points[i] = x;
+        fillStatus[i] = true;
+    };
+
+    if (invert) {
+        setPoint(0, 1.0);
+        setPoint(NumValues - 1, 0.0);
+    } else {
+        setPoint(0, 0.0);
+        setPoint(NumValues - 1, 1.0);
+    }
+
+    for (const auto& point: points) {
+        setPoint(point.first, point.second);
+    }
+
+    curve.fill(itp, fillStatus);
+    return curve;
+}
+
 Curve Curve::buildPredefinedCurve(int index)
 {
     Curve curve;

--- a/src/sfizz/Curve.h
+++ b/src/sfizz/Curve.h
@@ -68,6 +68,17 @@ public:
         Interpolator itp = Interpolator::Linear, bool limit = false);
 
     /**
+     * @brief Build a curve based on sfz v1 "amp_velcurve_&" points
+     *
+     * @param points the points vector
+     * @param itp kind of interpolator to fill between values
+     * @param invert whether to invert the curve
+     */
+    static Curve buildFromVelcurvePoints(
+        const std::vector<std::pair<uint8_t, float>>& points,
+        Interpolator itp = Interpolator::Linear, bool invert = false);
+
+    /**
      * @brief Number of predefined curves
      */
     enum { NumPredefinedCurves = 7 };

--- a/src/sfizz/Curve.h
+++ b/src/sfizz/Curve.h
@@ -75,7 +75,7 @@ public:
      * @param invert whether to invert the curve
      */
     static Curve buildFromVelcurvePoints(
-        const std::vector<std::pair<uint8_t, float>>& points,
+        absl::Span<const std::pair<uint8_t, float>> points,
         Interpolator itp = Interpolator::Linear, bool invert = false);
 
     /**

--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -122,7 +122,7 @@ inline absl::optional<ValueType> readOpcode(absl::string_view value, const Range
     if (!absl::SimpleAtoi(value, &returnedValue)) {
         float floatValue;
         if (!absl::SimpleAtof(value, &floatValue))
-            return {};
+            return absl::nullopt;
         returnedValue = static_cast<int64_t>(floatValue);
     }
 
@@ -151,7 +151,7 @@ inline absl::optional<ValueType> readOpcode(absl::string_view value, const Range
     value = value.substr(0, numberEnd);
 
     float returnedValue;
-    if (!absl::SimpleAtof(value.substr(0, numberEnd), &returnedValue))
+    if (!absl::SimpleAtof(value, &returnedValue))
 		return absl::nullopt;
 
     return validRange.clamp(returnedValue);

--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -115,20 +115,23 @@ private:
 template <typename ValueType, absl::enable_if_t<std::is_integral<ValueType>::value, int> = 0>
 inline absl::optional<ValueType> readOpcode(absl::string_view value, const Range<ValueType>& validRange)
 {
-        int64_t returnedValue;
-        if (!absl::SimpleAtoi(value, &returnedValue)) {
-            float floatValue;
-            if (!absl::SimpleAtof(value, &floatValue))
-                return {};
-            returnedValue = static_cast<int64_t>(floatValue);
-        }
+    const auto numberEnd = value.find_first_not_of("-1234567890.");
+    value = value.substr(0, numberEnd);
 
-        if (returnedValue > std::numeric_limits<ValueType>::max())
-            returnedValue = std::numeric_limits<ValueType>::max();
-        if (returnedValue < std::numeric_limits<ValueType>::min())
-            returnedValue = std::numeric_limits<ValueType>::min();
+    int64_t returnedValue;
+    if (!absl::SimpleAtoi(value, &returnedValue)) {
+        float floatValue;
+        if (!absl::SimpleAtof(value, &floatValue))
+            return {};
+        returnedValue = static_cast<int64_t>(floatValue);
+    }
 
-        return validRange.clamp(static_cast<ValueType>(returnedValue));
+    if (returnedValue > std::numeric_limits<ValueType>::max())
+        returnedValue = std::numeric_limits<ValueType>::max();
+    if (returnedValue < std::numeric_limits<ValueType>::min())
+        returnedValue = std::numeric_limits<ValueType>::min();
+
+    return validRange.clamp(static_cast<ValueType>(returnedValue));
 }
 
 /**
@@ -144,8 +147,11 @@ inline absl::optional<ValueType> readOpcode(absl::string_view value, const Range
 template <typename ValueType, absl::enable_if_t<std::is_floating_point<ValueType>::value, int> = 0>
 inline absl::optional<ValueType> readOpcode(absl::string_view value, const Range<ValueType>& validRange)
 {
+    const auto numberEnd = value.find_first_not_of("-1234567890.");
+    value = value.substr(0, numberEnd);
+
     float returnedValue;
-    if (!absl::SimpleAtof(value, &returnedValue))
+    if (!absl::SimpleAtof(value.substr(0, numberEnd), &returnedValue))
 		return absl::nullopt;
 
     return validRange.clamp(returnedValue);

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -6,6 +6,7 @@
 
 #pragma once
 #include "CCMap.h"
+#include "Curve.h"
 #include "LeakDetector.h"
 #include "Defaults.h"
 #include "EGDescription.h"
@@ -304,7 +305,8 @@ struct Region {
     uint8_t ampKeycenter { Default::ampKeycenter }; // amp_keycenter
     float ampKeytrack { Default::ampKeytrack }; // amp_keytrack
     float ampVeltrack { Default::ampVeltrack }; // amp_keytrack
-    std::vector<std::pair<float, float>> velocityPoints; // amp_velcurve_N
+    std::vector<std::pair<uint8_t, float>> velocityPoints; // amp_velcurve_N
+    absl::optional<Curve> velCurve {};
     float ampRandom { Default::ampRandom }; // amp_random
     Range<uint8_t> crossfadeKeyInRange { Default::crossfadeKeyInRange };
     Range<uint8_t> crossfadeKeyOutRange { Default::crossfadeKeyOutRange };

--- a/tests/FilesT.cpp
+++ b/tests/FilesT.cpp
@@ -346,14 +346,12 @@ TEST_CASE("[Files] wrong (overlapping) replacement for defines")
 
     REQUIRE( synth.getNumRegions() == 3 );
 
-#if 0
     // Note: test checked to be wrong under Sforzando 1.961
     //       It is the shorter matching $-variable which matches among both.
     //       The rest of the variable name creates some trailing junk text
-    //       which Sforzando accepts without warning. (eg. `key=52Edge`)
-    REQUIRE( synth.getRegionView(0)->keyRange.getStart() == 52 );
-    REQUIRE( synth.getRegionView(0)->keyRange.getEnd() == 52 );
-#endif
+    //       which Sforzando accepts without warning. (eg. `key=57Edge`)
+    REQUIRE( synth.getRegionView(0)->keyRange.getStart() == 57 );
+    REQUIRE( synth.getRegionView(0)->keyRange.getEnd() == 57 );
 
     REQUIRE( synth.getRegionView(1)->keyRange.getStart() == 57 );
     REQUIRE( synth.getRegionView(1)->keyRange.getEnd() == 57 );

--- a/tests/OpcodeT.cpp
+++ b/tests/OpcodeT.cpp
@@ -246,3 +246,20 @@ TEST_CASE("[Opcode] Normalization")
 
     REQUIRE(sfz::Opcode("SaMpLe", "").cleanUp(sfz::kOpcodeScopeRegion).opcode == "sample");
 }
+
+TEST_CASE("[Opcode] readOpcode")
+{
+    REQUIRE( sfz::readOpcode("16", sfz::Range<uint8_t>(0, 100)).value() == 16 );
+    REQUIRE( sfz::readOpcode("110", sfz::Range<uint8_t>(0, 100)).value() == 100 );
+    REQUIRE( sfz::readOpcode("-1", sfz::Range<uint8_t>(0, 100)).value() == 0 );
+    REQUIRE( sfz::readOpcode("12.5", sfz::Range<int>(-100, 100)).value() == 12 );
+    REQUIRE( sfz::readOpcode("-40", sfz::Range<int>(-100, 100)).value() == -40 );
+    REQUIRE( sfz::readOpcode("-140", sfz::Range<int>(-100, 100)).value() == -100 );
+    REQUIRE( sfz::readOpcode("12.5", sfz::Range<float>(0.0f, 100.0f)).value() == 12.5_a );
+    REQUIRE( sfz::readOpcode("-22.5", sfz::Range<float>(-20.0f, 100.0f)).value() == -20.0_a );
+    REQUIRE( sfz::readOpcode("150.5", sfz::Range<float>(-20.0f, 100.0f)).value() == 100.0_a );
+    REQUIRE( sfz::readOpcode("50.25garbage", sfz::Range<float>(-20.0f, 100.0f)).value() == 50.25_a );
+    REQUIRE( sfz::readOpcode("50.25garbage", sfz::Range<int>(-20, 100)).value() == 50 );
+    REQUIRE( !sfz::readOpcode("garbage50.25", sfz::Range<int>(-20, 100)) );
+    REQUIRE( !sfz::readOpcode("garbage", sfz::Range<int>(-20, 100)) );
+}

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -694,9 +694,13 @@ TEST_CASE("[Region] Parsing opcodes")
     SECTION("amp_velcurve")
     {
         region.parseOpcode({ "amp_velcurve_6", "0.4" });
-        REQUIRE(region.velocityPoints.back() == std::make_pair<float, float>(6_norm, 0.4f));
+        REQUIRE(region.velocityPoints.back() == std::pair<uint8_t, float>(6, 0.4f));
         region.parseOpcode({ "amp_velcurve_127", "-1.0" });
-        REQUIRE(region.velocityPoints.back() == std::make_pair<float, float>(127_norm, 0.0f));
+        REQUIRE(region.velocityPoints.back() == std::pair<uint8_t, float>(127, 0.0f));
+        region.parseOpcode({ "amp_velcurve_008", "0.3" });
+        REQUIRE(region.velocityPoints.back() == std::pair<uint8_t, float>(8, 0.3f));
+        region.parseOpcode({ "amp_velcurve_064", "0.9" });
+        REQUIRE(region.velocityPoints.back() == std::pair<uint8_t, float>(64, 0.9f));
     }
 
     SECTION("xfin_lokey, xfin_hikey")

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -434,3 +434,31 @@ TEST_CASE("[Synth] Basic curves")
     // Default linear
     REQUIRE( curves.getCurve(16).evalCC7(63) == Approx(63_norm) );
 }
+
+TEST_CASE("[Synth] Velocity points")
+{
+    sfz::Synth synth;
+    synth.loadSfzFile(fs::current_path() / "tests/TestFiles/velocity_endpoints.sfz");
+    REQUIRE( !synth.getRegionView(0)->velocityPoints.empty());
+    REQUIRE( synth.getRegionView(0)->velocityPoints[0].first == 64 );
+    REQUIRE( synth.getRegionView(0)->velocityPoints[0].second == 1.0_a );
+    REQUIRE( !synth.getRegionView(1)->velocityPoints.empty());
+    REQUIRE( synth.getRegionView(1)->velocityPoints[0].first == 64 );
+    REQUIRE( synth.getRegionView(1)->velocityPoints[0].second == 1.0_a );
+}
+
+TEST_CASE("[Synth] velcurve")
+{
+    sfz::Synth synth;
+    synth.loadSfzFile(fs::current_path() / "tests/TestFiles/velocity_endpoints.sfz");
+    REQUIRE( synth.getRegionView(0)->velocityCurve(0_norm) == 0.0_a );
+    REQUIRE( synth.getRegionView(0)->velocityCurve(32_norm) == Approx(0.5f).margin(1e-2) );
+    REQUIRE( synth.getRegionView(0)->velocityCurve(64_norm) == 1.0_a );
+    REQUIRE( synth.getRegionView(0)->velocityCurve(96_norm) == 1.0_a );
+    REQUIRE( synth.getRegionView(0)->velocityCurve(127_norm) == 1.0_a );
+    REQUIRE( synth.getRegionView(1)->velocityCurve(0_norm) == 1.0_a );
+    REQUIRE( synth.getRegionView(1)->velocityCurve(32_norm) == 1.0_a );
+    REQUIRE( synth.getRegionView(1)->velocityCurve(64_norm) == 1.0_a );
+    REQUIRE( synth.getRegionView(1)->velocityCurve(96_norm) == Approx(0.5f).margin(1e-2) );
+    REQUIRE( synth.getRegionView(1)->velocityCurve(127_norm) == 0.0_a );
+}

--- a/tests/TestFiles/velocity_endpoints.sfz
+++ b/tests/TestFiles/velocity_endpoints.sfz
@@ -1,0 +1,2 @@
+<region> amp_velcurve_064=1 sample=*sine
+<region> amp_velcurve_064=1 amp_veltrack=-100 sample=*sine


### PR DESCRIPTION
- Corrected a bug with sfz v1 velcurve. I made it use the Curve facilities now.
- When you encounter something like `key=64Garbage`, it seems that ARIA actually reads `key=64` and ignores the `Garbage`. 