### PR TITLE
Prep work for finer polyphony control

### DIFF
--- a/lv2/sfizz.ttl.in
+++ b/lv2/sfizz.ttl.in
@@ -129,7 +129,7 @@ midnam:update a lv2:Feature .
     lv2:portProperty pprop:expensive ;
     lv2:portProperty lv2:integer ;
     lv2:portProperty lv2:enumeration ;
-    lv2:default 256 ;
+    lv2:default 64 ;
     lv2:minimum 8 ;
     lv2:maximum 256 ;
     lv2:scalePoint [ rdfs:label "8 voices",
@@ -161,11 +161,6 @@ midnam:update a lv2:Feature .
       "256 voix"@fr ,
       "256 Voci"@it;
       rdf:value 256
-    ] ;
-    lv2:scalePoint [ rdfs:label "512 voices",
-      "512 voix"@fr ,
-      "512 Voci"@it;
-      rdf:value 512
     ] ;
   ] , [
     a lv2:InputPort, lv2:ControlPort ;

--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -37,8 +37,8 @@ namespace config {
     constexpr bool loggingEnabled { false };
     constexpr size_t numChannels { 2 };
     constexpr int numBackgroundThreads { 4 };
-    constexpr int numVoices { 256 };
-    constexpr unsigned maxVoices { 512 };
+    constexpr int numVoices { 64 };
+    constexpr unsigned maxVoices { 256 };
     constexpr int maxFilePromises { maxVoices };
     constexpr int sustainCC { 64 };
     constexpr int allSoundOffCC { 120 };

--- a/src/sfizz/Group.h
+++ b/src/sfizz/Group.h
@@ -1,0 +1,47 @@
+#pragma once
+#include "Region.h"
+#include "Voice.h"
+#include <vector>
+
+namespace sfz
+{
+
+class Group {
+public:
+    void setPolyphonyLimit(unsigned limit);
+    unsigned getPolyphonyLimit() { return polyphonyLimit; }
+    void addRegion(Region* region)
+    {
+        if (absl::c_find(regions, region) == regions.end())
+            regions.push_back(region);
+    }
+    void addSubgroup(Group* group)
+    {
+        if (absl::c_find(subgroups, group) == subgroups.end())
+            subgroups.push_back(group);
+    }
+    void registerVoice(Voice* voice)
+    {
+        if (absl::c_find(voices, voice) == voices.end())
+            voices.push_back(voice);
+    }
+    void removeVoice(Voice* voice)
+    {
+        auto it = absl::c_find(voices, voice);
+        if (it != voices.end()) {
+            std::iter_swap(it, voices.rbegin().base());
+            voices.pop_back();
+        }
+    }
+    const std::vector<Voice*>& getActiveVoices() { return voices; }
+    const std::vector<Region*>& getRegions() { return regions; }
+    const std::vector<Group*>& getSubgroups() { return subgroups; }
+private:
+    Group* parent { nullptr };
+    std::vector<Region*> regions;
+    std::vector<Group*> subgroups;
+    std::vector<Voice*> voices;
+    unsigned polyphonyLimit;
+};
+
+}

--- a/src/sfizz/PolyphonyGroup.h
+++ b/src/sfizz/PolyphonyGroup.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "Region.h"
+#include "Voice.h"
+#include "absl/algorithm/container.h"
+
+namespace sfz
+{
+class PolyphonyGroup {
+public:
+    PolyphonyGroup() = delete;
+    PolyphonyGroup(unsigned id)
+    : id(id) {}
+    void setPolyphonyLimit(unsigned limit)
+    {
+        polyphonyLimit = limit;
+        voices.reserve(limit);
+    }
+    unsigned getPolyphonyLimit() { return polyphonyLimit; }
+    unsigned getID() const { return id; }
+    void addRegion(Region* region)
+    {
+        if (absl::c_find(regions, region) == regions.end())
+            regions.push_back(region);
+    }
+    void addVoice(Voice* voice)
+    {
+        if (absl::c_find(voices, voice) == voices.end())
+            voices.push_back(voice);
+    }
+private:
+    unsigned id;
+    unsigned polyphonyLimit;
+    std::vector<Voice*> voices;
+    std::vector<Region*> regions;
+};
+
+}

--- a/src/sfizz/PolyphonyGroup.h
+++ b/src/sfizz/PolyphonyGroup.h
@@ -13,14 +13,22 @@ public:
         voices.reserve(limit);
     }
     unsigned getPolyphonyLimit() const { return polyphonyLimit; }
-    void addVoice(Voice* voice)
+    void registerVoice(Voice* voice)
     {
         if (absl::c_find(voices, voice) == voices.end())
             voices.push_back(voice);
     }
+    void removeVoice(Voice* voice)
+    {
+        auto it = absl::c_find(voices, voice);
+        if (it != voices.end()) {
+            std::iter_swap(it, voices.rbegin().base());
+            voices.pop_back();
+        }
+    }
     const std::vector<Voice*>& getActiveVoices() const { return voices; }
 private:
-    unsigned polyphonyLimit;
+    unsigned polyphonyLimit { config::maxVoices };
     std::vector<Voice*> voices;
 };
 

--- a/src/sfizz/PolyphonyGroup.h
+++ b/src/sfizz/PolyphonyGroup.h
@@ -15,7 +15,7 @@ public:
         polyphonyLimit = limit;
         voices.reserve(limit);
     }
-    unsigned getPolyphonyLimit() { return polyphonyLimit; }
+    unsigned getPolyphonyLimit() const { return polyphonyLimit; }
     unsigned getID() const { return id; }
     void addRegion(Region* region)
     {
@@ -27,6 +27,7 @@ public:
         if (absl::c_find(voices, voice) == voices.end())
             voices.push_back(voice);
     }
+    const std::vector<Voice*>& getActiveVoices() const { return voices; }
 private:
     unsigned id;
     unsigned polyphonyLimit;

--- a/src/sfizz/PolyphonyGroup.h
+++ b/src/sfizz/PolyphonyGroup.h
@@ -7,21 +7,12 @@ namespace sfz
 {
 class PolyphonyGroup {
 public:
-    PolyphonyGroup() = delete;
-    PolyphonyGroup(unsigned id)
-    : id(id) {}
     void setPolyphonyLimit(unsigned limit)
     {
         polyphonyLimit = limit;
         voices.reserve(limit);
     }
     unsigned getPolyphonyLimit() const { return polyphonyLimit; }
-    unsigned getID() const { return id; }
-    void addRegion(Region* region)
-    {
-        if (absl::c_find(regions, region) == regions.end())
-            regions.push_back(region);
-    }
     void addVoice(Voice* voice)
     {
         if (absl::c_find(voices, voice) == voices.end())
@@ -29,10 +20,8 @@ public:
     }
     const std::vector<Voice*>& getActiveVoices() const { return voices; }
 private:
-    unsigned id;
     unsigned polyphonyLimit;
     std::vector<Voice*> voices;
-    std::vector<Region*> regions;
 };
 
 }

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -155,6 +155,10 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
             DBG("Unkown off mode:" << std::string(opcode.value));
         }
         break;
+    case hash("polyphony"):
+        if (auto value = readOpcode(opcode.value, Default::polyphonyRange))
+            polyphony = *value;
+        break;
     case hash("note_polyphony"):
         if (auto value = readOpcode(opcode.value, Default::polyphonyRange))
             notePolyphony = *value;

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -23,6 +23,9 @@
 #include <vector>
 
 namespace sfz {
+
+class RegionSet;
+
 /**
  * @brief Regions are the basic building blocks for the SFZ parsing and handling code.
  * All SFZ files are made of regions that are activated when a key is pressed or a CC
@@ -357,6 +360,8 @@ struct Region {
     // Effects
     std::vector<float> gainToEffect;
 
+    // Parent
+    RegionSet* parent { nullptr };
 private:
     const MidiState& midiState;
     bool keySwitched { true };

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -275,7 +275,8 @@ struct Region {
     uint32_t group { Default::group }; // group
     absl::optional<uint32_t> offBy {}; // off_by
     SfzOffMode offMode { Default::offMode }; // off_mode
-    absl::optional<uint32_t> notePolyphony {};
+    absl::optional<uint32_t> notePolyphony {}; // note_polyphony
+    unsigned polyphony { config::maxVoices };
     SfzSelfMask selfMask { Default::selfMask };
 
     // Region logic: key mapping

--- a/src/sfizz/RegionSet.h
+++ b/src/sfizz/RegionSet.h
@@ -8,7 +8,7 @@ namespace sfz
 
 class RegionSet {
 public:
-    void setPolyphonyLimit(unsigned limit);
+    void setPolyphonyLimit(unsigned limit) { polyphonyLimit = limit; }
     unsigned getPolyphonyLimit() { return polyphonyLimit; }
     void addRegion(Region* region)
     {

--- a/src/sfizz/RegionSet.h
+++ b/src/sfizz/RegionSet.h
@@ -6,7 +6,7 @@
 namespace sfz
 {
 
-class Group {
+class RegionSet {
 public:
     void setPolyphonyLimit(unsigned limit);
     unsigned getPolyphonyLimit() { return polyphonyLimit; }
@@ -15,7 +15,7 @@ public:
         if (absl::c_find(regions, region) == regions.end())
             regions.push_back(region);
     }
-    void addSubgroup(Group* group)
+    void addSubgroup(RegionSet* group)
     {
         if (absl::c_find(subgroups, group) == subgroups.end())
             subgroups.push_back(group);
@@ -35,11 +35,11 @@ public:
     }
     const std::vector<Voice*>& getActiveVoices() { return voices; }
     const std::vector<Region*>& getRegions() { return regions; }
-    const std::vector<Group*>& getSubgroups() { return subgroups; }
+    const std::vector<RegionSet*>& getSubgroups() { return subgroups; }
 private:
-    Group* parent { nullptr };
+    RegionSet* parent { nullptr };
     std::vector<Region*> regions;
-    std::vector<Group*> subgroups;
+    std::vector<RegionSet*> subgroups;
     std::vector<Voice*> voices;
     unsigned polyphonyLimit;
 };

--- a/src/sfizz/RegionSet.h
+++ b/src/sfizz/RegionSet.h
@@ -8,8 +8,12 @@ namespace sfz
 
 class RegionSet {
 public:
-    void setPolyphonyLimit(unsigned limit) { polyphonyLimit = limit; }
-    unsigned getPolyphonyLimit() { return polyphonyLimit; }
+    void setPolyphonyLimit(unsigned limit)
+    {
+        polyphonyLimit = limit;
+        voices.reserve(limit);
+    }
+    unsigned getPolyphonyLimit() const { return polyphonyLimit; }
     void addRegion(Region* region)
     {
         if (absl::c_find(regions, region) == regions.end())
@@ -43,7 +47,7 @@ private:
     std::vector<Region*> regions;
     std::vector<RegionSet*> subsets;
     std::vector<Voice*> voices;
-    unsigned polyphonyLimit;
+    unsigned polyphonyLimit { config::maxVoices };
 };
 
 }

--- a/src/sfizz/RegionSet.h
+++ b/src/sfizz/RegionSet.h
@@ -15,10 +15,10 @@ public:
         if (absl::c_find(regions, region) == regions.end())
             regions.push_back(region);
     }
-    void addSubgroup(RegionSet* group)
+    void addSubset(RegionSet* group)
     {
-        if (absl::c_find(subgroups, group) == subgroups.end())
-            subgroups.push_back(group);
+        if (absl::c_find(subsets, group) == subsets.end())
+            subsets.push_back(group);
     }
     void registerVoice(Voice* voice)
     {
@@ -33,13 +33,14 @@ public:
             voices.pop_back();
         }
     }
+    RegionSet* getParent() { return parent; }
     const std::vector<Voice*>& getActiveVoices() { return voices; }
     const std::vector<Region*>& getRegions() { return regions; }
-    const std::vector<RegionSet*>& getSubgroups() { return subgroups; }
+    const std::vector<RegionSet*>& getSubsets() { return subsets; }
 private:
     RegionSet* parent { nullptr };
     std::vector<Region*> regions;
-    std::vector<RegionSet*> subgroups;
+    std::vector<RegionSet*> subsets;
     std::vector<Voice*> voices;
     unsigned polyphonyLimit;
 };

--- a/src/sfizz/RegionSet.h
+++ b/src/sfizz/RegionSet.h
@@ -33,10 +33,11 @@ public:
             voices.pop_back();
         }
     }
-    RegionSet* getParent() { return parent; }
-    const std::vector<Voice*>& getActiveVoices() { return voices; }
-    const std::vector<Region*>& getRegions() { return regions; }
-    const std::vector<RegionSet*>& getSubsets() { return subsets; }
+    RegionSet* getParent() const { return parent; }
+    void setParent(RegionSet* parent) { this->parent = parent; }
+    const std::vector<Voice*>& getActiveVoices() const { return voices; }
+    const std::vector<Region*>& getRegions() const { return regions; }
+    const std::vector<RegionSet*>& getSubsets() const { return subsets; }
 private:
     RegionSet* parent { nullptr };
     std::vector<Region*> regions;

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -144,6 +144,10 @@ void sfz::Synth::buildRegion(const std::vector<Opcode>& regionOpcodes)
     if (octaveOffset != 0 || noteOffset != 0)
         lastRegion->offsetAllKeys(octaveOffset * 12 + noteOffset);
 
+    // There was a combination of group= and polyphony= on a region, so set the group polyphony
+    if (lastRegion->group != Default::group && lastRegion->polyphony != config::maxVoices)
+        setGroupPolyphony(lastRegion->group, lastRegion->polyphony);
+
     lastRegion->parent = currentSet;
     currentSet->addRegion(lastRegion.get());
     regions.push_back(std::move(lastRegion));

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1296,8 +1296,11 @@ void sfz::Synth::resetVoices(int numVoices)
 
     overflowVoices.clear();
     overflowVoices.reserve(numVoices);
-    for (int i = 0; i < numVoices; ++i)
-        overflowVoices.push_back(absl::make_unique<Voice>(resources));
+    for (int i = 0; i < numVoices; ++i) {
+        auto voice = absl::make_unique<Voice>(numVoices + i, resources);
+        voice->setStateListener(this);
+        overflowVoices.push_back(std::move(voice));
+    }
 
     for (auto& voice : overflowVoices) {
         voice->setSampleRate(this->sampleRate);

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1125,6 +1125,11 @@ const sfz::Region* sfz::Synth::getRegionView(int idx) const noexcept
     return (size_t)idx < regions.size() ? regions[idx].get() : nullptr;
 }
 
+const sfz::RegionSet* sfz::Synth::getRegionSetView(int idx) const noexcept
+{
+    return (size_t)idx < sets.size() ? sets[idx].get() : nullptr;
+}
+
 const sfz::EffectBus* sfz::Synth::getEffectBusView(int idx) const noexcept
 {
     return (size_t)idx < effectBuses.size() ? effectBuses[idx].get() : nullptr;

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -52,9 +52,21 @@ void sfz::Synth::onVoiceStateChanged(NumericId<Voice> id, Voice::State state)
 
 void sfz::Synth::onParseFullBlock(const std::string& header, const std::vector<Opcode>& members)
 {
+    const auto newRegionSet = [&]() {
+        sets.emplace_back(new RegionSet);
+        auto newSet = sets.back().get();
+        auto parentSet = currentSet->getParent();
+        ASSERT(parentSet != nullptr);
+        if (parentSet == nullptr)
+            parentSet = sets.front().get();
+        parentSet->addSubset(newSet);
+        currentSet = newSet;
+    };
+
     switch (hash(header)) {
     case hash("global"):
         globalOpcodes = members;
+        currentSet = sets.front().get();
         groupOpcodes.clear();
         masterOpcodes.clear();
         handleGlobalOpcodes(members);
@@ -65,11 +77,13 @@ void sfz::Synth::onParseFullBlock(const std::string& header, const std::vector<O
         break;
     case hash("master"):
         masterOpcodes = members;
+        newRegionSet();
         groupOpcodes.clear();
         numMasters++;
         break;
     case hash("group"):
         groupOpcodes = members;
+        newRegionSet();
         handleGroupOpcodes(members, masterOpcodes);
         numGroups++;
         break;
@@ -101,6 +115,7 @@ void sfz::Synth::onParseWarning(const SourceRange& range, const std::string& mes
 
 void sfz::Synth::buildRegion(const std::vector<Opcode>& regionOpcodes)
 {
+    ASSERT(currentSet != nullptr);
     int regionNumber = static_cast<int>(regions.size());
     auto lastRegion = absl::make_unique<Region>(regionNumber, resources.midiState, defaultPath);
 
@@ -124,6 +139,8 @@ void sfz::Synth::buildRegion(const std::vector<Opcode>& regionOpcodes)
     if (octaveOffset != 0 || noteOffset != 0)
         lastRegion->offsetAllKeys(octaveOffset * 12 + noteOffset);
 
+    lastRegion->parent = currentSet;
+    currentSet->addRegion(lastRegion.get());
     regions.push_back(std::move(lastRegion));
 }
 
@@ -139,6 +156,9 @@ void sfz::Synth::clear()
     for (auto& list : ccActivationLists)
         list.clear();
 
+    sets.clear();
+    sets.emplace_back(new RegionSet);
+    currentSet = sets.front().get();
     regions.clear();
     effectBuses.clear();
     effectBuses.emplace_back(new EffectBus);

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -542,14 +542,14 @@ sfz::Voice* sfz::Synth::findFreeVoice() noexcept
         return freeVoice->get();
 
     // Start of the voice stealing algorithm
-    absl::c_sort(voiceViewArray, voiceOrdering);
+    absl::c_sort(voiceViewVector, voiceOrdering);
 
-    const auto sumEnvelope = absl::c_accumulate(voiceViewArray, 0.0f, [](float sum, const Voice* v) {
+    const auto sumEnvelope = absl::c_accumulate(voiceViewVector, 0.0f, [](float sum, const Voice* v) {
         return sum + v->getAverageEnvelope();
     });
     const auto envThreshold = sumEnvelope
-        / static_cast<float>(voiceViewArray.size()) * config::stealingEnvelopeCoeff;
-    const auto ageThreshold = voiceViewArray.front()->getAge() * config::stealingAgeCoeff;
+        / static_cast<float>(voiceViewVector.size()) * config::stealingEnvelopeCoeff;
+    const auto ageThreshold = voiceViewVector.front()->getAge() * config::stealingAgeCoeff;
 
     auto tempSpan = resources.bufferPool.getStereoBuffer(samplesPerBlock);
     const auto killVoice = [&] (Voice* v) {
@@ -557,18 +557,18 @@ sfz::Voice* sfz::Synth::findFreeVoice() noexcept
         v->reset();
     };
 
-    Voice* returnedVoice = voiceViewArray.front();
+    Voice* returnedVoice = voiceViewVector.front();
     unsigned idx = 0;
-    while (idx < voiceViewArray.size()) {
+    while (idx < voiceViewVector.size()) {
         const auto refIdx = idx;
-        const auto ref = voiceViewArray[idx];
+        const auto ref = voiceViewVector[idx];
         idx++;
 
         if (ref->getAge() < ageThreshold) {
             unsigned killIdx = 1;
-            while (killIdx < voiceViewArray.size()
-                    && sisterVoices(returnedVoice, voiceViewArray[killIdx])) {
-                killVoice(voiceViewArray[killIdx]);
+            while (killIdx < voiceViewVector.size()
+                    && sisterVoices(returnedVoice, voiceViewVector[killIdx])) {
+                killVoice(voiceViewVector[killIdx]);
                 killIdx++;
             }
             // std::cout << "Went too far, picking the oldest voice and killing "
@@ -578,9 +578,9 @@ sfz::Voice* sfz::Synth::findFreeVoice() noexcept
         }
 
         float maxEnvelope = ref->getAverageEnvelope();
-        while (idx < voiceViewArray.size()
-                && sisterVoices(ref, voiceViewArray[idx])) {
-            maxEnvelope = max(maxEnvelope, voiceViewArray[idx]->getAverageEnvelope());
+        while (idx < voiceViewVector.size()
+                && sisterVoices(ref, voiceViewVector[idx])) {
+            maxEnvelope = max(maxEnvelope, voiceViewVector[idx]->getAverageEnvelope());
             idx++;
         }
 
@@ -588,7 +588,7 @@ sfz::Voice* sfz::Synth::findFreeVoice() noexcept
             returnedVoice = ref;
             // std::cout << "Killing " << idx - refIdx << " voices" << '\n';
             for (unsigned j = refIdx; j < idx; j++) {
-                killVoice(voiceViewArray[j]);
+                killVoice(voiceViewVector[j]);
             }
             break;
         }
@@ -1151,13 +1151,13 @@ void sfz::Synth::resetVoices(int numVoices)
         voices.emplace_back(std::move(voice));
     }
 
-    voiceViewArray.clear();
-    voiceViewArray.reserve(numVoices);
+    voiceViewVector.clear();
+    voiceViewVector.reserve(numVoices);
 
     for (auto& voice : voices) {
         voice->setSampleRate(this->sampleRate);
         voice->setSamplesPerBlock(this->samplesPerBlock);
-        voiceViewArray.push_back(voice.get());
+        voiceViewVector.push_back(voice.get());
     }
 
     overflowVoices.clear();

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -9,6 +9,8 @@
 #include "Parser.h"
 #include "Voice.h"
 #include "Region.h"
+#include "Group.h"
+#include "PolyphonyGroup.h"
 #include "Effects.h"
 #include "LeakDetector.h"
 #include "MidiState.h"
@@ -659,11 +661,17 @@ private:
     using RegionViewVector = std::vector<Region*>;
     using VoiceViewVector = std::vector<Voice*>;
     using VoicePtr = std::unique_ptr<Voice>;
-    std::vector<std::unique_ptr<Region>> regions;
-    std::vector<std::unique_ptr<Voice>> voices;
-    std::vector<std::unique_ptr<Voice>> overflowVoices;
-    // Views to speed up iteration over the regions and voices when events
-    // occur in the audio callback
+    using RegionPtr = std::unique_ptr<Region>;
+    using GroupPtr = std::unique_ptr<Group>;
+    using PolyphonyGroupPtr = std::unique_ptr<PolyphonyGroup>;
+    std::vector<RegionPtr> regions;
+    std::vector<VoicePtr> voices;
+    std::vector<VoicePtr> overflowVoices;
+    // These are more general "groups" than sfz and encapsulates the full hierarchy
+    std::vector<GroupPtr> groups;
+    // These are the `group=` groups where you can off voices
+    std::vector<PolyphonyGroupPtr> polyphonyGroups;
+    // Views to speed up iteration over the regions and voices
     VoiceViewVector voiceViewVector;
     std::array<RegionViewVector, 128> noteActivationLists;
     std::array<RegionViewVector, config::numCCs> ccActivationLists;

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -217,13 +217,21 @@ public:
      */
     const Voice* getVoiceView(int idx) const noexcept;
     /**
-     * @brief Get a raw view into a specific voice. This is mostly used
+     * @brief Get a raw view into a specific effect bus. This is mostly used
      * for testing.
      *
      * @param idx
-     * @return const Region*
+     * @return const EffectBus*
      */
     const EffectBus* getEffectBusView(int idx) const noexcept;
+    /**
+     * @brief Get a raw view into a specific set of regions. This is mostly used
+     * for testing.
+     *
+     * @param idx
+     * @return const RegionSet*
+     */
+    const RegionSet* getRegionSetView(int idx) const noexcept;
     /**
      * @brief Get a list of unknown opcodes. The lifetime of the
      * string views in the code are linked to the currently loaded

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -558,7 +558,6 @@ private:
      * @param polyphone the max polyphony
      */
     void setGroupPolyphony(unsigned groupIdx, unsigned polyphony) noexcept;
-    std::vector<unsigned> groupMaxPolyphony { config::maxVoices };
 
     /**
      * @brief Reset all CCs; to be used on CC 121
@@ -677,7 +676,6 @@ private:
     using VoicePtr = std::unique_ptr<Voice>;
     using RegionPtr = std::unique_ptr<Region>;
     using RegionSetPtr = std::unique_ptr<RegionSet>;
-    using PolyphonyGroupPtr = std::unique_ptr<PolyphonyGroup>;
     std::vector<RegionPtr> regions;
     std::vector<VoicePtr> voices;
     std::vector<VoicePtr> overflowVoices;
@@ -687,7 +685,7 @@ private:
     Header lastHeader { Header::Global };
     std::vector<RegionSetPtr> sets;
     // These are the `group=` groups where you can off voices
-    std::vector<PolyphonyGroupPtr> polyphonyGroups;
+    std::vector<PolyphonyGroup> polyphonyGroups;
     // Views to speed up iteration over the regions and voices
     VoiceViewVector voiceViewVector;
     std::array<RegionViewVector, 128> noteActivationLists;

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -585,6 +585,12 @@ private:
      */
     void handleGlobalOpcodes(const std::vector<Opcode>& members);
     /**
+     * @brief Helper function to dispatch <global> opcodes
+     *
+     * @param members the opcodes of the <global> block
+     */
+    void handleMasterOpcodes(const std::vector<Opcode>& members);
+    /**
      * @brief Helper function to dispatch <group> opcodes
      *
      * @param members the opcodes of the <group> block

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -623,6 +623,18 @@ private:
 
     unsigned killSisterVoices(const Voice* voiceToKill) noexcept;
 
+    /**
+     * @brief Applies some lambda function to both voices and overflow voices
+     *
+     * @tparam F a lambda type decaying to void(std::unique_ptr<Voice>&)
+     * @param lambda the function to apply
+     */
+    template<class F>
+    void applyToAllVoices(F&& lambda) {
+        absl::c_for_each(voices, lambda);
+        absl::c_for_each(overflowVoices, lambda);
+    }
+
     // Opcode memory; these are used to build regions, as a new region
     // will integrate opcodes from the group, master and global block
     std::vector<Opcode> globalOpcodes;
@@ -646,8 +658,10 @@ private:
     std::vector<std::string> unknownOpcodes;
     using RegionPtrVector = std::vector<Region*>;
     using VoicePtrVector = std::vector<Voice*>;
+    using VoicePtr = std::unique_ptr<Voice>;
     std::vector<std::unique_ptr<Region>> regions;
     std::vector<std::unique_ptr<Voice>> voices;
+    std::vector<std::unique_ptr<Voice>> overflowVoices;
     // Views to speed up iteration over the regions and voices when events
     // occur in the audio callback
     VoicePtrVector voiceViewArray;

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -233,6 +233,20 @@ public:
      */
     const RegionSet* getRegionSetView(int idx) const noexcept;
     /**
+     * @brief Get a raw view into a specific polyphony group. This is mostly used
+     * for testing.
+     *
+     * @param idx
+     * @return const PolyphonyGroup*
+     */
+    const PolyphonyGroup* getPolyphonyGroupView(int idx) const noexcept;
+    /**
+     * @brief Get the number of polyphony groups
+     *
+     * @return unsigned
+     */
+    unsigned getNumPolyphonyGroups() const noexcept;
+    /**
      * @brief Get a list of unknown opcodes. The lifetime of the
      * string views in the code are linked to the currently loaded
      * sfz file.

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -9,7 +9,7 @@
 #include "Parser.h"
 #include "Voice.h"
 #include "Region.h"
-#include "Group.h"
+#include "RegionSet.h"
 #include "PolyphonyGroup.h"
 #include "Effects.h"
 #include "LeakDetector.h"
@@ -662,13 +662,14 @@ private:
     using VoiceViewVector = std::vector<Voice*>;
     using VoicePtr = std::unique_ptr<Voice>;
     using RegionPtr = std::unique_ptr<Region>;
-    using GroupPtr = std::unique_ptr<Group>;
+    using RegionSetPtr = std::unique_ptr<RegionSet>;
     using PolyphonyGroupPtr = std::unique_ptr<PolyphonyGroup>;
     std::vector<RegionPtr> regions;
     std::vector<VoicePtr> voices;
     std::vector<VoicePtr> overflowVoices;
     // These are more general "groups" than sfz and encapsulates the full hierarchy
-    std::vector<GroupPtr> groups;
+    RegionSet* currentSet;
+    std::vector<RegionSetPtr> sets;
     // These are the `group=` groups where you can off voices
     std::vector<PolyphonyGroupPtr> polyphonyGroups;
     // Views to speed up iteration over the regions and voices

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -213,7 +213,7 @@ public:
      * for testing.
      *
      * @param idx
-     * @return const Region*
+     * @return const Voice*
      */
     const Voice* getVoiceView(int idx) const noexcept;
     /**

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -676,7 +676,9 @@ private:
     std::vector<VoicePtr> voices;
     std::vector<VoicePtr> overflowVoices;
     // These are more general "groups" than sfz and encapsulates the full hierarchy
+    enum class Header { Global, Master, Group };
     RegionSet* currentSet;
+    Header lastHeader { Header::Global };
     std::vector<RegionSetPtr> sets;
     // These are the `group=` groups where you can off voices
     std::vector<PolyphonyGroupPtr> polyphonyGroups;

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -656,17 +656,17 @@ private:
     // Default active switch if multiple keyswitchable regions are present
     absl::optional<uint8_t> defaultSwitch;
     std::vector<std::string> unknownOpcodes;
-    using RegionPtrVector = std::vector<Region*>;
-    using VoicePtrVector = std::vector<Voice*>;
+    using RegionViewVector = std::vector<Region*>;
+    using VoiceViewVector = std::vector<Voice*>;
     using VoicePtr = std::unique_ptr<Voice>;
     std::vector<std::unique_ptr<Region>> regions;
     std::vector<std::unique_ptr<Voice>> voices;
     std::vector<std::unique_ptr<Voice>> overflowVoices;
     // Views to speed up iteration over the regions and voices when events
     // occur in the audio callback
-    VoicePtrVector voiceViewArray;
-    std::array<RegionPtrVector, 128> noteActivationLists;
-    std::array<RegionPtrVector, config::numCCs> ccActivationLists;
+    VoiceViewVector voiceViewVector;
+    std::array<RegionViewVector, 128> noteActivationLists;
+    std::array<RegionViewVector, config::numCCs> ccActivationLists;
 
     // Effect factory and buses
     EffectFactory effectFactory;

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -707,7 +707,6 @@ unsigned sfz::Voice::countSisterVoices(const Voice* start)
     return count;
 }
 
-
 float sfz::Voice::getAverageEnvelope() const noexcept
 {
     return max(smoothedChannelEnvelopes[0], smoothedChannelEnvelopes[1]);

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -682,12 +682,31 @@ void sfz::Voice::setNextSisterVoice(Voice* voice) noexcept
     ASSERT(voice);
     nextSisterVoice = voice;
 }
+
 void sfz::Voice::setPreviousSisterVoice(Voice* voice) noexcept
 {
     // Should never be null
     ASSERT(voice);
     previousSisterVoice = voice;
 }
+
+unsigned sfz::Voice::countSisterVoices(const Voice* start)
+{
+    if (!start)
+        return 0;
+
+    unsigned count = 0;
+    auto next = start;
+    do
+    {
+        count++;
+        next = next->getNextSisterVoice();
+    } while (next != start && count < config::maxVoices);
+
+    ASSERT(count < config::maxVoices);
+    return count;
+}
+
 
 float sfz::Voice::getAverageEnvelope() const noexcept
 {

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -15,7 +15,7 @@
 #include "absl/algorithm/container.h"
 
 sfz::Voice::Voice(int voiceNumber, sfz::Resources& resources)
-: id{voiceNumber}, stateListener(nullptr), resources(resources)
+: id{voiceNumber}, stateListener(nullptr), resources(resources), nextSisterVoice(this), previousSisterVoice(this)
 {
     filters.reserve(config::filtersPerVoice);
     equalizers.reserve(config::eqsPerVoice);
@@ -668,6 +668,25 @@ void sfz::Voice::reset() noexcept
 
     filters.clear();
     equalizers.clear();
+
+    // Remove the voice from the sister ring
+    previousSisterVoice->setNextSisterVoice(nextSisterVoice);
+    nextSisterVoice->setPreviousSisterVoice(previousSisterVoice);
+    previousSisterVoice = this;
+    nextSisterVoice = this;
+}
+
+void sfz::Voice::setNextSisterVoice(Voice* voice) noexcept
+{
+    // Should never be null
+    ASSERT(voice);
+    nextSisterVoice = voice;
+}
+void sfz::Voice::setPreviousSisterVoice(Voice* voice) noexcept
+{
+    // Should never be null
+    ASSERT(voice);
+    previousSisterVoice = voice;
 }
 
 float sfz::Voice::getAverageEnvelope() const noexcept

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -224,6 +224,29 @@ public:
     void setPreviousSisterVoice(Voice* voice) noexcept;
 
     /**
+     * @brief Get the next sister voice in the ring
+     *
+     * @return Voice*
+     */
+    Voice* getNextSisterVoice() const noexcept { return nextSisterVoice; };
+
+    /**
+     * @brief Count the number of sister voices
+     *
+     * @param start
+     * @return unsigned
+     */
+    static unsigned countSisterVoices(const Voice* start);
+
+    /**
+     * @brief Count the number of sister voices
+     *
+     * @param start
+     * @return unsigned
+     */
+    unsigned countSisterVoices() const { return countSisterVoices(this); }
+
+    /**
      * @brief Get the mean squared power of the last rendered block. This is used
      * to determine which voice to steal if there are too many notes flying around.
      *

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -204,6 +204,26 @@ public:
     void reset() noexcept;
 
     /**
+     * @brief Set the next voice in the "sister voice" ring
+     * The sister voices are voices that started on the same event.
+     * This has to be set by the synth. A voice will remove itself from
+     * the ring upon reset.
+     *
+     * @param voice
+     */
+    void setNextSisterVoice(Voice* voice) noexcept;
+
+    /**
+     * @brief Set the previous voice in the "sister voice" ring
+     * The sister voices are voices that started on the same event.
+     * This has to be set by the synth. A voice will remove itself from
+     * the ring upon reset.
+     *
+     * @param voice
+     */
+    void setPreviousSisterVoice(Voice* voice) noexcept;
+
+    /**
      * @brief Get the mean squared power of the last rendered block. This is used
      * to determine which voice to steal if there are too many notes flying around.
      *
@@ -351,6 +371,9 @@ private:
     Duration amplitudeDuration;
     Duration panningDuration;
     Duration filterDuration;
+
+    Voice* nextSisterVoice;
+    Voice* previousSisterVoice;
 
     std::normal_distribution<float> noiseDist { 0, config::noiseVariance };
 

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -231,12 +231,52 @@ public:
     Voice* getNextSisterVoice() const noexcept { return nextSisterVoice; };
 
     /**
+     * @brief Get the previous sister voice in the ring
+     *
+     * @return Voice*
+     */
+    Voice* getPreviousSisterVoice() const noexcept { return previousSisterVoice; };
+
+    /**
      * @brief Count the number of sister voices
      *
      * @param start
      * @return unsigned
      */
     static unsigned countSisterVoices(const Voice* start);
+
+    /**
+     * @brief Apply a function to the sister ring, including the current voice.
+     * This function should be safe enough to even reset the sister voices, but
+     * if you mutate the ring significantly you should probably roll your own
+     * iterator.
+     *
+     * @tparam F
+     * @param lambda the function to apply.
+     */
+    template<class F>
+    void applyToSisterRing(F&& lambda)
+    {
+        auto v = getNextSisterVoice();
+        while (v != this) {
+            const auto next = v->getNextSisterVoice();
+            lambda(v);
+            v = next;
+        }
+        lambda(this);
+    }
+
+    template<class F>
+    void applyToSisterRing(F&& lambda) const
+    {
+        auto v = getNextSisterVoice();
+        while (v != this) {
+            const auto next = v->getNextSisterVoice();
+            lambda(v);
+            v = next;
+        }
+        lambda(this);
+    }
 
     /**
      * @brief Count the number of sister voices

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -522,6 +522,23 @@ R"(<region> key=61 sample=*sine
     REQUIRE( synth.getVoiceView(5)->getPreviousSisterVoice() == synth.getVoiceView(4) );
 }
 
+TEST_CASE("[Synth] Apply function on sisters")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, 256 };
+    synth.loadSfzString(fs::current_path(),
+R"(<region> key=63 sample=*saw
+<region> key=63 sample=*saw
+<region> key=63 sample=*saw)");
+    synth.noteOn(0, 63, 85);
+    REQUIRE( synth.getVoiceView(0)->countSisterVoices() == 3 );
+    float start = 1.0f;
+    synth.getVoiceView(0)->applyToSisterRing([&](const sfz::Voice* v) {
+        start += static_cast<float>(v->getTriggerNumber());
+    });
+    REQUIRE( start == 1.0f + 3.0f * 63.0f );
+}
+
 
 TEST_CASE("[Synth] Sisters and off-by")
 {

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -640,3 +640,31 @@ R"(
     REQUIRE( rootSet->getSubsets()[1]->getSubsets()[0]->getRegions().size() == 4 );
     REQUIRE( rootSet->getSubsets()[1]->getSubsets()[0]->getSubsets().size() == 0 );
 }
+
+TEST_CASE("[Synth] Polyphony in hierarchy")
+{
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path(),
+R"(
+<region> key=61 sample=*sine polyphony=2
+<group> polyphony=2
+<region> key=62 sample=*sine
+<master> polyphony=3
+<region> key=63 sample=*sine
+<region> key=63 sample=*sine
+<region> key=63 sample=*sine
+<group> polyphony=4
+<region> key=64 sample=*sine polyphony=5
+<region> key=64 sample=*sine
+<region> key=64 sample=*sine
+<region> key=64 sample=*sine
+)");
+    REQUIRE( synth.getRegionView(0)->polyphony == 2 );
+    REQUIRE( synth.getRegionSetView(1)->getPolyphonyLimit() == 2 );
+    REQUIRE( synth.getRegionView(1)->polyphony == 2 );
+    REQUIRE( synth.getRegionSetView(2)->getPolyphonyLimit() == 3 );
+    REQUIRE( synth.getRegionSetView(2)->getRegions()[0]->polyphony == 3 );
+    REQUIRE( synth.getRegionSetView(3)->getPolyphonyLimit() == 4 );
+    REQUIRE( synth.getRegionSetView(3)->getRegions()[0]->polyphony == 5 );
+    REQUIRE( synth.getRegionSetView(3)->getRegions()[1]->polyphony == 4 );
+}

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -500,24 +500,30 @@ R"(<region> key=61 sample=*sine
     synth.noteOn(0, 61, 85);
     REQUIRE( synth.getVoiceView(0)->countSisterVoices() == 1 );
     REQUIRE( synth.getVoiceView(0)->getNextSisterVoice() == synth.getVoiceView(0) );
+    REQUIRE( synth.getVoiceView(0)->getPreviousSisterVoice() == synth.getVoiceView(0) );
     synth.noteOn(0, 62, 85);
     REQUIRE( synth.getNumActiveVoices() == 3 );
     REQUIRE( synth.getVoiceView(1)->countSisterVoices() == 2 );
     REQUIRE( synth.getVoiceView(1)->getNextSisterVoice() == synth.getVoiceView(2) );
+    REQUIRE( synth.getVoiceView(1)->getPreviousSisterVoice() == synth.getVoiceView(2) );
     REQUIRE( synth.getVoiceView(2)->countSisterVoices() == 2 );
     REQUIRE( synth.getVoiceView(2)->getNextSisterVoice() == synth.getVoiceView(1) );
+    REQUIRE( synth.getVoiceView(2)->getPreviousSisterVoice() == synth.getVoiceView(1) );
     synth.noteOn(0, 63, 85);
     REQUIRE( synth.getNumActiveVoices() == 6 );
     REQUIRE( synth.getVoiceView(3)->countSisterVoices() == 3 );
     REQUIRE( synth.getVoiceView(3)->getNextSisterVoice() == synth.getVoiceView(4) );
+    REQUIRE( synth.getVoiceView(3)->getPreviousSisterVoice() == synth.getVoiceView(5) );
     REQUIRE( synth.getVoiceView(4)->countSisterVoices() == 3 );
     REQUIRE( synth.getVoiceView(4)->getNextSisterVoice() == synth.getVoiceView(5) );
+    REQUIRE( synth.getVoiceView(4)->getPreviousSisterVoice() == synth.getVoiceView(3) );
     REQUIRE( synth.getVoiceView(5)->countSisterVoices() == 3 );
     REQUIRE( synth.getVoiceView(5)->getNextSisterVoice() == synth.getVoiceView(3) );
+    REQUIRE( synth.getVoiceView(5)->getPreviousSisterVoice() == synth.getVoiceView(4) );
 }
 
 
-TEST_CASE("[Synth] Sister and off-by")
+TEST_CASE("[Synth] Sisters and off-by")
 {
     sfz::Synth synth;
     sfz::AudioBuffer<float> buffer { 2, 256 };
@@ -528,8 +534,6 @@ R"(<region> <region> key=62 sample=*sine
     synth.noteOn(0, 62, 85);
     REQUIRE( synth.getNumActiveVoices() == 2 );
     REQUIRE( synth.getVoiceView(0)->countSisterVoices() == 2 );
-    REQUIRE( synth.getVoiceView(0)->getNextSisterVoice() == synth.getVoiceView(1) );
-    REQUIRE( synth.getVoiceView(1)->getNextSisterVoice() == synth.getVoiceView(0) );
     synth.renderBlock(buffer);
     REQUIRE( synth.getNumActiveVoices() == 2 );
     synth.noteOn(0, 63, 85);

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -668,3 +668,31 @@ R"(
     REQUIRE( synth.getRegionSetView(3)->getRegions()[0]->polyphony == 5 );
     REQUIRE( synth.getRegionSetView(3)->getRegions()[1]->polyphony == 4 );
 }
+
+TEST_CASE("[Synth] Polyphony groups")
+{
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path(),
+R"(
+<group> polyphony=2
+<region> key=62 sample=*sine
+<group> group=1 polyphony=3
+<region> key=63 sample=*sine
+<region> key=63 sample=*sine group=2 polyphony=4
+<region> key=63 sample=*sine group=4 polyphony=5
+<group> group=4
+<region> key=62 sample=*sine
+)");
+    REQUIRE( synth.getNumPolyphonyGroups() == 5 );
+    REQUIRE( synth.getNumRegions() == 5 );
+    REQUIRE( synth.getRegionView(0)->group == 0 );
+    REQUIRE( synth.getRegionView(1)->group == 1 );
+    REQUIRE( synth.getRegionView(2)->group == 2 );
+    REQUIRE( synth.getRegionView(3)->group == 4 );
+    REQUIRE( synth.getRegionView(3)->polyphony == 5 );
+    REQUIRE( synth.getRegionView(4)->group == 4 );
+    REQUIRE( synth.getPolyphonyGroupView(1)->getPolyphonyLimit() == 3 );
+    REQUIRE( synth.getPolyphonyGroupView(2)->getPolyphonyLimit() == 4 );
+    REQUIRE( synth.getPolyphonyGroupView(3)->getPolyphonyLimit() == sfz::config::maxVoices );
+    REQUIRE( synth.getPolyphonyGroupView(4)->getPolyphonyLimit() == 5 );
+}


### PR DESCRIPTION
I'm thinking I'll break this down a little bit into pieces. The final goal is to handle voice stealing under different policies and at different levels. Ideally in the spec, you should be able to steal because of
- `note_polyphony` at the region level
- `polyphony` limits for regions, groups, (masters) and global
- `group=` in conjunction with `polyphony` at the group level, but also apparently at the region level.
- Global engine limit

This PR adds the following facilities to support stealing and allow for the above:
- The "hierarchy" of groups/masters/... is now built as a view onto the still flat vector of regions. Each region has a parent `RegionSet`, that can contain regions and other region sets. This should make at least the structure amenable to possibly arbitrary nesting of groups within groups. The sets should also track their active voices, using the voice lifecycle addition or the synth updating it upon cleaning up voices that have ended.
- Polyphony groups (for `group=` opcodes) also follow a similar idea in a separate structure.
- A small linked list is added to the voices and set when they're started so that you can iterate over the "sister" voices that were started at the same time. This is needed now and later for flexible voice stealing. The current voice stealing algorithm has been updated to make use of this. When a voice dies, it removes itself from the ring of sister voices.
- I added also a set of "overflow" voices to gather stolen voices that do not have `off_mode=fast` set. The `off_mode=time` and `off_mode=normal` need that the normal release of the voices play. For now I set the number of overflow voices at the same number of normal voices but we can try to see how it behaves in practice. We can also kill some overflow voices if they get out of control the same way we do normal voices now.
- I reduced the default number of voices to 64. Hopefully with the coming improvements it will be a sane baseline and as @FrnchFrgg said it's better to be conservative so that standard settings look good from a CPU usage PoV.

What needs to happen here:
- [x] Add some tests for the polyphony groups (on groups, on regions, etc)

What I plan to do next is:
- [ ] Hook this with the voice lifecycle somehow to update the polyphony properly over all the needed elements.
- [ ] Try to have templated `Voice* stealVoice<VoiceStealingPolicy>(span<Voice*> activeVoices)` functions that provide you with a stolen voice (or null) within a set of active voices. 

Probably some more stuff too. This would be in a further PR.