### PR TITLE
The synth now resets the voices

### DIFF
--- a/src/sfizz/MidiState.cpp
+++ b/src/sfizz/MidiState.cpp
@@ -40,6 +40,12 @@ void sfz::MidiState::noteOffEvent(int delay, int noteNumber, float velocity) noe
 
 }
 
+void sfz::MidiState::allNotesOff(int delay) noexcept
+{
+    for (int note = 0; note < 128; note++)
+        noteOffEvent(delay, note, 0.0f);
+}
+
 void sfz::MidiState::setSampleRate(float sampleRate) noexcept
 {
     this->sampleRate = sampleRate;

--- a/src/sfizz/MidiState.h
+++ b/src/sfizz/MidiState.h
@@ -25,6 +25,7 @@ public:
     /**
      * @brief Update the state after a note on event
      *
+     * @param delay
      * @param noteNumber
      * @param velocity
      */
@@ -33,11 +34,22 @@ public:
     /**
      * @brief Update the state after a note off event
      *
+     * @param delay
      * @param noteNumber
      * @param velocity
      */
     void noteOffEvent(int delay, int noteNumber, float velocity) noexcept;
 
+    /**
+     * @brief Set all notes off
+     *
+     * @param delay
+     */
+    void allNotesOff(int delay) noexcept;
+
+    /**
+     * @brief Get the number of active notes
+     */
     int getActiveNotes() const noexcept { return activeNotes; }
 
     /**

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -708,6 +708,9 @@ void sfz::Synth::renderBlock(AudioSpan<float> buffer) noexcept
             callbackBreakdown.amplitude += voice->getLastAmplitudeDuration();
             callbackBreakdown.filters += voice->getLastFilterDuration();
             callbackBreakdown.panning += voice->getLastPanningDuration();
+
+            if (voice->toBeCleanedUp())
+                    voice->reset();
         }
     }
 
@@ -889,6 +892,13 @@ void sfz::Synth::hdcc(int delay, int ccNumber, float normValue) noexcept
 
     if (ccNumber == config::resetCC) {
         resetAllControllers(delay);
+        return;
+    }
+
+    if (ccNumber == config::allNotesOffCC || ccNumber == config::allSoundOffCC) {
+        for (auto& voice : voices)
+            voice->reset();
+        resources.midiState.allNotesOff(delay);
         return;
     }
 

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -53,13 +53,19 @@ public:
 
     enum class State {
         idle,
-        playing
+        playing,
+        cleanMeUp,
     };
 
     class StateListener {
     public:
         virtual void onVoiceStateChanged(NumericId<Voice> /*id*/, State /*state*/) {}
     };
+
+    /**
+     * @brief Return true if the voice is to be cleaned up (zombie state)
+     */
+    bool toBeCleanedUp() const { return state == State::cleanMeUp; }
 
     /**
      * @brief Sets the listener which is called when the voice state changes.

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -152,15 +152,18 @@ TEST_CASE("[Synth] Releasing before the EG started smoothing (initial delay) kil
 {
     sfz::Synth synth;
     synth.setSamplesPerBlock(1024);
+    sfz::AudioBuffer<float> buffer { 2, 1024 };
     synth.setNumVoices(1);
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/delay_release.sfz");
     synth.noteOn(0, 60, 63);
     REQUIRE( !synth.getVoiceView(0)->isFree() );
     synth.noteOff(100, 60, 63);
+    synth.renderBlock(buffer);
     REQUIRE( synth.getVoiceView(0)->isFree() );
     synth.noteOn(200, 60, 63);
     REQUIRE( !synth.getVoiceView(0)->isFree() );
     synth.noteOff(1000, 60, 63);
+    synth.renderBlock(buffer);
     REQUIRE( !synth.getVoiceView(0)->isFree() );
 }
 


### PR DESCRIPTION
The voice does not reset itself anymore, but rather enters a zombie state.
This intermediate state will be used by the synth to update the polyphony counters if needed.