### PR TITLE
Add the fast random number generator

### DIFF
--- a/benchmarks/BM_random.cpp
+++ b/benchmarks/BM_random.cpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "MathHelpers.h"
+#include <benchmark/benchmark.h>
+#include <vector>
+#include <random>
+
+class RandomFill : public benchmark::Fixture {
+public:
+  void SetUp(const ::benchmark::State& state) {
+    output = std::vector<float>(state.range(0));
+  }
+
+  void TearDown(const ::benchmark::State& state) {
+      UNUSED(state);
+  }
+
+  std::vector<float> output;
+};
+
+BENCHMARK_DEFINE_F(RandomFill, StdRandom)(benchmark::State& state) {
+    std::minstd_rand prng;
+    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+
+    for (auto _ : state)
+    {
+        for (float &out : output)
+            out = dist(prng);
+    }
+}
+
+BENCHMARK_DEFINE_F(RandomFill, FastRandom)(benchmark::State& state) {
+    fast_rand prng;
+    fast_real_distribution<float> dist(0.0f, 1.0f);
+
+    for (auto _ : state)
+    {
+        for (float &out : output)
+            out = dist(prng);
+    }
+}
+BENCHMARK_DEFINE_F(RandomFill, StdRandomBipolar)(benchmark::State& state) {
+    std::minstd_rand prng;
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+
+    for (auto _ : state)
+    {
+        for (float &out : output)
+            out = dist(prng);
+    }
+}
+
+BENCHMARK_DEFINE_F(RandomFill, FastRandomBipolar)(benchmark::State& state) {
+    fast_rand prng;
+    fast_real_distribution<float> dist(-1.0f, 1.0f);
+
+    for (auto _ : state)
+    {
+        for (float &out : output)
+            out = dist(prng);
+    }
+}
+
+BENCHMARK_REGISTER_F(RandomFill, StdRandom)->RangeMultiplier(4)->Range(1 << 2, 1 << 12);
+BENCHMARK_REGISTER_F(RandomFill, StdRandomBipolar)->RangeMultiplier(4)->Range(1 << 2, 1 << 12);
+BENCHMARK_REGISTER_F(RandomFill, FastRandom)->RangeMultiplier(4)->Range(1 << 2, 1 << 12);
+BENCHMARK_REGISTER_F(RandomFill, FastRandomBipolar)->RangeMultiplier(4)->Range(1 << 2, 1 << 12);

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -64,6 +64,7 @@ sfizz_add_benchmark(bm_pointerIterationOrOffsets BM_pointerIterationOrOffsets.cp
 sfizz_add_benchmark(bm_maps BM_maps.cpp)
 target_link_libraries(bm_maps PRIVATE absl::flat_hash_map)
 sfizz_add_benchmark(bm_mapVsArray BM_mapVsArray.cpp)
+sfizz_add_benchmark(bm_random BM_random.cpp)
 
 sfizz_add_benchmark(bm_logger BM_logger.cpp)
 target_link_libraries(bm_logger PRIVATE sfizz::sfizz)

--- a/src/sfizz/MathHelpers.h
+++ b/src/sfizz/MathHelpers.h
@@ -14,8 +14,10 @@
 #include "SIMDConfig.h"
 #include "absl/types/span.h"
 #include <algorithm>
-#include <cmath>
 #include <random>
+#include <limits>
+#include <type_traits>
+#include <cmath>
 #include <cfenv>
 #if SFIZZ_HAVE_SSE
 #include <xmmintrin.h>
@@ -108,17 +110,6 @@ constexpr Type mag2db(Type in)
 {
     return static_cast<Type>(20.0) * std::log10(in);
 }
-
-/**
- * @brief Global random singletons
- *
- * TODO: could be moved into a singleton class holder
- *
- */
-namespace Random {
-static std::random_device randomDevice;
-static std::minstd_rand randomGenerator { randomDevice() };
-} // namespace Random
 
 /**
  * @brief Converts a midi note to a frequency value
@@ -504,3 +495,108 @@ public:
 private:
     const int savedFloatMode;
 };
+
+/**
+ * @brief A low-quality random number generator guaranteed to be very fast
+ */
+class fast_rand {
+public:
+    typedef uint32_t result_type;
+
+    fast_rand() noexcept
+    {
+    }
+
+    explicit fast_rand(uint32_t value) noexcept
+        : mem(value)
+    {
+    }
+
+    static constexpr uint32_t min() noexcept
+    {
+        return 0;
+    }
+
+    static constexpr uint32_t max() noexcept
+    {
+        return std::numeric_limits<uint32_t>::max();
+    }
+
+    uint32_t operator()() noexcept
+    {
+        uint32_t next = mem * 1664525u + 1013904223u; // Numerical Recipes
+        mem = next;
+        return next;
+    }
+
+    void seed(uint32_t value = 0) noexcept
+    {
+        mem = value;
+    }
+
+    void discard(unsigned long long z) noexcept
+    {
+        for (unsigned long long i = 0; i < z; ++i)
+            operator()();
+    }
+
+private:
+    uint32_t mem = 0;
+};
+
+/**
+ * @brief A uniform real distribution guaranteed to be very fast
+ */
+template <class T>
+class fast_real_distribution {
+public:
+    static_assert(std::is_floating_point<T>::value, "The type must be floating point.");
+
+    typedef T result_type;
+
+    fast_real_distribution(T a, T b)
+        : a_(a), b_(b), k_(b - a)
+    {
+    }
+
+    template <class G>
+    T operator()(G& g) const
+    {
+        return a_ + (g() - T(G::min())) * (k_ / T(G::max() - G::min()));
+    }
+
+    T a() const noexcept
+    {
+        return a_;
+    }
+
+    T b() const noexcept
+    {
+        return b_;
+    }
+
+    T min() const noexcept
+    {
+        return a_;
+    }
+
+    T max() const noexcept
+    {
+        return b_;
+    }
+
+private:
+    T a_;
+    T b_;
+    T k_;
+};
+
+/**
+ * @brief Global random singletons
+ *
+ * TODO: could be moved into a singleton class holder
+ *
+ */
+namespace Random {
+static fast_rand randomGenerator;
+} // namespace Random

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -1036,7 +1036,7 @@ float sfz::Region::getBasePitchVariation(float noteNumber, float velocity) const
 
 float sfz::Region::getBaseVolumedB(int noteNumber) const noexcept
 {
-    std::uniform_real_distribution<float> volumeDistribution { -ampRandom, ampRandom };
+    fast_real_distribution<float> volumeDistribution { -ampRandom, ampRandom };
     auto baseVolumedB = volume + volumeDistribution(Random::randomGenerator);
     if (trigger == SfzTrigger::release || trigger == SfzTrigger::release_key)
         baseVolumedB -= rtDecay * midiState.getNoteDuration(noteNumber);
@@ -1055,7 +1055,7 @@ float sfz::Region::getPhase() const noexcept
         phase = oscillatorPhase * (1.0f / 360.0f);
         phase -= static_cast<float>(static_cast<int>(phase));
     } else {
-        std::uniform_real_distribution<float> phaseDist { 0.0001f, 0.9999f };
+        fast_real_distribution<float> phaseDist { 0.0001f, 0.9999f };
         phase = phaseDist(Random::randomGenerator);
     }
     return phase;
@@ -1072,7 +1072,7 @@ uint64_t sfz::Region::getOffset(Oversampling factor) const noexcept
 
 float sfz::Region::getDelay() const noexcept
 {
-    std::uniform_real_distribution<float> delayDistribution { 0, delayRandom };
+    fast_real_distribution<float> delayDistribution { 0, delayRandom };
     return delay + delayDistribution(Random::randomGenerator);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SFIZZ_TEST_SOURCES
     CurveT.cpp
     RegionTriggersT.cpp
     FloatHelpersT.cpp
+    RandomHelpersT.cpp
     WavetablesT.cpp
     SemaphoreT.cpp
     TuningT.cpp

--- a/tests/RandomHelpersT.cpp
+++ b/tests/RandomHelpersT.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "catch2/catch.hpp"
+#include "sfizz/MathHelpers.h"
+#include <vector>
+
+/**
+ * @brief Check the behavior of a uniform real random generator
+ *
+ * - ensure all results to be in range [min;max]
+ * - ensure to have at least one element in every division of the result range
+ */
+template <class Rand, class Dist>
+static bool randomTest(float min, float max, unsigned gen, unsigned div)
+{
+    fast_rand prng;
+    fast_real_distribution<float> dist(min, max);
+    std::vector<unsigned> counts(div);
+
+    for (unsigned i = 0; i < gen; ++i) {
+        float r = dist(prng);
+        if (r < min || r > max)
+            return false;
+        unsigned d = clamp<int>(div * (r - min) / (max - min), 0, div - 1);
+        ++counts[d];
+    }
+
+    for (unsigned count : counts) {
+        if (count == 0)
+            return false;
+    }
+    return true;
+}
+
+TEST_CASE("[Random] Fast random generation")
+{
+    unsigned numGenerations = 1000;
+    unsigned numDivisions = 128;
+
+    auto& test = randomTest<fast_rand, fast_real_distribution<float>>;
+
+    REQUIRE(test(0.0f, 1.0f, numGenerations, numDivisions));
+    REQUIRE(test(-1.0f, 1.0f, numGenerations, numDivisions));
+    REQUIRE(test(0.0f, 123.0f, numGenerations, numDivisions));
+    REQUIRE(test(-123.0f, 0.0f, numGenerations, numDivisions));
+}


### PR DESCRIPTION
#67
It's 4x faster in the benchmark.

```
2020-06-16 12:41:32
Running ./build/benchmarks/bm_random
Run on (8 X 3600 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 64K (x4)
  L2 Unified 512K (x4)
  L3 Unified 4096K (x1)
Load Average: 3.20, 1.92, 1.13
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
RandomFill/StdRandom/4                  16.0 ns         16.0 ns     41844831
RandomFill/StdRandom/16                 63.8 ns         63.6 ns     10990813
RandomFill/StdRandom/64                  256 ns          255 ns      2748246
RandomFill/StdRandom/256                1029 ns         1023 ns       685498
RandomFill/StdRandom/1024               4094 ns         4079 ns       171171
RandomFill/StdRandom/4096              16361 ns        16299 ns        42905
RandomFill/StdRandomBipolar/4           16.4 ns         16.3 ns     42879739
RandomFill/StdRandomBipolar/16          65.4 ns         65.2 ns     10710480
RandomFill/StdRandomBipolar/64           261 ns          260 ns      2689280
RandomFill/StdRandomBipolar/256         1045 ns         1042 ns       671687
RandomFill/StdRandomBipolar/1024        4200 ns         4176 ns       168138
RandomFill/StdRandomBipolar/4096       17089 ns        16937 ns        41836
RandomFill/FastRandom/4                 4.35 ns         4.33 ns    160934278
RandomFill/FastRandom/16                17.4 ns         17.3 ns     40407215
RandomFill/FastRandom/64                70.4 ns         70.0 ns     10030776
RandomFill/FastRandom/256                278 ns          277 ns      2524776
RandomFill/FastRandom/1024              1115 ns         1111 ns       630578
RandomFill/FastRandom/4096              4463 ns         4447 ns       157879
RandomFill/FastRandomBipolar/4          4.37 ns         4.36 ns    160553950
RandomFill/FastRandomBipolar/16         17.5 ns         17.4 ns     40205255
RandomFill/FastRandomBipolar/64         69.8 ns         69.6 ns     10021214
RandomFill/FastRandomBipolar/256         279 ns          278 ns      2505383
RandomFill/FastRandomBipolar/1024       1115 ns         1111 ns       627295
RandomFill/FastRandomBipolar/4096       4447 ns         4431 ns       157962
```