### PR TITLE
Prevent a warning about std::move redundancy

### DIFF
--- a/src/sfizz/Macros.h
+++ b/src/sfizz/Macros.h
@@ -10,10 +10,8 @@
 
 #if __cplusplus > 201103L
 #define CXX14_CONSTEXPR constexpr
-#define CXX11_MOVE(x) x
 #else
 #define CXX14_CONSTEXPR
-#define CXX11_MOVE(x) std::move(x)
 #endif
 
 #if __cplusplus >= 201703L

--- a/src/sfizz/effects/Apan.cpp
+++ b/src/sfizz/effects/Apan.cpp
@@ -109,7 +109,7 @@ namespace fx {
             }
         }
 
-        return CXX11_MOVE(fx);
+        return std::unique_ptr<Effect> { fx.release() };
     }
 
     void Apan::computeLfos(float* left, float* right, unsigned nframes)

--- a/src/sfizz/effects/Apan.cpp
+++ b/src/sfizz/effects/Apan.cpp
@@ -75,41 +75,42 @@ namespace fx {
 
     std::unique_ptr<Effect> Apan::makeInstance(absl::Span<const Opcode> members)
     {
-        std::unique_ptr<Apan> fx { new Apan };
+        Apan* apan = new Apan;
+        std::unique_ptr<Effect> fx { apan };
 
         for (const Opcode& opc : members) {
             switch (opc.lettersOnlyHash) {
             case hash("apan_waveform"):
                 if (auto value = readOpcode(opc.value, Default::apanWaveformRange))
-                    fx->_lfoWave = *value;
+                    apan->_lfoWave = *value;
                 break;
             case hash("apan_freq"):
                 if (auto value = readOpcode(opc.value, Default::apanFrequencyRange))
-                    fx->_lfoFrequency = *value;
+                    apan->_lfoFrequency = *value;
                 break;
             case hash("apan_phase"):
                 if (auto value = readOpcode(opc.value, Default::apanPhaseRange)) {
                     float phase = *value / 360.0f;
                     phase -= static_cast<int>(phase);
-                    fx->_lfoPhaseOffset = phase;
+                    apan->_lfoPhaseOffset = phase;
                 }
                 break;
             case hash("apan_dry"):
                 if (auto value = readOpcode(opc.value, Default::apanLevelRange))
-                    fx->_dry = *value / 100.0f;
+                    apan->_dry = *value / 100.0f;
                 break;
             case hash("apan_wet"):
                 if (auto value = readOpcode(opc.value, Default::apanLevelRange))
-                    fx->_wet = *value / 100.0f;
+                    apan->_wet = *value / 100.0f;
                 break;
             case hash("apan_depth"):
                 if (auto value = readOpcode(opc.value, Default::apanLevelRange))
-                    fx->_depth = *value / 100.0f;
+                    apan->_depth = *value / 100.0f;
                 break;
             }
         }
 
-        return std::unique_ptr<Effect> { fx.release() };
+        return fx;
     }
 
     void Apan::computeLfos(float* left, float* right, unsigned nframes)

--- a/src/sfizz/effects/Eq.cpp
+++ b/src/sfizz/effects/Eq.cpp
@@ -92,7 +92,9 @@ namespace fx {
             }
         }
 
-        return absl::make_unique<Eq>(desc);
+        Eq* eq = new Eq(desc);
+        std::unique_ptr<Effect> fx { eq };
+        return fx;
     }
 
     void Eq::prepareFilter()

--- a/src/sfizz/effects/Filter.cpp
+++ b/src/sfizz/effects/Filter.cpp
@@ -95,7 +95,9 @@ namespace fx {
             }
         }
 
-        return absl::make_unique<Filter>(desc);
+        Filter* filter = new Filter(desc);
+        std::unique_ptr<Effect> fx { filter };
+        return fx;
     }
 
     void Filter::prepareFilter()

--- a/src/sfizz/effects/Gain.cpp
+++ b/src/sfizz/effects/Gain.cpp
@@ -66,7 +66,7 @@ namespace fx {
             }
         }
 
-        return CXX11_MOVE(fx);
+        return std::unique_ptr<Effect> { fx.release() };
     }
 
 } // namespace fx

--- a/src/sfizz/effects/Gain.cpp
+++ b/src/sfizz/effects/Gain.cpp
@@ -56,17 +56,18 @@ namespace fx {
 
     std::unique_ptr<Effect> Gain::makeInstance(absl::Span<const Opcode> members)
     {
-        auto fx = absl::make_unique<Gain>();
+        Gain* gain = new Gain;
+        std::unique_ptr<Effect> fx { gain };
 
         for (const Opcode& opc : members) {
             switch (opc.lettersOnlyHash) {
             case hash("gain"):
-                setValueFromOpcode(opc, fx->_gain, {-96.0f, 96.0f});
+                setValueFromOpcode(opc, gain->_gain, {-96.0f, 96.0f});
                 break;
             }
         }
 
-        return std::unique_ptr<Effect> { fx.release() };
+        return fx;
     }
 
 } // namespace fx

--- a/src/sfizz/effects/Limiter.cpp
+++ b/src/sfizz/effects/Limiter.cpp
@@ -78,7 +78,7 @@ namespace fx {
             (void)opc;
         }
 
-        return CXX11_MOVE(fx);
+        return std::unique_ptr<Effect> { fx.release() };
     }
 
 } // namespace fx

--- a/src/sfizz/effects/Limiter.cpp
+++ b/src/sfizz/effects/Limiter.cpp
@@ -71,14 +71,15 @@ namespace fx {
 
     std::unique_ptr<Effect> Limiter::makeInstance(absl::Span<const Opcode> members)
     {
-        auto fx = absl::make_unique<Limiter>();
+        Limiter* limiter = new Limiter;
+        std::unique_ptr<Effect> fx { limiter };
 
         for (const Opcode& opc : members) {
             // no opcodes
             (void)opc;
         }
 
-        return std::unique_ptr<Effect> { fx.release() };
+        return fx;
     }
 
 } // namespace fx

--- a/src/sfizz/effects/Lofi.cpp
+++ b/src/sfizz/effects/Lofi.cpp
@@ -92,7 +92,7 @@ namespace fx {
             }
         }
 
-        return CXX11_MOVE(fx);
+        return std::unique_ptr<Effect> { fx.release() };
     }
 
     ///

--- a/src/sfizz/effects/Lofi.cpp
+++ b/src/sfizz/effects/Lofi.cpp
@@ -79,20 +79,21 @@ namespace fx {
 
     std::unique_ptr<Effect> Lofi::makeInstance(absl::Span<const Opcode> members)
     {
-        auto fx = absl::make_unique<Lofi>();
+        Lofi* lofi = new Lofi;
+        std::unique_ptr<Effect> fx { lofi };
 
         for (const Opcode& opcode : members) {
             switch (opcode.lettersOnlyHash) {
             case hash("bitred"):
-                setValueFromOpcode(opcode, fx->_bitred_depth, { 0.0, 100.0 });
+                setValueFromOpcode(opcode, lofi->_bitred_depth, { 0.0, 100.0 });
                 break;
             case hash("decim"):
-                setValueFromOpcode(opcode, fx->_decim_depth, { 0.0, 100.0 });
+                setValueFromOpcode(opcode, lofi->_decim_depth, { 0.0, 100.0 });
                 break;
             }
         }
 
-        return std::unique_ptr<Effect> { fx.release() };
+        return fx;
     }
 
     ///

--- a/src/sfizz/effects/Rectify.cpp
+++ b/src/sfizz/effects/Rectify.cpp
@@ -83,23 +83,24 @@ namespace fx {
 
     std::unique_ptr<Effect> Rectify::makeInstance(absl::Span<const Opcode> members)
     {
-        auto fx = absl::make_unique<Rectify>();
+        Rectify* rectify = new Rectify;
+        std::unique_ptr<Effect> fx { rectify };
 
         for (const Opcode& opc : members) {
             switch (opc.lettersOnlyHash) {
             case hash("rectify_mode"):
                 if (opc.value == "full")
-                    fx->_full = true;
+                    rectify->_full = true;
                 else if (opc.value == "half")
-                    fx->_full = false;
+                    rectify->_full = false;
                 break;
             case hash("rectify"):
-                setValueFromOpcode(opc, fx->_amount, { 0.0, 100.0 });
+                setValueFromOpcode(opc, rectify->_amount, { 0.0, 100.0 });
                 break;
             }
         }
 
-        return std::unique_ptr<Effect> { fx.release() };
+        return fx;
     }
 
 } // namespace fx

--- a/src/sfizz/effects/Rectify.cpp
+++ b/src/sfizz/effects/Rectify.cpp
@@ -99,7 +99,7 @@ namespace fx {
             }
         }
 
-        return CXX11_MOVE(fx);
+        return std::unique_ptr<Effect> { fx.release() };
     }
 
 } // namespace fx

--- a/src/sfizz/effects/Strings.cpp
+++ b/src/sfizz/effects/Strings.cpp
@@ -126,20 +126,21 @@ namespace fx {
 
     std::unique_ptr<Effect> Strings::makeInstance(absl::Span<const Opcode> members)
     {
-        auto fx = absl::make_unique<Strings>();
+        Strings* strings = new Strings;
+        std::unique_ptr<Effect> fx { strings };
 
         for (const Opcode& opc : members) {
             switch (opc.lettersOnlyHash) {
             case hash("strings_number"):
-                setValueFromOpcode(opc, fx->_numStrings, {0, MaximumNumStrings});
+                setValueFromOpcode(opc, strings->_numStrings, {0, MaximumNumStrings});
                 break;
             case hash("strings_wet"):
-                setValueFromOpcode(opc, fx->_wet, {0.0f, 100.0f});
+                setValueFromOpcode(opc, strings->_wet, {0.0f, 100.0f});
                 break;
             }
         }
 
-        return std::unique_ptr<Effect> { fx.release() };
+        return fx;
     }
 
 } // namespace fx

--- a/src/sfizz/effects/Strings.cpp
+++ b/src/sfizz/effects/Strings.cpp
@@ -139,7 +139,7 @@ namespace fx {
             }
         }
 
-        return CXX11_MOVE(fx);
+        return std::unique_ptr<Effect> { fx.release() };
     }
 
 } // namespace fx

--- a/src/sfizz/effects/Width.cpp
+++ b/src/sfizz/effects/Width.cpp
@@ -73,7 +73,7 @@ namespace fx {
             }
         }
 
-        return CXX11_MOVE(fx);
+        return std::unique_ptr<Effect> { fx.release() };
     }
 
 } // namespace fx

--- a/src/sfizz/effects/Width.cpp
+++ b/src/sfizz/effects/Width.cpp
@@ -63,17 +63,18 @@ namespace fx {
 
     std::unique_ptr<Effect> Width::makeInstance(absl::Span<const Opcode> members)
     {
-        auto fx = absl::make_unique<Width>();
+        Width* width = new Width;
+        std::unique_ptr<Effect> fx { width };
 
         for (const Opcode& opc : members) {
             switch (opc.lettersOnlyHash) {
             case hash("width"):
-                setValueFromOpcode(opc, fx->_width, {-100.0f, 100.0f});
+                setValueFromOpcode(opc, width->_width, {-100.0f, 100.0f});
                 break;
             }
         }
 
-        return std::unique_ptr<Effect> { fx.release() };
+        return fx;
     }
 
 } // namespace fx


### PR DESCRIPTION
It should fix this warning below and keep it working on all compilers.

```
/home/redtide/Documenti/Sviluppo/SFZTools/sfizz/src/sfizz/effects/Limiter.cpp: In static member function ‘static std::unique_ptr<sfz::Effect> sfz::fx::Limiter::makeInstance(absl::lts_2020_02_25::Span<const sfz::Opcode>)’:
/home/redtide/Documenti/Sviluppo/SFZTools/sfizz/src/sfizz/Macros.h:16:32: warning: redundant move in return statement [-Wredundant-move]
   16 | #define CXX11_MOVE(x) std::move(x)
      |                       ~~~~~~~~~^~~
/home/redtide/Documenti/Sviluppo/SFZTools/sfizz/src/sfizz/effects/Limiter.cpp:81:16: note: in expansion of macro ‘CXX11_MOVE’
   81 |         return CXX11_MOVE(fx);
      |                ^~~~~~~~~~
/home/redtide/Documenti/Sviluppo/SFZTools/sfizz/src/sfizz/Macros.h:16:32: note: remove ‘std::move’ call
   16 | #define CXX11_MOVE(x) std::move(x)
      |                       ~~~~~~~~~^~~
/home/redtide/Documenti/Sviluppo/SFZTools/sfizz/src/sfizz/effects/Limiter.cpp:81:16: note: in expansion of macro ‘CXX11_MOVE’
   81 |         return CXX11_MOVE(fx);
      |                ^~~~~~~~~~
```