### PR TITLE
Load a default SFZ if path empty

### DIFF
--- a/lv2/sfizz.c
+++ b/lv2/sfizz.c
@@ -88,6 +88,10 @@
 #define LV2_DEBUG(...)
 #endif
 
+static const char default_sfz_text[] =
+    "<region>sample=*sine" "\n"
+    "ampeg_attack=0.02 ampeg_release=0.1" "\n";
+
 typedef struct
 {
     // Features
@@ -416,7 +420,7 @@ instantiate(const LV2_Descriptor *descriptor,
     }
 
     self->synth = sfizz_create_synth();
-    sfizz_load_string(self->synth, "default.sfz", "<region>sample=*sine");
+    sfizz_load_string(self->synth, "default.sfz", default_sfz_text);
 
     return (LV2_Handle)self;
 }
@@ -886,7 +890,7 @@ sfizz_lv2_load_file(LV2_Handle instance, const char *file_path)
 
     if (file_path[0] == '\0')
     {
-        if (!sfizz_load_string(self->synth, "default.sfz", "<region>sample=*sine"))
+        if (!sfizz_load_string(self->synth, "default.sfz", default_sfz_text))
             return false;
     }
     else

--- a/lv2/sfizz.c
+++ b/lv2/sfizz.c
@@ -416,6 +416,8 @@ instantiate(const LV2_Descriptor *descriptor,
     }
 
     self->synth = sfizz_create_synth();
+    sfizz_load_string(self->synth, "default.sfz", "<region>sample=*sine");
+
     return (LV2_Handle)self;
 }
 
@@ -433,6 +435,7 @@ activate(LV2_Handle instance)
     sfizz_plugin_t *self = (sfizz_plugin_t *)instance;
     sfizz_set_samples_per_block(self->synth, self->max_block_size);
     sfizz_set_sample_rate(self->synth, self->sample_rate);
+    atomic_store(&self->must_update_midnam, 1);
 }
 
 static void
@@ -856,11 +859,13 @@ lv2_set_options(LV2_Handle instance, const LV2_Options_Option *options)
 }
 
 static void
-sfizz_lv2_update_file_info(sfizz_plugin_t* self, const char* file_path)
+sfizz_lv2_update_file_info(sfizz_plugin_t* self, const char *file_path)
 {
     strcpy(self->sfz_file_path, file_path);
 
-    lv2_log_note(&self->logger, "[sfizz] File changed to: %s\n", self->sfz_file_path);
+    const char *display_path = (file_path[0] != '\0') ? file_path : "(default)";
+    lv2_log_note(&self->logger, "[sfizz] File changed to: %s\n", display_path);
+
     char *unknown_opcodes = sfizz_get_unknown_opcodes(self->synth);
     if (unknown_opcodes)
     {
@@ -872,6 +877,26 @@ sfizz_lv2_update_file_info(sfizz_plugin_t* self, const char* file_path)
     lv2_log_note(&self->logger, "[sfizz] Number of regions: %d\n", sfizz_get_num_regions(self->synth));
 
     atomic_store(&self->must_update_midnam, 1);
+}
+
+static bool
+sfizz_lv2_load_file(LV2_Handle instance, const char *file_path)
+{
+    sfizz_plugin_t *self = (sfizz_plugin_t *)instance;
+
+    if (file_path[0] == '\0')
+    {
+        if (!sfizz_load_string(self->synth, "default.sfz", "<region>sample=*sine"))
+            return false;
+    }
+    else
+    {
+        if (!sfizz_load_file(self->synth, file_path))
+            return false;
+    }
+
+    sfizz_lv2_update_file_info(self, file_path);
+    return true;
 }
 
 static LV2_State_Status
@@ -894,10 +919,7 @@ restore(LV2_Handle instance,
     if (value)
     {
         lv2_log_note(&self->logger, "[sfizz] Restoring the file %s\n", (const char *)value);
-        if (sfizz_load_file(self->synth, (const char *)value))
-        {
-            sfizz_lv2_update_file_info(self, (const char *)value);
-        }
+        sfizz_lv2_load_file(instance, (const char *)value);
     }
 
     value = retrieve(handle, self->sfizz_scala_file_uri, &size, &type, &val_flags);
@@ -1038,9 +1060,7 @@ work(LV2_Handle instance,
     if (atom->type == self->sfizz_sfz_file_uri)
     {
         const char *sfz_file_path = LV2_ATOM_BODY_CONST(atom);
-        if (sfizz_load_file(self->synth, sfz_file_path)) {
-            sfizz_lv2_update_file_info(self, sfz_file_path);
-        } else {
+        if (!sfizz_lv2_load_file(self, sfz_file_path)) {
             lv2_log_error(&self->logger,
                 "[sfizz] Error with %s; no file should be loaded\n", sfz_file_path);
         }
@@ -1104,9 +1124,7 @@ work(LV2_Handle instance,
             lv2_log_note(&self->logger,
                         "[sfizz] File %s seems to have been updated, reloading\n",
                         self->sfz_file_path);
-            if (sfizz_load_file(self->synth, self->sfz_file_path)) {
-                sfizz_lv2_update_file_info(self, self->sfz_file_path);
-            } else {
+            if (!sfizz_lv2_load_file(self, self->sfz_file_path)) {
                 lv2_log_error(&self->logger,
                     "[sfizz] Error with %s; no file should be loaded\n", self->sfz_file_path);
             }

--- a/vst/SfizzVstProcessor.cpp
+++ b/vst/SfizzVstProcessor.cpp
@@ -20,6 +20,10 @@ constexpr int fastRound(T x)
     return static_cast<int>(x + T{ 0.5 }); // NOLINT
 }
 
+static const char defaultSfzText[] =
+    "<region>sample=*sine" "\n"
+    "ampeg_attack=0.02 ampeg_release=0.1" "\n";
+
 SfizzVstProcessor::SfizzVstProcessor()
     : _fifoToWorker(64 * 1024)
 {
@@ -342,7 +346,7 @@ void SfizzVstProcessor::loadSfzFileOrDefault(sfz::Sfizz& synth, const std::strin
     if (!filePath.empty())
         synth.loadSfzFile(filePath);
     else
-        synth.loadSfzString("default.sfz", "<region>sample=*sine");
+        synth.loadSfzString("default.sfz", defaultSfzText);
 }
 
 void SfizzVstProcessor::doBackgroundWork()

--- a/vst/SfizzVstProcessor.h
+++ b/vst/SfizzVstProcessor.h
@@ -49,6 +49,9 @@ private:
     std::unique_ptr<sfz::Sfizz> _synth;
     SfizzVstState _state;
 
+    // misc
+    static void loadSfzFileOrDefault(sfz::Sfizz& synth, const std::string& filePath);
+
     // worker and thread sync
     std::thread _worker;
     volatile bool _workRunning = false;


### PR DESCRIPTION
This loads the sine by default, or when the sfz file parameter is empty.