### PR TITLE
Wavetables hq

### DIFF
--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -67,6 +67,8 @@ namespace Default
     constexpr Range<int> oscillatorMultiRange { 1, config::oscillatorsPerVoice };
     constexpr float oscillatorDetune { 0 };
     constexpr Range<float> oscillatorDetuneRange { -9600, 9600 };
+    constexpr int oscillatorQuality { 1 };
+    constexpr Range<int> oscillatorQualityRange { 0, 3 };
 
     // Instrument setting: voice lifecycle
 	constexpr uint32_t group { 0 };

--- a/src/sfizz/Interpolators.h
+++ b/src/sfizz/Interpolators.h
@@ -9,6 +9,8 @@
 namespace sfz {
 
 enum InterpolatorModel : int {
+    // a nearest interpolator
+    kInterpolatorNearest,
     // a linear interpolator
     kInterpolatorLinear,
     // a Hermite 3rd order interpolator

--- a/src/sfizz/Interpolators.hpp
+++ b/src/sfizz/Interpolators.hpp
@@ -20,6 +20,19 @@ inline R interpolate(const R* values, R coeff)
 }
 
 //------------------------------------------------------------------------------
+// Nearest
+
+template <class R>
+class Interpolator<kInterpolatorNearest, R>
+{
+public:
+    static inline R process(const R* values, R coeff)
+    {
+        return values[coeff > static_cast<R>(0.5)];
+    }
+};
+
+//------------------------------------------------------------------------------
 // Linear
 
 template <class R>

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -135,6 +135,12 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
     case hash("oscillator_detune"):
         setValueFromOpcode(opcode, oscillatorDetune, Default::oscillatorDetuneRange);
         break;
+    case hash("oscillator_quality"):
+        if (opcode.value == "-1")
+            oscillatorQuality.reset();
+        else
+            setValueFromOpcode(opcode, oscillatorQuality, Default::oscillatorQualityRange);
+        break;
 
     // Instrument settings: voice lifecycle
     case hash("group"): // also polyphony_group

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -276,6 +276,7 @@ struct Region {
     bool oscillator = false;
     int oscillatorMulti = Default::oscillatorMulti;
     float oscillatorDetune = Default::oscillatorDetune;
+    absl::optional<int> oscillatorQuality;
 
     // Instrument settings: voice lifecycle
     uint32_t group { Default::group }; // group

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -65,19 +65,21 @@ void sfz::Voice::startVoice(Region* region, int delay, int number, float value, 
             wave = resources.wavePool.getWaveSaw();
             break;
         }
-        const int quality = region->oscillatorQuality ? *region->oscillatorQuality : Default::oscillatorQuality;
+        const float phase = region->getPhase();
+        const int quality = region->oscillatorQuality.value_or(Default::oscillatorQuality);
         for (WavetableOscillator& osc : waveOscillators) {
             osc.setWavetable(wave);
-            osc.setPhase(region->getPhase());
+            osc.setPhase(phase);
             osc.setQuality(quality);
         }
         setupOscillatorUnison();
     } else if (region->oscillator) {
         const WavetableMulti* wave = resources.wavePool.getFileWave(region->sampleId.filename());
-        const int quality = region->oscillatorQuality ? *region->oscillatorQuality : Default::oscillatorQuality;
+        const float phase = region->getPhase();
+        const int quality = region->oscillatorQuality.value_or(Default::oscillatorQuality);
         for (WavetableOscillator& osc : waveOscillators) {
             osc.setWavetable(wave);
-            osc.setPhase(region->getPhase());
+            osc.setPhase(phase);
             osc.setQuality(quality);
         }
         setupOscillatorUnison();

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -65,16 +65,20 @@ void sfz::Voice::startVoice(Region* region, int delay, int number, float value, 
             wave = resources.wavePool.getWaveSaw();
             break;
         }
+        const int quality = region->oscillatorQuality ? *region->oscillatorQuality : Default::oscillatorQuality;
         for (WavetableOscillator& osc : waveOscillators) {
             osc.setWavetable(wave);
             osc.setPhase(region->getPhase());
+            osc.setQuality(quality);
         }
         setupOscillatorUnison();
     } else if (region->oscillator) {
         const WavetableMulti* wave = resources.wavePool.getFileWave(region->sampleId.filename());
+        const int quality = region->oscillatorQuality ? *region->oscillatorQuality : Default::oscillatorQuality;
         for (WavetableOscillator& osc : waveOscillators) {
             osc.setWavetable(wave);
             osc.setPhase(region->getPhase());
+            osc.setQuality(quality);
         }
         setupOscillatorUnison();
     } else {

--- a/src/sfizz/Wavetables.cpp
+++ b/src/sfizz/Wavetables.cpp
@@ -144,8 +144,9 @@ void WavetableOscillator::process(float frequency, float detuneRatio, float* out
     int quality = clamp(_quality, 0, 3);
 
     switch (quality) {
-    case 0: // supposed to be nearest according to book
-        // fall through
+    case 0:
+        processSingle<kInterpolatorNearest>(frequency, detuneRatio, output, nframes);
+        break;
     case 1:
         processSingle<kInterpolatorLinear>(frequency, detuneRatio, output, nframes);
         break;
@@ -163,8 +164,9 @@ void WavetableOscillator::processModulated(const float* frequencies, float detun
     int quality = clamp(_quality, 0, 3);
 
     switch (quality) {
-    case 0: // supposed to be nearest according to book
-        // fall through
+    case 0:
+        processModulatedSingle<kInterpolatorNearest>(frequencies, detuneRatio, output, nframes);
+        break;
     case 1:
         processModulatedSingle<kInterpolatorLinear>(frequencies, detuneRatio, output, nframes);
         break;

--- a/src/sfizz/Wavetables.h
+++ b/src/sfizz/Wavetables.h
@@ -113,6 +113,7 @@ public:
     static constexpr float frequencyScaleFactor = 0.05;
 
     static unsigned getOctaveForFrequency(float f);
+    static float getFractionalOctaveForFrequency(float f);
     static WavetableRange getRangeForOctave(int o);
     static WavetableRange getRangeForFrequency(float f);
 

--- a/src/sfizz/Wavetables.h
+++ b/src/sfizz/Wavetables.h
@@ -8,6 +8,7 @@
 #include "Config.h"
 #include "LeakDetector.h"
 #include "Buffer.h"
+#include "MathHelpers.h"
 #include <absl/types/span.h>
 #include <absl/container/flat_hash_map.h>
 #include <memory>
@@ -17,6 +18,8 @@ namespace sfz {
 class FilePool;
 
 class WavetableMulti;
+
+enum InterpolatorModel : int;
 
 /**
    An oscillator based on wavetables
@@ -45,6 +48,16 @@ public:
     void setPhase(float phase);
 
     /**
+       Set the quality of this oscillator. (cf. `oscillator_quality`)
+
+       0: nearest
+       1: linear
+       2: high
+       3: dual-high
+     */
+    void setQuality(int q) { _quality = q; }
+
+    /**
        Compute a cycle of the oscillator, with constant frequency.
      */
     void process(float frequency, float detuneRatio, float* output, unsigned nframes);
@@ -55,17 +68,23 @@ public:
     void processModulated(const float* frequencies, float detuneRatio, float* output, unsigned nframes);
 
 private:
-    /**
-       Interpolate a value from a part of table, with delta in 0 to 1 excluded.
-       There are `TableExtra` elements available for reading.
-       (cf. WavetableMulti)
-     */
-    static float interpolate(const float* x, float delta);
+    // single-table interpolation
+    template <InterpolatorModel M>
+    void processSingle(float frequency, float detuneRatio, float* output, unsigned nframes);
+    template <InterpolatorModel M>
+    void processModulatedSingle(const float* frequencies, float detuneRatio, float* output, unsigned nframes);
+
+    // dual-table interpolation
+    template <InterpolatorModel M>
+    void processDual(float frequency, float detuneRatio, float* output, unsigned nframes);
+    template <InterpolatorModel M>
+    void processModulatedDual(const float* frequencies, float detuneRatio, float* output, unsigned nframes);
 
 private:
     float _phase = 0.0f;
     float _sampleInterval = 0.0f;
     const WavetableMulti* _multi = nullptr;
+    int _quality = 1;
     LEAK_DETECTOR(WavetableOscillator);
 };
 
@@ -154,6 +173,31 @@ public:
         return getTable(WavetableRange::getOctaveForFrequency(freq));
     }
 
+    // adjacent tables with interpolation factor between them
+    struct DualTable {
+        const float* table1;
+        const float* table2;
+        float delta;
+    };
+
+    // get the pair of tables at the fractional multisample position (range checked)
+    DualTable getInterpolationPair(float position) const
+    {
+        DualTable dt;
+        int index = static_cast<int>(position);
+        dt.delta = position - index;
+        dt.table1 = getTablePointer(clamp<int>(index, 0, WavetableRange::countOctaves - 1));
+        dt.table2 = getTablePointer(clamp<int>(index + 1, 0, WavetableRange::countOctaves - 1));
+        return dt;
+    }
+
+    // get the pair of tables for the given playback frequency (range checked)
+    DualTable getInterpolationPairForFrequency(float freq) const
+    {
+        float position = WavetableRange::getFractionalOctaveForFrequency(freq);
+        return getInterpolationPair(position);
+    }
+
     // create a multisample according to a given harmonic profile
     // the reference sample rate is the minimum value accepted by the DSP
     // system (most defavorable wrt. aliasing)
@@ -167,7 +211,7 @@ private:
     // get a pointer to the beginning of the N-th table
     const float* getTablePointer(unsigned index) const
     {
-        return _multiData.data() + index * (_tableSize + _tableExtra);
+        return _multiData.data() + index * (_tableSize + 2 * _tableExtra) + _tableExtra;
     }
 
     // allocate the internal data for tables of the given size

--- a/tests/WavetablesT.cpp
+++ b/tests/WavetablesT.cpp
@@ -8,6 +8,7 @@
 #include "sfizz/MathHelpers.h"
 #include "catch2/catch.hpp"
 #include <algorithm>
+#include <cmath>
 
 TEST_CASE("[Wavetables] Frequency ranges")
 {
@@ -37,4 +38,19 @@ TEST_CASE("[Wavetables] Frequency ranges")
     // check ranges to be decently adjusted to the MIDI frequency range
     REQUIRE(min_oct == 0);
     REQUIRE(max_oct == sfz::WavetableRange::countOctaves - 1);
+}
+
+TEST_CASE("[Wavetables] Octave number lookup")
+{
+    for (int note = 0; note < 128; ++note) {
+        double f = midiNoteFrequency(note);
+
+        float ref = std::log2(f * sfz::WavetableRange::frequencyScaleFactor);
+        float oct = sfz::WavetableRange::getFractionalOctaveForFrequency(f);
+
+        ref = clamp<float>(ref, 0, sfz::WavetableRange::countOctaves - 1);
+        oct = clamp<float>(oct, 0, sfz::WavetableRange::countOctaves - 1);
+
+        REQUIRE(oct == Approx(ref).margin(0.03f));
+    }
 }


### PR DESCRIPTION
Support various qualities of oscillator playback.

- 0: nearest
- 1: linear
- 2: high
- 3: dual-high

example: `<region> sample=*saw oscillator_quality=3`

The quality dual-high interpolates from a pair of adjacent tables.
In this case, a fractional table position is looked up from a table.

The wavetables will allocate extra elements before.
This is to accomodate with the polynomial interpolator.