### PR TITLE
Scheduling

### DIFF
--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -99,6 +99,10 @@ namespace config {
     static constexpr double amplitudeTriangle = 0.625;
     static constexpr double amplitudeSaw = 0.515;
     static constexpr double amplitudeSquare = 0.515;
+    /**
+       Background file loading
+     */
+    static constexpr int backgroundLoaderPthreadPriority = 50; // expressed in %
 } // namespace config
 
 } // namespace sfz

--- a/src/sfizz/FilePool.cpp
+++ b/src/sfizz/FilePool.cpp
@@ -377,7 +377,7 @@ void sfz::FilePool::clearingThread()
 void sfz::FilePool::loadingThread() noexcept
 {
     FilePromisePtr promise;
-    while (!quitThread) {
+    do {
         workerBarrier.wait();
 
         if (emptyQueue) {
@@ -388,6 +388,9 @@ void sfz::FilePool::loadingThread() noexcept
             semEmptyQueueFinished.post();
             continue;
         }
+
+        if (quitThread)
+            return;
 
         if (!promiseQueue.try_pop(promise)) {
             continue;
@@ -418,7 +421,7 @@ void sfz::FilePool::loadingThread() noexcept
         }
 
         promise.reset();
-    }
+    } while (1);
 }
 
 void sfz::FilePool::clear()

--- a/src/sfizz/FilePool.cpp
+++ b/src/sfizz/FilePool.cpp
@@ -516,7 +516,6 @@ void sfz::FilePool::waitForBackgroundLoading() noexcept
 void sfz::FilePool::raiseCurrentThreadPriority() noexcept
 {
 #if defined(_WIN32)
-    #pragma message("Implement Win32 thread background priority")
     HANDLE thread = GetCurrentThread();
     const int priority = THREAD_PRIORITY_ABOVE_NORMAL; /*THREAD_PRIORITY_HIGHEST*/
     if (!SetThreadPriority(thread, priority)) {

--- a/src/sfizz/FilePool.h
+++ b/src/sfizz/FilePool.h
@@ -273,6 +273,7 @@ private:
     // Signals
     volatile bool quitThread { false };
     volatile bool emptyQueue { false };
+    RTSemaphore semEmptyQueueFinished;
     std::atomic<int> threadsLoading { 0 };
     RTSemaphore workerBarrier;
     RTSemaphore semClearingRequest;

--- a/src/sfizz/FilePool.h
+++ b/src/sfizz/FilePool.h
@@ -259,6 +259,11 @@ public:
      * in the queue.
      */
     void waitForBackgroundLoading() noexcept;
+    /**
+     * @brief Assign the current thread a priority which is appropriate
+     * for background sample file processing.
+     */
+    static void raiseCurrentThreadPriority() noexcept;
 private:
     Logger& logger;
     fs::path rootDirectory;

--- a/src/sfizz/FilePool.h
+++ b/src/sfizz/FilePool.h
@@ -268,6 +268,7 @@ private:
 
     atomic_queue::AtomicQueue2<FilePromisePtr, config::maxVoices> promiseQueue;
     atomic_queue::AtomicQueue2<FilePromisePtr, config::maxVoices> filledPromiseQueue;
+    RTSemaphore semFilledPromiseQueueAvailable { config::maxVoices };
     uint32_t preloadSize { config::preloadSize };
     Oversampling oversamplingFactor { config::defaultOversamplingFactor };
     // Signals

--- a/src/sfizz/FilePool.h
+++ b/src/sfizz/FilePool.h
@@ -275,6 +275,7 @@ private:
     volatile bool emptyQueue { false };
     std::atomic<int> threadsLoading { 0 };
     RTSemaphore workerBarrier;
+    RTSemaphore semClearingRequest;
 
     // File promises data structures along with their guards.
     std::vector<FilePromisePtr> emptyPromises;


### PR DESCRIPTION
This increases the running priority of background threads, so it would react faster on note playback.
Some parts are rewritten to use semaphore, to ensure these high-prio threads are not going to spin.

One thing to make sure I get it right:
If a promise enters the list `toClear`, is it correct that it can't be anything else than `Ready` state?
(hence the condition below is redundant and safe to remove)
```
void sfz::FilePool::tryToClearPromises()
{
    const std::lock_guard<std::mutex> promiseLock { promiseGuard };

    for (auto& promise: promisesToClear) {
        if (promise->dataStatus != FilePromise::DataStatus::Wait)
            promise->reset();
    }
}
```