### PR TITLE
Smoother initial value

### DIFF
--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -111,7 +111,7 @@ namespace Default
         // Performance parameters: amplifier
 	constexpr float globalVolume { -7.35f };
 	constexpr float volume { 0.0f };
-	constexpr Range<float> volumeRange { -144.0, 6.0 };
+	constexpr Range<float> volumeRange { -144.0, 48.0 };
 	constexpr Range<float> volumeCCRange { -144.0, 48.0 };
 	constexpr float amplitude { 100.0 };
 	constexpr Range<float> amplitudeRange { 0.0, 100.0 };

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -136,21 +136,24 @@ void sfz::Voice::startVoice(Region* region, int delay, int number, float value, 
     for (auto& modId : allModifiers) {
         ASSERT(modifierSmoothers[modId].size() >= region->modifiers[modId].size());
         forEachWithSmoother(modId, [modId, this](const CCData<Modifier>& mod, Smoother& smoother) {
+            const auto ccValue = resources.midiState.getCCValue(mod.cc);
+            const auto curve = resources.curves.getCurve(mod.data.curve);
+            const auto finalValue = curve.evalNormalized(ccValue) * mod.data.value;
             switch (modId) {
             case Mod::volume:
-                smoother.reset(db2mag(resources.midiState.getCCValue(mod.cc) * mod.data.value));
+                smoother.reset(db2mag(finalValue));
                 break;
             case Mod::pitch:
-                smoother.reset(centsFactor(resources.midiState.getCCValue(mod.cc) * mod.data.value));
+                smoother.reset(centsFactor(finalValue));
                 break;
             case Mod::amplitude:
             case Mod::pan:
             case Mod::width:
             case Mod::position:
-                smoother.reset(normalizePercents(resources.midiState.getCCValue(mod.cc) * mod.data.value));
+                smoother.reset(normalizePercents(finalValue));
                 break;
             default:
-                smoother.reset(resources.midiState.getCCValue(mod.cc) * mod.data.value);
+                smoother.reset(finalValue);
                 break;
             }
             smoother.setSmoothing(mod.data.smooth, sampleRate);

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -522,8 +522,8 @@ TEST_CASE("[Region] Parsing opcodes")
         REQUIRE(region.volume == -123.0f);
         region.parseOpcode({ "volume", "-185" });
         REQUIRE(region.volume == -144.0f);
-        region.parseOpcode({ "volume", "19" });
-        REQUIRE(region.volume == 6.0f);
+        region.parseOpcode({ "volume", "79" });
+        REQUIRE(region.volume == 48.0f);
     }
 
     SECTION("pan")


### PR DESCRIPTION
The smoothers were not set taking a possible curve into account in the modifier. This was an issue in e.g. the FrnchFrgg version of IvyPiano.