### PR TITLE
lv2: add state path mapping

### DIFF
--- a/lv2/sfizz.ttl.in
+++ b/lv2/sfizz.ttl.in
@@ -67,7 +67,7 @@ midnam:update a lv2:Feature .
   lv2:microVersion @LV2PLUGIN_VERSION_MICRO@ ;
 
   lv2:requiredFeature urid:map, bufsize:boundedBlockLength, work:schedule ;
-  lv2:optionalFeature lv2:hardRTCapable, opts:options ;
+  lv2:optionalFeature lv2:hardRTCapable, opts:options, state:mapPath ;
   lv2:extensionData opts:interface, state:interface, work:interface ;
 
   lv2:optionalFeature midnam:update ;

--- a/lv2/sfizz.ttl.in
+++ b/lv2/sfizz.ttl.in
@@ -67,7 +67,7 @@ midnam:update a lv2:Feature .
   lv2:microVersion @LV2PLUGIN_VERSION_MICRO@ ;
 
   lv2:requiredFeature urid:map, bufsize:boundedBlockLength, work:schedule ;
-  lv2:optionalFeature lv2:hardRTCapable, opts:options, state:mapPath ;
+  lv2:optionalFeature lv2:hardRTCapable, opts:options, state:mapPath, state:freePath ;
   lv2:extensionData opts:interface, state:interface, work:interface ;
 
   lv2:optionalFeature midnam:update ;

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -331,7 +331,11 @@ bool sfz::Synth::loadSfzFile(const fs::path& file)
     clear();
 
     const std::lock_guard<std::mutex> disableCallback { callbackGuard };
-    parser.parseFile(file);
+
+    std::error_code ec;
+    fs::path realFile = fs::canonical(file, ec);
+
+    parser.parseFile(ec ? file : realFile);
     if (parser.getErrorCount() > 0)
         return false;
 


### PR DESCRIPTION
This implements the `mapPath` support in LV2. The feature is optional in the host.
The symlinks will be resolved in order to locate the sidecar files properly.