### PR TITLE
Noise generators

### DIFF
--- a/benchmarks/BM_random.cpp
+++ b/benchmarks/BM_random.cpp
@@ -77,12 +77,13 @@ BENCHMARK_DEFINE_F(RandomFill, StdNormal)(benchmark::State& state) {
 }
 
 BENCHMARK_DEFINE_F(RandomFill, FastNormal)(benchmark::State& state) {
+    fast_rand prng;
     fast_gaussian_generator<float, 4> generator(0.0f, 0.25f);
 
     for (auto _ : state)
     {
         for (float &out : output)
-            out = generator();
+            out = generator(prng);
     }
 }
 

--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -79,6 +79,7 @@ namespace config {
     constexpr int eqsPerVoice { 3 };
     constexpr int oscillatorsPerVoice { 9 };
     constexpr float noiseVariance { 0.25f };
+    constexpr float uniformNoiseBounds { 0.25f };
     /**
        Minimum interval in frames between recomputations of coefficients of the
        modulated filter. The lower, the more CPU resources are consumed.

--- a/src/sfizz/MathHelpers.h
+++ b/src/sfizz/MathHelpers.h
@@ -571,8 +571,7 @@ class fast_real_distribution {
 public:
     static_assert(std::is_floating_point<T>::value, "The type must be floating point.");
 
-    typedef T result_type;
-
+    fast_real_distribution() = delete;
     fast_real_distribution(T a, T b)
         : a_(a), b_(b), k_(b - a)
     {
@@ -628,38 +627,25 @@ static fast_rand randomGenerator;
  */
 template <class T, unsigned N = 4>
 class fast_gaussian_generator {
-    static_assert(N > 1, "Invalid quality setting");
-
 public:
-    explicit fast_gaussian_generator(float mean, float variance, uint32_t initialSeed = Random::randomGenerator())
+    fast_gaussian_generator() = delete;
+    explicit fast_gaussian_generator(T mean, T variance)
     {
         mean_ = mean;
-        gain_ = variance / std::sqrt(N / 3.0);
-        seed(initialSeed);
+        gain_ = variance / std::sqrt(N / T{ 3 });
     }
 
-    void seed(uint32_t s)
+    template <class G>
+    T operator()(G& g) noexcept
     {
-        seeds_[0] = s;
-        for (unsigned i = 1; i < N; ++i) {
-            s += s * 1664525u + 1013904223u;
-            seeds_[i] = s;
-        }
-    }
-
-    float operator()() noexcept
-    {
-        float sum = 0;
+        T sum { 0.0 };
         for (unsigned i = 0; i < N; ++i) {
-            uint32_t next = seeds_[i] * 1664525u + 1013904223u;
-            seeds_[i] = next;
-            sum += static_cast<int32_t>(next) * (1.0f / (1ll << 31));
+            sum += static_cast<int32_t>(g()) * (1.0f / (1ll << 31));
         }
         return mean_ + gain_ * sum;
     }
 
 private:
-    std::array<uint32_t, N> seeds_ {};
-    float mean_ { 0 };
-    float gain_ { 0 };
+    T mean_ { 0 };
+    T gain_ { T{ 1 } / std::sqrt(N / T{ 3 }) };
 };

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -609,8 +609,17 @@ void sfz::Voice::fillWithGenerator(AudioSpan<float> buffer) noexcept
     const auto rightSpan  = buffer.getSpan(1);
 
     if (region->sampleId.filename() == "*noise") {
-        absl::c_generate(leftSpan, noiseDist);
-        absl::c_generate(rightSpan, noiseDist);
+        auto gen = [&]() {
+            return uniformNoiseDist(Random::randomGenerator);
+        };
+        absl::c_generate(leftSpan, gen);
+        absl::c_generate(rightSpan, gen);
+    } else if (region->sampleId.filename() == "*gnoise") {
+        auto gen = [&]() {
+            return gaussianNoiseDist(Random::randomGenerator);
+        };
+        absl::c_generate(leftSpan, gen);
+        absl::c_generate(rightSpan, gen);
     } else {
         const auto numFrames = buffer.getNumFrames();
 

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -467,7 +467,8 @@ private:
     Voice* nextSisterVoice { this };
     Voice* previousSisterVoice { this };
 
-    fast_gaussian_generator<float> noiseDist { 0.0f, config::noiseVariance };
+    fast_real_distribution<float> uniformNoiseDist { -config::uniformNoiseBounds, config::uniformNoiseBounds };
+    fast_gaussian_generator<float> gaussianNoiseDist { 0.0f, config::noiseVariance };
 
     ModifierArray<std::vector<Smoother>> modifierSmoothers;
     Smoother gainSmoother;

--- a/tests/RandomHelpersT.cpp
+++ b/tests/RandomHelpersT.cpp
@@ -76,7 +76,7 @@ static bool gaussianRandomTest(double mean, float variance, size_t numGen, size_
     // generate, quantify, count occurrences
     std::vector<size_t> counts(histSize);
     for (size_t i = 0; i < numGen; ++i) {
-        double value = gen();
+        double value = gen(prng);
         double normalized = (value - min) / (max - min);
         long bin = std::lround(histSize * normalized);
         if (bin >= 0 && static_cast<size_t>(bin) < histSize)


### PR DESCRIPTION
Closes #290 

This implements `*noise` as the uniform noise, and `*gnoise` as the Gaussian one.

There was one issue with the current Gaussian noise generator in that it acted like a shift register. The gaussian samples are formed by summing N uniforms, but since these were shifted along, consecutive gaussian samples actually shared N-1 common samples and were therefore highly correlated. Such correlation acts like a filter in the output.

The second issue was that for some reason, `std::generate` (or abseil `c_generate`) took a copy of the `fast_gaussian_generator` instead of a reference, thereby copying the initial state of the generator at the beginning of each block. After some very boring debugging, I decided to avoid the aggravation and make the `fast_gaussian_generator` call the PRNG. This is a bit slower (about 50%), for some reason there's no automatic SIMD in this case, but since it's an exotic noise that's only in sfizz maybe we can let it go.