### PR TITLE
Windows tests

### DIFF
--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -41,7 +41,7 @@ namespace config {
     constexpr int numVoices { 64 };
     constexpr unsigned maxVoices { 256 };
     constexpr unsigned smoothingSteps { 512 };
-    constexpr uint8_t gainSmoothing { 5 };
+    constexpr uint8_t gainSmoothing { 0 };
     constexpr unsigned powerTableSizeExponent { 11 };
     constexpr int maxFilePromises { maxVoices };
     constexpr int sustainCC { 64 };

--- a/src/sfizz/MathHelpers.h
+++ b/src/sfizz/MathHelpers.h
@@ -15,6 +15,7 @@
 #include "SIMDConfig.h"
 #include "absl/types/span.h"
 #include <algorithm>
+#include <array>
 #include <random>
 #include <limits>
 #include <type_traits>

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -409,8 +409,9 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
             if (opcode.parameters.back() > 127)
                 return false;
 
+            const auto inputVelocity = static_cast<uint8_t>(opcode.parameters.back());
             if (value)
-                velocityPoints.emplace_back(opcode.parameters.back(), *value);
+                velocityPoints.emplace_back(inputVelocity, *value);
         }
         break;
     case hash("xfin_lokey"):

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -301,8 +301,10 @@ void sfz::Synth::handleControlOpcodes(const std::vector<Opcode>& members)
                 ccLabels.emplace_back(member.parameters.back(), std::string(member.value));
             break;
         case hash("label_key&"):
-            if (Default::keyRange.containsWithEnd(member.parameters.back()))
-                keyLabels.emplace_back(member.parameters.back(), std::string(member.value));
+            if (member.parameters.back() <= Default::keyRange.getEnd()) {
+                const auto noteNumber = static_cast<uint8_t>(member.parameters.back());
+                keyLabels.emplace_back(noteNumber, std::string(member.value));
+            }
             break;
         case hash("default_path"):
             defaultPath = absl::StrReplaceAll(trim(member.value), { { "\\", "/" } });

--- a/tests/InterpolatorsT.cpp
+++ b/tests/InterpolatorsT.cpp
@@ -6,7 +6,8 @@
 
 #include "sfizz/Interpolators.h"
 #include "catch2/catch.hpp"
-#include <algorithm>
+#include <array>
+#include <numeric>
 using namespace Catch::literals;
 
 TEST_CASE("[Interpolators] Sample at points")


### PR DESCRIPTION
This silences some warnings on MSVC, and disable the global gain smoother which does not exist on sforzando and has a high performance cost. We could add a global switch/opcode to reactivate it at some point, to declick e.g. crossfades which sometimes are not smooth and for which there is no `_smooth` modifier.