### PR TITLE
Crossfade smoothers

### DIFF
--- a/.travis/install_osx.sh
+++ b/.travis/install_osx.sh
@@ -4,6 +4,7 @@ set -ex
 
 sudo ln -s /usr/local /opt/local
 brew update
+brew upgrade python ||  brew link --overwrite python
 brew upgrade cmake
 brew install jack
 brew install dylibbundler

--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -41,6 +41,7 @@ namespace config {
     constexpr int numVoices { 64 };
     constexpr unsigned maxVoices { 256 };
     constexpr unsigned smoothingSteps { 512 };
+    constexpr uint8_t xfadeSmoothing { 5 };
     constexpr uint8_t gainSmoothing { 0 };
     constexpr unsigned powerTableSizeExponent { 11 };
     constexpr int maxFilePromises { maxVoices };

--- a/src/sfizz/OnePoleFilter.h
+++ b/src/sfizz/OnePoleFilter.h
@@ -25,6 +25,8 @@ class OnePoleFilter {
 public:
     OnePoleFilter() = default;
 
+    Type current() const { return state; }
+
     void setGain(Type gain)
     {
         G = gain / (1 + gain);

--- a/src/sfizz/Smoothers.cpp
+++ b/src/sfizz/Smoothers.cpp
@@ -27,10 +27,25 @@ void Smoother::reset(float value)
 
 void Smoother::process(absl::Span<const float> input, absl::Span<float> output)
 {
-    if (smoothing)
+    CHECK_SPAN_SIZES(input, output);
+    if (input.size() == 0)
+        return;
+
+    const auto midValue = input[input.size() / 2];
+    const bool shortcut = (
+        input.front() == input.back()
+        && input.front() == midValue
+        && input.front() == current()
+    );
+
+    if (smoothing && !shortcut) {
         filter.processLowpass(input, output);
-    else
+    }
+    else if (input.data() != output.data()) {
         copy<float>(input, output);
+    } else {
+        // Nothing to do
+    }
 }
 
 }

--- a/src/sfizz/Smoothers.h
+++ b/src/sfizz/Smoothers.h
@@ -45,6 +45,7 @@ public:
      */
     void process(absl::Span<const float> input, absl::Span<float> output);
 
+    float current() const { return filter.current(); }
 private:
     bool smoothing { false };
     OnePoleFilter<float> filter {};

--- a/src/sfizz/Smoothers.h
+++ b/src/sfizz/Smoothers.h
@@ -42,8 +42,11 @@ public:
      *
      * @param input
      * @param output
+     * @param canShortcut whether we can have a fast path if the filter is within
+     *                    a reasonable range around the first value of the input
+     *                    span.
      */
-    void process(absl::Span<const float> input, absl::Span<float> output);
+    void process(absl::Span<const float> input, absl::Span<float> output, bool canShortcut = false);
 
     float current() const { return filter.current(); }
 private:

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -347,6 +347,7 @@ private:
      * @param modulationSpan
      */
     void applyCrossfades(absl::Span<float> modulationSpan) noexcept;
+    void resetCrossfades() noexcept;
 
     /**
      * @brief Amplitude stage for a mono source

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -340,6 +340,14 @@ private:
      * @param modulationSpan
      */
     void amplitudeEnvelope(absl::Span<float> modulationSpan) noexcept;
+
+    /**
+     * @brief Apply the crossfade envelope to a span.
+     *
+     * @param modulationSpan
+     */
+    void applyCrossfades(absl::Span<float> modulationSpan) noexcept;
+
     /**
      * @brief Amplitude stage for a mono source
      *
@@ -473,6 +481,7 @@ private:
     ModifierArray<std::vector<Smoother>> modifierSmoothers;
     Smoother gainSmoother;
     Smoother bendSmoother;
+    Smoother xfadeSmoother;
     void resetSmoothers() noexcept;
 
     std::array<OnePoleFilter<float>, 2> channelEnvelopeFilters;


### PR DESCRIPTION
This adds a crossfade smoother, regarding previous reports in #153 #22 #19 . There was an improvement with the global gain smoothing in #181 which was reverted in #309 because applying it globally on the gain had undesirable side-effects on e.g. drums with big transients.

This PR:
- Adds a "shortcut" in all smoothers. A smoother will just copy the span if i) the input span to smooth seems to be basically constant, and ii) the first value of the span is the same as the current state of the smoother.
- Add a separate process for the crossfades.

I'll evaluate the performance loss/gain.

@jpcima When doing this modulation matrix I think it'd be good to find a clean way to shortcut as much as possible. Let's discuss this further 🙂 