### PR TITLE
Allow opcodes to print in test outputs

### DIFF
--- a/src/sfizz/Opcode.cpp
+++ b/src/sfizz/Opcode.cpp
@@ -9,6 +9,7 @@
 #include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
+#include <iostream>
 #include <cctype>
 #include <cassert>
 
@@ -153,4 +154,9 @@ absl::optional<uint8_t> sfz::readNoteValue(absl::string_view value)
         return {};
 
     return static_cast<uint8_t>(noteNumber);
+}
+
+std::ostream &operator<<(std::ostream &os, const sfz::Opcode &opcode)
+{
+    return os << opcode.opcode << '=' << '"' << opcode.value << '"';
 }

--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -16,6 +16,7 @@
 #include <string_view>
 #include <vector>
 #include <type_traits>
+#include <iosfwd>
 
 // charconv support is still sketchy with clang/gcc so we use abseil's numbers
 #include "absl/strings/numbers.h"
@@ -292,3 +293,5 @@ inline void setCCPairFromOpcode(const Opcode& opcode, absl::optional<CCData<Valu
 }
 
 }
+
+std::ostream &operator<<(std::ostream &os, const sfz::Opcode &opcode);


### PR DESCRIPTION
Allows unit test to print opcodes instead of `{?}`