### PR TITLE
Higher quality wavetable mipmaps

### DIFF
--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -95,6 +95,7 @@ namespace config {
     constexpr int maxEffectBuses { 256 };
     // Wavetable constants; amplitude values are matched to reference
     static constexpr unsigned tableSize = 1024;
+    static constexpr double tableRefSampleRate = 44100.0 * 1.1; // +10% aliasing permissivity
     static constexpr double amplitudeSine = 0.625;
     static constexpr double amplitudeTriangle = 0.625;
     static constexpr double amplitudeSaw = 0.515;

--- a/src/sfizz/Wavetables.cpp
+++ b/src/sfizz/Wavetables.cpp
@@ -295,10 +295,9 @@ const std::array<float, 1024> MipmapRange::FrequencyToIndex = []()
     std::array<float, 1024> table;
 
     for (unsigned i = 0; i < table.size() - 1; ++i) {
-        double r = i * (1.0 / (table.size() - 1));
-        double f = F1 + r * (FN - F1);
-        double t = std::log(K * f) / LogB;
-        table[i] = clamp<float>(t, 0, N - 1);
+        float r = i * (1.0f / (table.size() - 1));
+        float f = F1 + r * (FN - F1);
+        table[i] = getExactIndexForFrequency(f);
     }
     // ensure the last element to be exact
     table[table.size() - 1] = N - 1;
@@ -319,6 +318,12 @@ float MipmapRange::getIndexForFrequency(float f)
 
     return (1.0f - frac) * FrequencyToIndex[index1] +
         frac * FrequencyToIndex[index2];
+}
+
+float MipmapRange::getExactIndexForFrequency(float f)
+{
+    float t = (f < F1) ? 0.0f : (std::log(K * f) / LogB);
+    return clamp<float>(t, 0, N - 1);
 }
 
 const std::array<float, MipmapRange::N + 1> MipmapRange::IndexToStartFrequency = []()

--- a/src/sfizz/Wavetables.h
+++ b/src/sfizz/Wavetables.h
@@ -142,6 +142,7 @@ public:
     static constexpr float FN = 12000.0;
 
     static float getIndexForFrequency(float f);
+    static float getExactIndexForFrequency(float f);
     static MipmapRange getRangeForIndex(int o);
     static MipmapRange getRangeForFrequency(float f);
 

--- a/src/sfizz/Wavetables.h
+++ b/src/sfizz/Wavetables.h
@@ -214,7 +214,9 @@ public:
     // the reference sample rate is the minimum value accepted by the DSP
     // system (most defavorable wrt. aliasing)
     static WavetableMulti createForHarmonicProfile(
-        const HarmonicProfile& hp, double amplitude, unsigned tableSize = config::tableSize, double refSampleRate = 44100.0);
+        const HarmonicProfile& hp, double amplitude,
+        unsigned tableSize = config::tableSize,
+        double refSampleRate = config::tableRefSampleRate);
 
     // get a tiny silent wavetable with null content for use with oscillators
     static const WavetableMulti* getSilenceWavetable();

--- a/tests/DemoWavetables.cpp
+++ b/tests/DemoWavetables.cpp
@@ -36,6 +36,7 @@ private:
 
 private:
     void valueChangedWave(int value);
+    void valueChangedQuality(int value);
     void buttonClickedPlaySweep();
 
 private:
@@ -46,6 +47,7 @@ private:
     sfz::WavetableOscillator fOsc;
     unsigned fWavePlaying = 0;
     std::atomic<int> fNewWavePending { -1 };
+    std::atomic<int> fNewQualityPending { -1 };
     std::atomic<bool> fStartNewSweep { false };
 
     static constexpr float sweepMin = 0.0;
@@ -88,13 +90,13 @@ bool DemoApp::initSound()
     fTmpFrequency.reset(new float[bufferSize]);
 
     fMulti[0] = sfz::WavetableMulti::createForHarmonicProfile(
-        sfz::HarmonicProfile::getSine(), 1.0, 2048);
+        sfz::HarmonicProfile::getSine(), sfz::config::amplitudeSine, 2048);
     fMulti[1] = sfz::WavetableMulti::createForHarmonicProfile(
-        sfz::HarmonicProfile::getTriangle(), 1.0, 2048);
+        sfz::HarmonicProfile::getTriangle(), sfz::config::amplitudeTriangle, 2048);
     fMulti[2] = sfz::WavetableMulti::createForHarmonicProfile(
-        sfz::HarmonicProfile::getSaw(), 1.0, 2048);
+        sfz::HarmonicProfile::getSaw(), sfz::config::amplitudeSaw, 2048);
     fMulti[3] = sfz::WavetableMulti::createForHarmonicProfile(
-        sfz::HarmonicProfile::getSquare(), 1.0, 2048);
+        sfz::HarmonicProfile::getSquare(), sfz::config::amplitudeSquare, 2048);
 
     fClient.reset(client);
 
@@ -128,9 +130,20 @@ void DemoApp::initWindow()
     fUi.valWave->addItem(tr("3 - Saw"));
     fUi.valWave->addItem(tr("4 - Square"));
 
+    fUi.valQuality->addItem(tr("1 - Nearest"));
+    fUi.valQuality->addItem(tr("2 - Linear"));
+    fUi.valQuality->addItem(tr("3 - High"));
+    fUi.valQuality->addItem(tr("4 - Dual-High"));
+
+    fUi.valQuality->setCurrentIndex(fOsc.quality());
+
     connect(
         fUi.valWave, QOverload<int>::of(&QComboBox::currentIndexChanged),
         this, [this](int index) { valueChangedWave(index); });
+
+    connect(
+        fUi.valQuality, QOverload<int>::of(&QComboBox::currentIndexChanged),
+        this, [this](int index) { valueChangedQuality(index); });
 
     connect(
         fUi.btnPlaySweep, &QPushButton::clicked,
@@ -151,6 +164,10 @@ int DemoApp::processAudio(jack_nframes_t nframes, void* cbdata)
     int newWave = self->fNewWavePending.exchange(-1);
     if (newWave != -1)
         self->fWavePlaying = newWave;
+
+    int newQuality = self->fNewQualityPending.exchange(-1);
+    if (newQuality != -1)
+        osc.setQuality(newQuality);
 
     osc.setWavetable(&self->fMulti[self->fWavePlaying]);
 
@@ -181,6 +198,11 @@ int DemoApp::processAudio(jack_nframes_t nframes, void* cbdata)
 void DemoApp::valueChangedWave(int value)
 {
     fNewWavePending.store(value);
+}
+
+void DemoApp::valueChangedQuality(int value)
+{
+    fNewQualityPending.store(value);
 }
 
 void DemoApp::buttonClickedPlaySweep()

--- a/tests/DemoWavetables.ui
+++ b/tests/DemoWavetables.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>170</width>
+    <width>255</width>
     <height>103</height>
    </rect>
   </property>
@@ -20,6 +20,13 @@
      </widget>
     </item>
     <item row="0" column="1">
+     <widget class="QLabel" name="label_3">
+      <property name="text">
+       <string>Select quality</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="2">
      <widget class="QLabel" name="label_2">
       <property name="text">
        <string>Play sweep</string>
@@ -30,6 +37,9 @@
      <widget class="QComboBox" name="valWave"/>
     </item>
     <item row="1" column="1">
+     <widget class="QComboBox" name="valQuality"/>
+    </item>
+    <item row="1" column="2">
      <widget class="QPushButton" name="btnPlaySweep">
       <property name="minimumSize">
        <size>
@@ -38,7 +48,8 @@
        </size>
       </property>
       <property name="icon">
-       <iconset theme="media-playback-start"/>
+       <iconset theme="media-playback-start">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </widget>
     </item>

--- a/tests/WavetablesT.cpp
+++ b/tests/WavetablesT.cpp
@@ -12,45 +12,38 @@
 
 TEST_CASE("[Wavetables] Frequency ranges")
 {
-    int cur_oct = std::numeric_limits<int>::min();
-    int min_oct = std::numeric_limits<int>::max();
-    int max_oct = std::numeric_limits<int>::min();
+    int cur_index = std::numeric_limits<int>::min();
+    int min_index = std::numeric_limits<int>::max();
+    int max_index = std::numeric_limits<int>::min();
 
     for (int note = 0; note < 128; ++note) {
         double f = midiNoteFrequency(note);
 
-        int oct = sfz::WavetableRange::getOctaveForFrequency(f);
+        float fractionalIndex = sfz::MipmapRange::getExactIndexForFrequency(f);
+        int index = static_cast<int>(fractionalIndex);
 
-        REQUIRE(oct >= 0);
-        REQUIRE(oct < sfz::WavetableRange::countOctaves);
+        REQUIRE(index >= 0);
+        REQUIRE(static_cast<unsigned>(index) < sfz::MipmapRange::N);
 
-        REQUIRE(oct >= cur_oct);
-        cur_oct = oct;
+        float lerpFractionalIndex = sfz::MipmapRange::getIndexForFrequency(f);
+        int lerpIndex = static_cast<int>(lerpFractionalIndex);
 
-        min_oct = std::min(min_oct, oct);
-        max_oct = std::max(max_oct, oct);
+        // approximation should be equal or off by 1 table in worst cases
+        bool lerpIndexValid = (lerpIndex - index) == 0 || (lerpIndex - index) == -1;
+        REQUIRE(lerpIndexValid);
 
-        sfz::WavetableRange range = sfz::WavetableRange::getRangeForOctave(oct);
-        REQUIRE((f >= range.minFrequency || oct == 0));
-        REQUIRE((f <= range.maxFrequency || oct == sfz::WavetableRange::countOctaves - 1));
+        REQUIRE(index >= cur_index);
+        cur_index = index;
+
+        min_index = std::min(min_index, index);
+        max_index = std::max(max_index, index);
+
+        sfz::MipmapRange range = sfz::MipmapRange::getRangeForIndex(index);
+        REQUIRE((f >= range.minFrequency || index == 0));
+        REQUIRE((f <= range.maxFrequency || index == sfz::MipmapRange::N - 1));
     }
 
     // check ranges to be decently adjusted to the MIDI frequency range
-    REQUIRE(min_oct == 0);
-    REQUIRE(max_oct == sfz::WavetableRange::countOctaves - 1);
-}
-
-TEST_CASE("[Wavetables] Octave number lookup")
-{
-    for (int note = 0; note < 128; ++note) {
-        double f = midiNoteFrequency(note);
-
-        float ref = std::log2(f * sfz::WavetableRange::frequencyScaleFactor);
-        float oct = sfz::WavetableRange::getFractionalOctaveForFrequency(f);
-
-        ref = clamp<float>(ref, 0, sfz::WavetableRange::countOctaves - 1);
-        oct = clamp<float>(oct, 0, sfz::WavetableRange::countOctaves - 1);
-
-        REQUIRE(oct == Approx(ref).margin(0.03f));
-    }
+    REQUIRE(min_index == 0);
+    REQUIRE(max_index == sfz::MipmapRange::N - 1);
 }


### PR DESCRIPTION
This increases the number of mipmaps and modifies the mapping formula frequency→table.
The older mipmaps could have a gap in higher frequencies which reaches as low as 11 kHz over some ranges.

This implements a case similar to the 24-table as seen here, which performs significantly better
https://www.earlevel.com/main/2019/04/30/waveutils-updated/

The mapping uses a base ≠ 2 for logarithm which is not so trivially computable in this case, the computation has been replaced with a look-up table. Formula is documented in comments.

A suggestion from these articles is to raise the `refSampleRate` by some amount, eg. +10%, such that some slight aliasing may be allowed, and this permits to reduce further the table transition harmonic gap.
If this is used, this can permit to maintain a comparable quality level but without increasing the number of tables.
To measure. Not done as a part of this commit but it's trivial changing it.

The formula is designed such that it adapts to some parameter constants.
Following can be edited for experimenting
- number of tables: `static constexpr unsigned N = 24;`
- reference sample rate for cutoff `double refSampleRate = 44100.0`
  (eg. change to `1.1 * refSampleRate` for 10% aliasing permissivity)

![wavetables](https://user-images.githubusercontent.com/17614485/89724282-4b37ec00-da01-11ea-8f55-41a58997f33f.png)

Gnuplot code
```
set xrange [10:22000]
set logscale x
set grid
set key top left

log2(x)=log(x)/log(2)
min(a, b)=(a<b)?a:b
max(a, b)=(a>b)?a:b

# defaults
f0=20.0       # minimum frequency
fK=12000.0    # start frequency of last table

# compute adjustment variables b and k, such that first/last table begins at frequency f0/fK
k(f0, fK, nt)=1.0/f0
b(f0, fK, nt)=exp(log(fK/f0)/(nt-1.0))

# compute table index for frequency
t(f, f0, fK, nt)=max(0, min(nt-1, (f<f0)?0:floor(log(k(f0, fK, nt)*f)/log(b(f0, fK, nt)))))

plot \
     t(x, f0, fK, 16) t "new 16 tables", \
     t(x, f0, fK, 20) t "new 20 tables", \
     t(x, f0, fK, 24) t "new 24 tables", \
     floor(max(0, log2(0.05*x))) t "old"
```