### PR TITLE
Ignore released voices in search of selfmask candidate

### DIFF
--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -877,7 +877,7 @@ void sfz::Synth::noteOnDispatch(int delay, int noteNumber, float velocity) noexc
                 }
 
                 if (region->notePolyphony) {
-                    if (voice->getTriggerNumber() == noteNumber && voice->getTriggerType() == Voice::TriggerType::NoteOn) {
+                    if (voice->getTriggerNumber() == noteNumber && voice->getTriggerType() == Voice::TriggerType::NoteOn && !voice->releasedOrFree()) {
                         notePolyphonyCounter += 1;
                         switch (region->selfMask) {
                         case SfzSelfMask::mask:

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -877,7 +877,9 @@ void sfz::Synth::noteOnDispatch(int delay, int noteNumber, float velocity) noexc
                 }
 
                 if (region->notePolyphony) {
-                    if (voice->getTriggerNumber() == noteNumber && voice->getTriggerType() == Voice::TriggerType::NoteOn && !voice->releasedOrFree()) {
+                    if (!voice->releasedOrFree()
+                        && voice->getTriggerNumber() == noteNumber
+                        && voice->getTriggerType() == Voice::TriggerType::NoteOn) {
                         notePolyphonyCounter += 1;
                         switch (region->selfMask) {
                         case SfzSelfMask::mask:


### PR DESCRIPTION
Is it correct to think that selfmask search should ignore voices which are already released?
this should prevent it to reselecting a voice which has been previously self-masked but not finished its envelope? @paulfd