### PR TITLE
Polyphony again

### DIFF
--- a/src/sfizz/ADSREnvelope.h
+++ b/src/sfizz/ADSREnvelope.h
@@ -45,14 +45,17 @@ public:
      */
     void getBlock(absl::Span<Type> output) noexcept;
     /**
+     * @brief Set the release time for the envelope
+     *
+     * @param timeInSeconds
+     */
+    void setReleaseTime(Type timeInSeconds) noexcept;
+    /**
      * @brief Start the envelope release after a delay.
      *
      * @param releaseDelay the delay before releasing in samples
-     * @param fastRelease whether the release should be fast (i.e. 0 or so) or
-     *                    follow the release duration that was set when
-     *                    initializing the envelope
      */
-    void startRelease(int releaseDelay, bool fastRelease = false) noexcept;
+    void startRelease(int releaseDelay) noexcept;
     /**
      * @brief Is the envelope smoothing?
      *
@@ -75,6 +78,11 @@ public:
     int getRemainingDelay() const noexcept;
 
 private:
+    float sampleRate { config::defaultSampleRate };
+    Type secondsToSamples (Type timeInSeconds) const noexcept;
+    Type secondsToLinRate (Type timeInSeconds) const noexcept;
+    Type secondsToExpRate (Type timeInSeconds) const noexcept;
+
     enum class State {
         Delay,
         Attack,

--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -31,7 +31,7 @@
 
 enum class SfzTrigger { attack, release, release_key, first, legato };
 enum class SfzLoopMode { no_loop, one_shot, loop_continuous, loop_sustain };
-enum class SfzOffMode { fast, normal };
+enum class SfzOffMode { fast, normal, time };
 enum class SfzVelocityOverride { current, previous };
 enum class SfzCrossfadeCurve { gain, power };
 enum class SfzSelfMask { mask, dontMask };
@@ -75,6 +75,7 @@ namespace Default
 	constexpr uint32_t group { 0 };
 	constexpr Range<uint32_t> groupRange { 0, std::numeric_limits<uint32_t>::max() };
 	constexpr SfzOffMode offMode { SfzOffMode::fast };
+	constexpr float offTime { 6e-3f };
     constexpr Range<uint32_t> polyphonyRange { 0, config::maxVoices };
     constexpr SfzSelfMask selfMask { SfzSelfMask::mask };
 

--- a/src/sfizz/PolyphonyGroup.cpp
+++ b/src/sfizz/PolyphonyGroup.cpp
@@ -16,3 +16,10 @@ void sfz::PolyphonyGroup::removeVoice(const Voice* voice) noexcept
 {
     swapAndPopFirst(voices, [voice](const Voice* v) { return v == voice; });
 }
+
+unsigned sfz::PolyphonyGroup::numPlayingVoices() const noexcept
+{
+    return absl::c_count_if(voices, [](const Voice* v) {
+        return !v->releasedOrFree();
+    });
+}

--- a/src/sfizz/PolyphonyGroup.h
+++ b/src/sfizz/PolyphonyGroup.h
@@ -41,6 +41,10 @@ public:
      */
     unsigned getPolyphonyLimit() const noexcept { return polyphonyLimit; }
     /**
+     * @brief Returns the number of playing (unreleased) voices
+     */
+    unsigned numPlayingVoices() const noexcept;
+    /**
      * @brief Get the active voices
      *
      * @return const std::vector<Voice*>&

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -169,6 +169,7 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
         }
         break;
     case hash("off_time"):
+        offMode = SfzOffMode::time;
         setValueFromOpcode(opcode, offTime, Default::egTimeRange);
         break;
     case hash("polyphony"):

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -161,9 +161,15 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
         case hash("normal"):
             offMode = SfzOffMode::normal;
             break;
+        case hash("time"):
+            offMode = SfzOffMode::time;
+            break;
         default:
             DBG("Unkown off mode:" << opcode.value);
         }
+        break;
+    case hash("off_time"):
+        setValueFromOpcode(opcode, offTime, Default::egTimeRange);
         break;
     case hash("polyphony"):
         if (auto value = readOpcode(opcode.value, Default::polyphonyRange))

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -286,6 +286,7 @@ struct Region {
     uint32_t group { Default::group }; // group
     absl::optional<uint32_t> offBy {}; // off_by
     SfzOffMode offMode { Default::offMode }; // off_mode
+    float offTime { Default::offTime }; // off_mode
     absl::optional<uint32_t> notePolyphony {}; // note_polyphony
     unsigned polyphony { config::maxVoices }; // polyphony
     SfzSelfMask selfMask { Default::selfMask };

--- a/src/sfizz/RegionSet.cpp
+++ b/src/sfizz/RegionSet.cpp
@@ -46,3 +46,10 @@ void sfz::RegionSet::removeVoiceFromHierarchy(const Region* region, const Voice*
         parent = parent->getParent();
     }
 }
+
+unsigned sfz::RegionSet::numPlayingVoices() const noexcept
+{
+    return absl::c_count_if(voices, [](const Voice* v) {
+        return !v->releasedOrFree();
+    });
+}

--- a/src/sfizz/RegionSet.h
+++ b/src/sfizz/RegionSet.h
@@ -80,6 +80,10 @@ public:
      */
     void setParent(RegionSet* parent) noexcept { this->parent = parent; }
     /**
+     * @brief Returns the number of playing (unreleased) voices
+     */
+    unsigned numPlayingVoices() const noexcept;
+    /**
      * @brief Get the active voices
      *
      * @return const std::vector<Voice*>&

--- a/src/sfizz/SisterVoiceRing.h
+++ b/src/sfizz/SisterVoiceRing.h
@@ -57,6 +57,22 @@ struct SisterVoiceRing {
     }
 
     /**
+     * @brief Off all sisters in a ring
+     *
+     * @param voice
+     * @param delay
+     */
+    template<class T,
+        absl::enable_if_t<std::is_same<Voice, absl::remove_const_t<T>>::value, int> = 0>
+    static void offAllSisters(T* voice, int delay) {
+        if (voice != nullptr) {
+            SisterVoiceRing::applyToRing(voice, [&] (Voice* v) {
+                v->off(delay);
+            });
+        }
+    }
+
+    /**
      * @brief Check if a sister voice ring is well formed
      *
      * @param start

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -925,6 +925,7 @@ void sfz::Synth::noteOnDispatch(int delay, int noteNumber, float velocity) noexc
 
                 if (region->notePolyphony) {
                     if (!voice->releasedOrFree()
+                        && voice->getRegion()->group == region->group
                         && voice->getTriggerNumber() == noteNumber
                         && voice->getTriggerType() == Voice::TriggerType::NoteOn) {
                         notePolyphonyCounter += 1;
@@ -948,11 +949,11 @@ void sfz::Synth::noteOnDispatch(int delay, int noteNumber, float velocity) noexc
             }
 
             // Polyphony reached on note_polyphony
-            if (region->notePolyphony && notePolyphonyCounter >= *region->notePolyphony) {
-                if (selfMaskCandidate != nullptr)
-                    selfMaskCandidate->release(delay);
-                else // We're the lowest velocity guy here
-                    continue;
+            // If there's a self-masking candidate, release it
+            if (region->notePolyphony
+                && notePolyphonyCounter >= *region->notePolyphony
+                && selfMaskCandidate != nullptr) {
+                selfMaskCandidate->release(delay);
             }
 
             auto parent = region->parent;

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -288,7 +288,15 @@ public:
      * @param delay
      * @param fastRelease whether to do a normal release or cut the voice abruptly
      */
-    void release(int delay, bool fastRelease = false) noexcept;
+    void release(int delay) noexcept;
+
+    /**
+     * @brief Off the voice (steal). This will respect the off mode of the region
+     *      and set the envelopes if necessary.
+     *
+     * @param delay
+     */
+    void off(int delay) noexcept;
 
     /**
      * @brief gets the age of the Voice

--- a/src/sfizz/VoiceStealing.cpp
+++ b/src/sfizz/VoiceStealing.cpp
@@ -7,6 +7,9 @@ sfz::VoiceStealing::VoiceStealing()
 
 sfz::Voice* sfz::VoiceStealing::steal(absl::Span<sfz::Voice*> voices) noexcept
 {
+    if (voices.empty())
+        return {};
+
     // Start of the voice stealing algorithm
     absl::c_stable_sort(voices, voiceOrdering);
 

--- a/src/sfizz/VoiceStealing.cpp
+++ b/src/sfizz/VoiceStealing.cpp
@@ -52,9 +52,5 @@ sfz::Voice* sfz::VoiceStealing::steal(absl::Span<sfz::Voice*> voices) noexcept
         while (idx < voices.size() && sisterVoices(ref, voices[idx]));
     }
 
-    // Guard for future changes: voices with age 0 just started; don't kill those.
-    if (returnedVoice->getAge() == 0)
-        return {};
-
     return returnedVoice;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,8 +5,8 @@ project(sfizz)
 
 set(SFIZZ_TEST_SOURCES
     RegionT.cpp
-    RegionTHelpers.h
-    RegionTHelpers.cpp
+    TestHelpers.h
+    TestHelpers.cpp
     ParsingT.cpp
     HelpersT.cpp
     HelpersT.cpp

--- a/tests/FilesT.cpp
+++ b/tests/FilesT.cpp
@@ -4,7 +4,7 @@
 // license. You should have receive a LICENSE.md file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
-#include "RegionTHelpers.h"
+#include "TestHelpers.h"
 #include "sfizz/Synth.h"
 #include "sfizz/SfzHelpers.h"
 #include "sfizz/modulations/ModId.h"
@@ -517,7 +517,8 @@ TEST_CASE("[Files] Off by with the same notes at the same time")
     synth.renderBlock(buffer);
     synth.noteOn(0, 65, 63);
     synth.renderBlock(buffer);
-    REQUIRE( synth.getNumActiveVoices(true) == 2 );
+    REQUIRE( synth.getNumActiveVoices(true) == 6 );
+    REQUIRE( numPlayingVoices(synth) == 2 );
 }
 
 TEST_CASE("[Files] Off modes")
@@ -538,8 +539,10 @@ TEST_CASE("[Files] Off modes")
             synth.getVoiceView(0) ;
     synth.noteOn(100, 63, 63);
     REQUIRE( synth.getNumActiveVoices(true) == 3 );
+    REQUIRE( numPlayingVoices(synth) == 1 );
     AudioBuffer<float> buffer { 2, 256 };
-    synth.renderBlock(buffer);
+    for (unsigned i = 0; i < 10; ++i) // Not enough for the "normal" voice to die
+        synth.renderBlock(buffer);
     REQUIRE( synth.getNumActiveVoices(true) == 2 );
     REQUIRE( fastVoice->isFree() );
     REQUIRE( !normalVoice->isFree() );

--- a/tests/PolyphonyT.cpp
+++ b/tests/PolyphonyT.cpp
@@ -6,13 +6,14 @@
 
 #include "sfizz/Synth.h"
 #include "sfizz/SfzHelpers.h"
+#include "TestHelpers.h"
+#include <absl/algorithm/container.h>
 #include "catch2/catch.hpp"
 
 using namespace Catch::literals;
 using namespace sfz::literals;
 
 constexpr int blockSize { 256 };
-
 
 TEST_CASE("[Polyphony] Polyphony in hierarchy")
 {
@@ -71,6 +72,7 @@ TEST_CASE("[Polyphony] Polyphony groups")
 TEST_CASE("[Polyphony] group polyphony limits")
 {
     sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
         <group> group=1 polyphony=2
         <region> sample=*sine key=65
@@ -78,12 +80,15 @@ TEST_CASE("[Polyphony] group polyphony limits")
     synth.noteOn(0, 65, 64);
     synth.noteOn(0, 65, 64);
     synth.noteOn(0, 65, 64);
-    REQUIRE(synth.getNumActiveVoices(true) == 2); // group polyphony should block the last note
+    REQUIRE( synth.getNumActiveVoices(true) == 3 );
+    synth.renderBlock(buffer);
+    REQUIRE( numPlayingVoices(synth) == 2 ); // One is releasing
 }
 
 TEST_CASE("[Polyphony] Hierarchy polyphony limits")
 {
     sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
         <group> polyphony=2
         <region> sample=*sine key=65
@@ -91,12 +96,15 @@ TEST_CASE("[Polyphony] Hierarchy polyphony limits")
     synth.noteOn(0, 65, 64);
     synth.noteOn(0, 65, 64);
     synth.noteOn(0, 65, 64);
-    REQUIRE(synth.getNumActiveVoices(true) == 2);
+    REQUIRE( synth.getNumActiveVoices(true) == 3 );
+    synth.renderBlock(buffer);
+    REQUIRE( numPlayingVoices(synth) == 2 ); // One is releasing
 }
 
 TEST_CASE("[Polyphony] Hierarchy polyphony limits (group)")
 {
     sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
         <group> polyphony=2
         <region> sample=*sine key=65
@@ -104,12 +112,15 @@ TEST_CASE("[Polyphony] Hierarchy polyphony limits (group)")
     synth.noteOn(0, 65, 64);
     synth.noteOn(0, 65, 64);
     synth.noteOn(0, 65, 64);
-    REQUIRE(synth.getNumActiveVoices(true) == 2);
+    REQUIRE( synth.getNumActiveVoices(true) == 3 );
+    synth.renderBlock(buffer);
+    REQUIRE( numPlayingVoices(synth) == 2 ); // One is releasing
 }
 
 TEST_CASE("[Polyphony] Hierarchy polyphony limits (master)")
 {
     sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
         <master> polyphony=2
         <group> polyphony=5
@@ -118,12 +129,15 @@ TEST_CASE("[Polyphony] Hierarchy polyphony limits (master)")
     synth.noteOn(0, 65, 64);
     synth.noteOn(0, 65, 64);
     synth.noteOn(0, 65, 64);
-    REQUIRE(synth.getNumActiveVoices(true) == 2);
+    REQUIRE( synth.getNumActiveVoices(true) == 3 );
+    synth.renderBlock(buffer);
+    REQUIRE( numPlayingVoices(synth) == 2 ); // One is releasing
 }
 
 TEST_CASE("[Polyphony] Hierarchy polyphony limits (limit in another master)")
 {
     sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
         <master> polyphony=2
         <region> sample=*saw key=65
@@ -137,12 +151,15 @@ TEST_CASE("[Polyphony] Hierarchy polyphony limits (limit in another master)")
     synth.noteOn(0, 66, 64);
     synth.noteOn(0, 66, 64);
     synth.noteOn(0, 66, 64);
-    REQUIRE(synth.getNumActiveVoices(true) == 5);
+    REQUIRE( synth.getNumActiveVoices(true) == 6);
+    synth.renderBlock(buffer);
+    REQUIRE( numPlayingVoices(synth) == 5); // One is releasing
 }
 
 TEST_CASE("[Polyphony] Hierarchy polyphony limits (global)")
 {
     sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
         <global> polyphony=2
         <group> polyphony=5
@@ -151,14 +168,16 @@ TEST_CASE("[Polyphony] Hierarchy polyphony limits (global)")
     synth.noteOn(0, 65, 64);
     synth.noteOn(0, 65, 64);
     synth.noteOn(0, 65, 64);
-    REQUIRE(synth.getNumActiveVoices(true) == 2);
+    REQUIRE( synth.getNumActiveVoices(true) == 3 );
+    synth.renderBlock(buffer);
+    REQUIRE( numPlayingVoices(synth) == 2 ); // One is releasing
 }
 
 TEST_CASE("[Polyphony] Polyphony in master")
 {
     sfz::Synth synth;
-    synth.setSamplesPerBlock(blockSize);
     sfz::AudioBuffer<float> buffer { 2, blockSize };
+    synth.setSamplesPerBlock(blockSize);
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
         <master> polyphony=2
         <group> group=2
@@ -171,75 +190,90 @@ TEST_CASE("[Polyphony] Polyphony in master")
     synth.noteOn(0, 65, 64);
     synth.noteOn(0, 65, 64);
     synth.noteOn(0, 65, 64);
-    REQUIRE(synth.getNumActiveVoices(true) == 2); // group polyphony should block the last note
+    REQUIRE( synth.getNumActiveVoices(true) == 3 );
+    synth.renderBlock(buffer);
+    REQUIRE( numPlayingVoices(synth) == 2 ); // One is releasing
     synth.allSoundOff();
     synth.renderBlock(buffer);
-    REQUIRE(synth.getNumActiveVoices(true) == 0);
+    REQUIRE( synth.getNumActiveVoices(true) == 0);
     synth.noteOn(0, 63, 64);
     synth.noteOn(0, 63, 64);
     synth.noteOn(0, 63, 64);
-    REQUIRE(synth.getNumActiveVoices(true) == 2); // group polyphony should block the last note
+    REQUIRE( synth.getNumActiveVoices(true) == 3 );
+    synth.renderBlock(buffer);
+    REQUIRE( numPlayingVoices(synth) == 2 ); // One is releasing
     synth.allSoundOff();
     synth.renderBlock(buffer);
-    REQUIRE(synth.getNumActiveVoices(true) == 0);
+    REQUIRE( synth.getNumActiveVoices(true) == 0);
     synth.noteOn(0, 61, 64);
     synth.noteOn(0, 61, 64);
     synth.noteOn(0, 61, 64);
-    REQUIRE(synth.getNumActiveVoices(true) == 3);
+    REQUIRE( synth.getNumActiveVoices(true) == 3 );
+    synth.renderBlock(buffer);
+    REQUIRE( numPlayingVoices(synth) == 3 );
 }
 
 
 TEST_CASE("[Polyphony] Self-masking")
 {
     sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
         <region> sample=*sine key=64 note_polyphony=2
     )");
-    synth.noteOn(0, 64, 63);
-    synth.noteOn(0, 64, 62);
+    synth.noteOn(0, 64, 63 );
+    synth.noteOn(0, 64, 62 );
     synth.noteOn(0, 64, 64);
-    REQUIRE(synth.getNumActiveVoices(true) == 3); // One of these is releasing
-    REQUIRE(synth.getVoiceView(0)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getNumActiveVoices(true) == 3 ); // One of these is releasing
+    synth.renderBlock(buffer);
+    REQUIRE( numPlayingVoices(synth) == 2 );
+    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 63_norm);
     REQUIRE(!synth.getVoiceView(0)->releasedOrFree());
-    REQUIRE(synth.getVoiceView(1)->getTriggerValue() == 62_norm);
-    REQUIRE(synth.getVoiceView(1)->releasedOrFree()); // The lowest velocity voice is the masking candidate
-    REQUIRE(synth.getVoiceView(2)->getTriggerValue() == 64_norm);
+    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 62_norm);
+    REQUIRE( synth.getVoiceView(1)->releasedOrFree()); // The lowest velocity voice is the masking candidate
+    REQUIRE( synth.getVoiceView(2)->getTriggerValue() == 64_norm);
     REQUIRE(!synth.getVoiceView(2)->releasedOrFree());
 }
 
 TEST_CASE("[Polyphony] Not self-masking")
 {
     sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
         <region> sample=*sine key=66 note_polyphony=2 note_selfmask=off
     )");
-    synth.noteOn(0, 66, 63);
-    synth.noteOn(0, 66, 62);
+    synth.noteOn(0, 66, 63 );
+    synth.noteOn(0, 66, 62 );
     synth.noteOn(0, 66, 64);
-    REQUIRE(synth.getNumActiveVoices(true) == 3); // One of these is releasing
-    REQUIRE(synth.getVoiceView(0)->getTriggerValue() == 63_norm);
-    REQUIRE(synth.getVoiceView(0)->releasedOrFree());
-    REQUIRE(synth.getVoiceView(1)->getTriggerValue() == 62_norm);
+    REQUIRE( synth.getNumActiveVoices(true) == 3 ); // One of these is releasing
+    synth.renderBlock(buffer);
+    REQUIRE( numPlayingVoices(synth) == 2 );
+    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(0)->releasedOrFree());
+    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 62_norm);
     REQUIRE(!synth.getVoiceView(1)->releasedOrFree());
-    REQUIRE(synth.getVoiceView(2)->getTriggerValue() == 64_norm);
+    REQUIRE( synth.getVoiceView(2)->getTriggerValue() == 64_norm);
     REQUIRE(!synth.getVoiceView(2)->releasedOrFree());
 }
 
 TEST_CASE("[Polyphony] Self-masking with the exact same velocity")
 {
     sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzString(fs::current_path(), R"(
         <region> sample=*sine key=64 note_polyphony=2
     )");
     synth.noteOn(0, 64, 64);
-    synth.noteOn(0, 64, 63);
-    synth.noteOn(0, 64, 63);
-    REQUIRE(synth.getNumActiveVoices(true) == 3); // One of these is releasing
-    REQUIRE(synth.getVoiceView(0)->getTriggerValue() == 64_norm);
+    synth.noteOn(0, 64, 63 );
+    synth.noteOn(0, 64, 63 );
+    REQUIRE( synth.getNumActiveVoices(true) == 3 ); // One of these is releasing
+    synth.renderBlock(buffer);
+    REQUIRE( numPlayingVoices(synth) == 2 );
+    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 64_norm);
     REQUIRE(!synth.getVoiceView(0)->releasedOrFree());
-    REQUIRE(synth.getVoiceView(1)->getTriggerValue() == 63_norm);
-    REQUIRE(synth.getVoiceView(1)->releasedOrFree()); // The first one is the masking candidate since they have the same velocity
-    REQUIRE(synth.getVoiceView(2)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(1)->releasedOrFree()); // The first one is the masking candidate since they have the same velocity
+    REQUIRE( synth.getVoiceView(2)->getTriggerValue() == 63_norm);
     REQUIRE(!synth.getVoiceView(2)->releasedOrFree());
 }
 
@@ -249,53 +283,59 @@ TEST_CASE("[Polyphony] Self-masking only works from low to high")
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
         <region> sample=*sine key=64 note_polyphony=1
     )");
-    synth.noteOn(0, 64, 63);
-    synth.noteOn(0, 64, 62);
-    REQUIRE(synth.getNumActiveVoices(true) == 2); // Both notes are playing
-    REQUIRE(synth.getVoiceView(0)->getTriggerValue() == 63_norm);
+    synth.noteOn(0, 64, 63 );
+    synth.noteOn(0, 64, 62 );
+    REQUIRE( synth.getNumActiveVoices(true) == 2 ); // Both notes are playing
+    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 63_norm);
     REQUIRE(!synth.getVoiceView(0)->releasedOrFree());
-    REQUIRE(synth.getVoiceView(1)->getTriggerValue() == 62_norm);
+    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 62_norm);
     REQUIRE(!synth.getVoiceView(1)->releasedOrFree());
 }
 
 TEST_CASE("[Polyphony] Note polyphony checks works across regions in the same polyphony group (default)")
 {
     sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
         <region> sample=*saw key=64 note_polyphony=1
         <region> sample=*sine key=64 note_polyphony=1
     )");
-    synth.noteOn(0, 64, 62);
-    synth.noteOn(0, 64, 63);
-    REQUIRE(synth.getNumActiveVoices(true) == 4); // Both notes are playing
-    REQUIRE(synth.getVoiceView(0)->getTriggerValue() == 62_norm);
-    REQUIRE(synth.getVoiceView(0)->releasedOrFree()); // got killed
-    REQUIRE(synth.getVoiceView(1)->getTriggerValue() == 62_norm);
-    REQUIRE(synth.getVoiceView(1)->releasedOrFree()); // got killed
-    REQUIRE(synth.getVoiceView(2)->getTriggerValue() == 63_norm);
-    REQUIRE(synth.getVoiceView(2)->releasedOrFree()); // got killed
-    REQUIRE(synth.getVoiceView(3)->getTriggerValue() == 63_norm);
+    synth.noteOn(0, 64, 62 );
+    synth.noteOn(0, 64, 63 );
+    REQUIRE( synth.getNumActiveVoices(true) == 4);
+    synth.renderBlock(buffer);
+    REQUIRE( numPlayingVoices(synth) == 1 );
+    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 62_norm);
+    REQUIRE( synth.getVoiceView(0)->releasedOrFree()); // got killed
+    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 62_norm);
+    REQUIRE( synth.getVoiceView(1)->releasedOrFree()); // got killed
+    REQUIRE( synth.getVoiceView(2)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(2)->releasedOrFree()); // got killed
+    REQUIRE( synth.getVoiceView(3)->getTriggerValue() == 63_norm);
     REQUIRE(!synth.getVoiceView(3)->releasedOrFree());
 }
 
 TEST_CASE("[Polyphony] Note polyphony checks works across regions in the same polyphony group (default, with keyswitches)")
 {
     sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
         <global> sw_lokey=36 sw_hikey=37 sw_default=36
         <region> sw_last=36 key=48 note_polyphony=1 sample=*saw
         <region> sw_last=37 key=48 transpose=12 note_polyphony=1 sample=*tri
     )");
-    synth.noteOn(0, 48, 63);
-    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 48, 63 );
+    REQUIRE( synth.getNumActiveVoices(true) == 1);
     synth.cc(0, 64, 127);
     synth.noteOn(0, 37, 127);
     synth.noteOff(0, 37, 0);
     synth.noteOn(0, 48, 64);
-    REQUIRE(synth.getNumActiveVoices(true) == 2);
-    REQUIRE(synth.getVoiceView(0)->getTriggerValue() == 63_norm);
-    REQUIRE(synth.getVoiceView(0)->releasedOrFree());
-    REQUIRE(synth.getVoiceView(1)->getTriggerValue() == 64_norm);
+    REQUIRE( synth.getNumActiveVoices(true) == 2 );
+    synth.renderBlock(buffer);
+    REQUIRE( numPlayingVoices(synth) == 1 );
+    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(0)->releasedOrFree());
+    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 64_norm);
     REQUIRE(!synth.getVoiceView(1)->releasedOrFree());
 }
 
@@ -303,40 +343,46 @@ TEST_CASE("[Polyphony] Note polyphony checks works across regions in the same po
 TEST_CASE("[Polyphony] Note polyphony do not operate across polyphony groups")
 {
     sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
         <region> group=1 sample=*saw key=64 note_polyphony=1
         <region> group=2 sample=*sine key=64 note_polyphony=1
     )");
-    synth.noteOn(0, 64, 62);
-    synth.noteOn(0, 64, 63);
-    REQUIRE(synth.getNumActiveVoices(true) == 4); // Both notes are playing
-    REQUIRE(synth.getVoiceView(0)->getTriggerValue() == 62_norm);
-    REQUIRE(synth.getVoiceView(0)->releasedOrFree()); // got killed
-    REQUIRE(synth.getVoiceView(1)->getTriggerValue() == 62_norm);
-    REQUIRE(synth.getVoiceView(1)->releasedOrFree()); // got killed
-    REQUIRE(synth.getVoiceView(2)->getTriggerValue() == 63_norm);
+    synth.noteOn(0, 64, 62 );
+    synth.noteOn(0, 64, 63 );
+    REQUIRE( synth.getNumActiveVoices(true) == 4); // Both notes are playing
+    synth.renderBlock(buffer);
+    REQUIRE(numPlayingVoices(synth) == 2 );
+    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 62_norm);
+    REQUIRE( synth.getVoiceView(0)->releasedOrFree()); // got killed
+    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 62_norm);
+    REQUIRE( synth.getVoiceView(1)->releasedOrFree()); // got killed
+    REQUIRE( synth.getVoiceView(2)->getTriggerValue() == 63_norm);
     REQUIRE(!synth.getVoiceView(2)->releasedOrFree());
-    REQUIRE(synth.getVoiceView(3)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(3)->getTriggerValue() == 63_norm);
     REQUIRE(!synth.getVoiceView(3)->releasedOrFree());
 }
 
 TEST_CASE("[Polyphony] Note polyphony do not operate across polyphony groups (with keyswitches)")
 {
     sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
         <global> sw_lokey=36 sw_hikey=37 sw_default=36
         <region> group=1 sw_last=36 key=48 note_polyphony=1 sample=*saw
         <region> group=2 sw_last=37 key=48 transpose=12 note_polyphony=1 sample=*tri
     )");
-    synth.noteOn(0, 48, 63);
-    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 48, 63 );
+    REQUIRE( synth.getNumActiveVoices(true) == 1);
     synth.cc(0, 64, 127);
     synth.noteOn(0, 37, 127);
     synth.noteOff(0, 37, 0);
     synth.noteOn(0, 48, 64);
-    REQUIRE(synth.getNumActiveVoices(true) == 2);
-    REQUIRE(synth.getVoiceView(0)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getNumActiveVoices(true) == 2 );
+    synth.renderBlock(buffer);
+    REQUIRE(numPlayingVoices(synth) == 2 );
+    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 63_norm);
     REQUIRE(!synth.getVoiceView(0)->releasedOrFree());
-    REQUIRE(synth.getVoiceView(1)->getTriggerValue() == 64_norm);
+    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 64_norm);
     REQUIRE(!synth.getVoiceView(1)->releasedOrFree());
 }

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -195,6 +195,20 @@ TEST_CASE("[Region] Parsing opcodes")
         REQUIRE(region.offMode == SfzOffMode::fast);
         region.parseOpcode({ "off_mode", "normal" });
         REQUIRE(region.offMode == SfzOffMode::normal);
+        region.parseOpcode({ "off_mode", "time" });
+        REQUIRE(region.offMode == SfzOffMode::time);
+    }
+
+    SECTION("off_time")
+    {
+        REQUIRE(region.offTime == 0.006f);
+        region.parseOpcode({ "off_time", "0.1" });
+        REQUIRE(region.offTime == 0.1f);
+        region.parseOpcode({ "off_time", "0" });
+        REQUIRE(region.offTime == 0.0f);
+        region.parseOpcode({ "off_time", "0.1" });
+        region.parseOpcode({ "off_time", "-1" });
+        REQUIRE(region.offTime == 0.0f);
     }
 
     SECTION("lokey, hikey, and key")

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -4,7 +4,7 @@
 // license. You should have receive a LICENSE.md file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
-#include "RegionTHelpers.h"
+#include "TestHelpers.h"
 #include "sfizz/MidiState.h"
 #include "sfizz/Region.h"
 #include "sfizz/SfzHelpers.h"

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -202,8 +202,10 @@ TEST_CASE("[Region] Parsing opcodes")
     SECTION("off_time")
     {
         REQUIRE(region.offTime == 0.006f);
+        REQUIRE(region.offMode == SfzOffMode::fast);
         region.parseOpcode({ "off_time", "0.1" });
         REQUIRE(region.offTime == 0.1f);
+        REQUIRE(region.offMode == SfzOffMode::time);
         region.parseOpcode({ "off_time", "0" });
         REQUIRE(region.offTime == 0.0f);
         region.parseOpcode({ "off_time", "0.1" });

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -8,6 +8,7 @@
 #include "sfizz/SisterVoiceRing.h"
 #include "sfizz/SfzHelpers.h"
 #include "sfizz/NumericId.h"
+#include "TestHelpers.h"
 #include <algorithm>
 #include "catch2/catch.hpp"
 using namespace Catch::literals;
@@ -607,7 +608,8 @@ TEST_CASE("[Synth] Sisters and off-by")
     REQUIRE( synth.getNumActiveVoices(true) == 2 );
     synth.noteOn(0, 63, 85);
     REQUIRE( synth.getNumActiveVoices(true) == 3 );
-    synth.renderBlock(buffer);
+    for (unsigned i = 0; i < 100; ++i)
+        synth.renderBlock(buffer);
     REQUIRE( synth.getNumActiveVoices(true) == 2 );
     REQUIRE( sfz::SisterVoiceRing::countSisterVoices(synth.getVoiceView(0)) == 1 );
 }
@@ -733,30 +735,6 @@ TEST_CASE("[Synth] Sustain threshold")
     synth.cc(0, 64, 64);
     synth.noteOff(0, 62, 85);
     REQUIRE( synth.getNumActiveVoices(true) == 5 );
-}
-
-template<class C>
-void sortAll(C& container)
-{
-    std::sort(container.begin(), container.end());
-}
-
-template<class C, class... Args>
-void sortAll(C& container, Args&... others)
-{
-    std::sort(container.begin(), container.end());
-    sortAll(others...);
-}
-
-const std::vector<const sfz::Voice*> getActiveVoices(const sfz::Synth& synth)
-{
-    std::vector<const sfz::Voice*> activeVoices;
-    for (int i = 0; i < synth.getNumVoices(); ++i) {
-        const auto* voice = synth.getVoiceView(i);
-        if (!voice->isFree())
-            activeVoices.push_back(voice);
-    }
-    return activeVoices;
 }
 
 TEST_CASE("[Synth] Release (Multiple notes, release_key ignores the pedal)")

--- a/tests/TestHelpers.cpp
+++ b/tests/TestHelpers.cpp
@@ -4,7 +4,7 @@
 // license. You should have receive a LICENSE.md file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
-#include "RegionTHelpers.h"
+#include "TestHelpers.h"
 #include "sfizz/modulations/ModId.h"
 
 size_t RegionCCView::size() const
@@ -38,4 +38,22 @@ sfz::ModKey::Parameters RegionCCView::at(int cc) const
 bool RegionCCView::match(const sfz::Region::Connection& conn) const
 {
     return conn.source.id() == sfz::ModId::Controller && conn.target == target_;
+}
+
+const std::vector<const sfz::Voice*> getActiveVoices(const sfz::Synth& synth)
+{
+    std::vector<const sfz::Voice*> activeVoices;
+    for (int i = 0; i < synth.getNumVoices(); ++i) {
+        const auto* voice = synth.getVoiceView(i);
+        if (!voice->isFree())
+            activeVoices.push_back(voice);
+    }
+    return activeVoices;
+}
+
+unsigned numPlayingVoices(const sfz::Synth& synth)
+{
+    return absl::c_count_if(getActiveVoices(synth), [](const sfz::Voice* v) {
+        return !v->releasedOrFree();
+    });
 }

--- a/tests/TestHelpers.h
+++ b/tests/TestHelpers.h
@@ -5,6 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #pragma once
+#include "sfizz/Synth.h"
 #include "sfizz/Region.h"
 #include "sfizz/modulations/ModKey.h"
 
@@ -26,3 +27,32 @@ private:
     const sfz::Region& region_;
     sfz::ModKey target_;
 };
+
+template<class C>
+void sortAll(C& container)
+{
+    std::sort(container.begin(), container.end());
+}
+
+template<class C, class... Args>
+void sortAll(C& container, Args&... others)
+{
+    std::sort(container.begin(), container.end());
+    sortAll(others...);
+}
+
+/**
+ * @brief Get active voices from the synth
+ *
+ * @param synth
+ * @return const std::vector<const sfz::Voice*>
+ */
+const std::vector<const sfz::Voice*> getActiveVoices(const sfz::Synth& synth);
+
+/**
+ * @brief Count the number of playing (unreleased) voices from the synth
+ *
+ * @param synth
+ * @return unsigned
+ */
+unsigned numPlayingVoices(const sfz::Synth& synth);


### PR DESCRIPTION
- Note polyphony actually applies to polyphony groups (`group=...` opcodes)
- A lower velocity note with note_selfmask=on will not mute the high velocity one, but it will still play
- Parse `off_time` and `off_mode=time`
- Add some methods to change the release rate on the envelope after the envelope started smoothing
- Killing a voice is now done via `off(...)` rather than `release(..., fastRelease)` to allow a different behavior between naturally releasing a voice and killing it through e.g. voice stealing.
- Voices that are killed outside of the engine polyphony are not rendered abruptly; they're following their `off_mode`
- Added some helpers to count the number of actually playing voices in polyphony groups and region sets
- Added some test helpers alongside what was in `RegionTHelpers.cpp/h` into `TestHelpers.cpp/h`