### PR TITLE
Add runtime configs for loading in ram and voice stealing

### DIFF
--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -33,6 +33,7 @@ namespace config {
     constexpr int stereoBufferPoolSize { 4 };
     constexpr int indexBufferPoolSize { 2 };
     constexpr int preloadSize { 8192 };
+    constexpr bool loadInRam { false };
     constexpr int loggerQueueSize { 256 };
     constexpr int voiceLoggerQueueSize { 256 };
     constexpr bool loggingEnabled { false };

--- a/src/sfizz/FilePool.h
+++ b/src/sfizz/FilePool.h
@@ -51,6 +51,7 @@ using FileAudioBufferPtr = std::shared_ptr<FileAudioBuffer>;
 
 struct FileInformation {
     uint32_t end { Default::sampleEndRange.getEnd() };
+    uint32_t maxOffset { 0 };
     uint32_t loopBegin { Default::loopRange.getStart() };
     uint32_t loopEnd { Default::loopRange.getEnd() };
     bool hasLoop { false };
@@ -269,6 +270,13 @@ public:
      * for background sample file processing.
      */
     static void raiseCurrentThreadPriority() noexcept;
+    /**
+     * @brief Change whether all samples are loaded in ram.
+     * This will trigger a purge and reloading.
+     *
+     * @param loadInRam
+     */
+    void setRamLoading(bool loadInRam) noexcept;
 private:
     Logger& logger;
     fs::path rootDirectory;
@@ -279,6 +287,7 @@ private:
     atomic_queue::AtomicQueue2<FilePromisePtr, config::maxVoices> promiseQueue;
     atomic_queue::AtomicQueue2<FilePromisePtr, config::maxVoices> filledPromiseQueue;
     RTSemaphore semFilledPromiseQueueAvailable { config::maxVoices };
+    bool loadInRam { config::loadInRam };
     uint32_t preloadSize { config::preloadSize };
     Oversampling oversamplingFactor { config::defaultOversamplingFactor };
     // Signals

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -366,12 +366,21 @@ void sfz::Synth::handleControlOpcodes(const std::vector<Opcode>& members)
         case hash("hint_stealing"):
             switch(hash(member.value)) {
             case hash("first"):
+                for (auto& voice : voices)
+                    voice->disablePowerFollower();
+
                 stealer.setStealingAlgorithm(VoiceStealing::StealingAlgorithm::First);
                 break;
             case hash("oldest"):
+                for (auto& voice : voices)
+                    voice->disablePowerFollower();
+
                 stealer.setStealingAlgorithm(VoiceStealing::StealingAlgorithm::Oldest);
                 break;
             case hash("envelope_and_age"):
+                for (auto& voice : voices)
+                    voice->enablePowerFollower();
+
                 stealer.setStealingAlgorithm(VoiceStealing::StealingAlgorithm::EnvelopeAndAge);
                 break;
             default:

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -848,7 +848,10 @@ void sfz::Voice::removeVoiceFromRing() noexcept
 
 float sfz::Voice::getAveragePower() const noexcept
 {
-    return powerFollower.getAveragePower();
+    if (followPower)
+        return powerFollower.getAveragePower();
+    else
+        return 0.0f;
 }
 
 bool sfz::Voice::releasedOrFree() const noexcept
@@ -1029,4 +1032,15 @@ void sfz::Voice::saveModulationTargets(const Region* region) noexcept
     pitchTarget = mm.findTarget(ModKey::createNXYZ(ModId::Pitch, region->getId()));
     oscillatorDetuneTarget = mm.findTarget(ModKey::createNXYZ(ModId::OscillatorDetune, region->getId()));
     oscillatorModDepthTarget = mm.findTarget(ModKey::createNXYZ(ModId::OscillatorModDepth, region->getId()));
+}
+
+void sfz::Voice::enablePowerFollower() noexcept
+{
+    followPower = true;
+    powerFollower.clear();
+}
+
+void sfz::Voice::disablePowerFollower() noexcept
+{
+    followPower = false;
 }

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -248,6 +248,19 @@ public:
      * @return float
      */
     float getAveragePower() const noexcept;
+
+    /**
+     * @brief Enable the power follower
+     *
+     */
+
+    void enablePowerFollower() noexcept;
+    /**
+     * @brief Disable the power follower
+     *
+     */
+    void disablePowerFollower() noexcept;
+
     /**
      * Returns the region that is currently playing. May be null if the voice is not active!
      *
@@ -519,6 +532,7 @@ private:
     ModMatrix::TargetId oscillatorDetuneTarget;
     ModMatrix::TargetId oscillatorModDepthTarget;
 
+    bool followPower { false };
     PowerFollower powerFollower;
 
     LEAK_DETECTOR(Voice);

--- a/src/sfizz/VoiceStealing.cpp
+++ b/src/sfizz/VoiceStealing.cpp
@@ -10,7 +10,35 @@ sfz::Voice* sfz::VoiceStealing::steal(absl::Span<sfz::Voice*> voices) noexcept
     if (voices.empty())
         return {};
 
-    // Start of the voice stealing algorithm
+    switch(stealingAlgorithm) {
+    case StealingAlgorithm::First:
+        return stealFirst(voices);
+    case StealingAlgorithm::EnvelopeAndAge:
+        return stealEnvelopeAndAge(voices);
+    case StealingAlgorithm::Oldest:
+    default:
+        return stealOldest(voices);
+    }
+}
+
+void sfz::VoiceStealing::setStealingAlgorithm(StealingAlgorithm algorithm) noexcept
+{
+    stealingAlgorithm = algorithm;
+}
+
+sfz::Voice* sfz::VoiceStealing::stealFirst(absl::Span<Voice*> voices) noexcept
+{
+    return voices.front();
+}
+
+sfz::Voice* sfz::VoiceStealing::stealOldest(absl::Span<Voice*> voices) noexcept
+{
+    absl::c_stable_sort(voices, voiceOrdering);
+    return voices.front();
+}
+
+sfz::Voice* sfz::VoiceStealing::stealEnvelopeAndAge(absl::Span<Voice*> voices) noexcept
+{
     absl::c_stable_sort(voices, voiceOrdering);
 
     const auto sumPower = absl::c_accumulate(voices, 0.0f, [](float sum, const Voice* v) {

--- a/src/sfizz/VoiceStealing.h
+++ b/src/sfizz/VoiceStealing.h
@@ -17,7 +17,25 @@ namespace sfz
 class VoiceStealing
 {
 public:
+    enum class StealingAlgorithm {
+        First,
+        Oldest,
+        EnvelopeAndAge
+    };
+
     VoiceStealing();
+    /**
+     * @brief Get the current stealing algorithm
+     *
+     * @return StealingAlgorithm
+     */
+    StealingAlgorithm getStealingAlgorithm() const noexcept { return stealingAlgorithm; }
+    /**
+     * @brief Set a default stealing algorithm
+     *
+     * @param algorithm
+     */
+    void setStealingAlgorithm(StealingAlgorithm algorithm) noexcept;
     /**
      * @brief Propose a voice to steal from a set of voices
      *
@@ -26,6 +44,11 @@ public:
      */
     Voice* steal(absl::Span<Voice*> voices) noexcept;
 private:
+    StealingAlgorithm stealingAlgorithm { StealingAlgorithm::Oldest };
+    Voice* stealFirst(absl::Span<Voice*> voices) noexcept;
+    Voice* stealOldest(absl::Span<Voice*> voices) noexcept;
+    Voice* stealEnvelopeAndAge(absl::Span<Voice*> voices) noexcept;
+
     struct VoiceScore
     {
         Voice* voice;


### PR DESCRIPTION
Still needs some testing; allows for `hint_` opcodes to control ram loading and voice stealing.