### PR TITLE
Plugin-level support for host time

### DIFF
--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -302,13 +302,43 @@ SFIZZ_EXPORTED_API void sfizz_send_pitch_wheel(sfizz_synth_t* synth, int delay, 
 SFIZZ_EXPORTED_API void sfizz_send_aftertouch(sfizz_synth_t* synth, int delay, char aftertouch);
 
 /**
- * @brief      Send a tempo event. (CURRENTLY UNIMPLEMENTED)
+ * @brief      Send a tempo event.
  *
  * @param      synth                The synth.
  * @param      delay                The delay.
- * @param      seconds_per_quarter  The seconds per quarter.
+ * @param      seconds_per_beat     The seconds per beat.
  */
-SFIZZ_EXPORTED_API void sfizz_send_tempo(sfizz_synth_t* synth, int delay, float seconds_per_quarter);
+SFIZZ_EXPORTED_API void sfizz_send_tempo(sfizz_synth_t* synth, int delay, float seconds_per_beat);
+
+/**
+ * @brief      Send the time signature.
+ *
+ * @param      synth                The synth.
+ * @param      delay                The delay.
+ * @param      beats_per_bar        The number of beats per bar, or time signature numerator.
+ * @param      beat_unit            The note corresponding to one beat, or time signature denominator.
+ */
+SFIZZ_EXPORTED_API void sfizz_send_time_signature(sfizz_synth_t* synth, int delay, int beats_per_bar, int beat_unit);
+
+/**
+ * @brief      Send the time position.
+ *
+ * @param      synth                The synth.
+ * @param      delay                The delay.
+ * @param      bar                  The current bar.
+ * @param      bar_beat             The fractional position of the current beat within the bar.
+ */
+SFIZZ_EXPORTED_API void sfizz_send_time_position(sfizz_synth_t* synth, int delay, int bar, float bar_beat);
+
+/**
+ * @brief      Send the playback state.
+ *
+ * @param      synth                The synth.
+ * @param      delay                The delay.
+ * @param      playback_state       The playback state, 1 if playing, 0 if stopped.
+ */
+SFIZZ_EXPORTED_API void sfizz_send_playback_state(sfizz_synth_t* synth, int delay, int playback_state);
+
 
 /**
  * @brief      Render a block audio data into a stereo channel. No other channel

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -291,13 +291,39 @@ public:
     void aftertouch(int delay, uint8_t aftertouch) noexcept;
 
     /**
-     * @brief Send a tempo event to the synth. (CURRENTLY UNIMPLEMENTED)
+     * @brief Send a tempo event to the synth.
      *
      * @param delay the delay at which the event occurs; this should be lower than the size of
      *              the block in the next call to renderBlock().
-     * @param secondsPerQuarter the new period of the quarter note.
+     * @param secondsPerBeat the new period of the beat.
      */
-    void tempo(int delay, float secondsPerQuarter) noexcept;
+    void tempo(int delay, float secondsPerBeat) noexcept;
+
+    /**
+     * @brief      Send the time signature.
+     *
+     * @param      delay                The delay.
+     * @param      beats_per_bar        The number of beats per bar, or time signature numerator.
+     * @param      beat_unit            The note corresponding to one beat, or time signature denominator.
+     */
+    void timeSignature(int delay, int beatsPerBar, int beatUnit);
+
+    /**
+     * @brief      Send the time position.
+     *
+     * @param      delay                The delay.
+     * @param      bar                  The current bar.
+     * @param      bar_beat             The fractional position of the current beat within the bar.
+     */
+    void timePosition(int delay, int bar, float barBeat);
+
+    /**
+     * @brief      Send the playback state.
+     *
+     * @param      delay                The delay.
+     * @param      playback_state       The playback state, 1 if playing, 0 if stopped.
+     */
+    void playbackState(int delay, int playbackState);
 
     /**
      * @brief Render an block of audio data in the buffer. This call will reset

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1116,6 +1116,29 @@ void sfz::Synth::tempo(int /* delay */, float /* secondsPerQuarter */) noexcept
 {
     ScopedTiming logger { dispatchDuration, ScopedTiming::Operation::addToDuration };
 }
+void sfz::Synth::timeSignature(int delay, int beatsPerBar, int beatUnit)
+{
+    ScopedTiming logger { dispatchDuration, ScopedTiming::Operation::addToDuration };
+
+    (void)delay;
+    (void)beatsPerBar;
+    (void)beatUnit;
+}
+void sfz::Synth::timePosition(int delay, int bar, float barBeat)
+{
+    ScopedTiming logger { dispatchDuration, ScopedTiming::Operation::addToDuration };
+
+    (void)delay;
+    (void)bar;
+    (void)barBeat;
+}
+void sfz::Synth::playbackState(int delay, int playbackState)
+{
+    ScopedTiming logger { dispatchDuration, ScopedTiming::Operation::addToDuration };
+
+    (void)delay;
+    (void)playbackState;
+}
 
 int sfz::Synth::getNumRegions() const noexcept
 {

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -393,6 +393,29 @@ public:
      */
     void tempo(int delay, float secondsPerQuarter) noexcept;
     /**
+     * @brief      Send the time signature.
+     *
+     * @param      delay                The delay.
+     * @param      beats_per_bar        The number of beats per bar, or time signature numerator.
+     * @param      beat_unit            The note corresponding to one beat, or time signature denominator.
+     */
+    void timeSignature(int delay, int beatsPerBar, int beatUnit);
+    /**
+     * @brief      Send the time position.
+     *
+     * @param      delay                The delay.
+     * @param      bar                  The current bar.
+     * @param      bar_beat             The fractional position of the current beat within the bar.
+     */
+    void timePosition(int delay, int bar, float barBeat);
+    /**
+     * @brief      Send the playback state.
+     *
+     * @param      delay                The delay.
+     * @param      playback_state       The playback state, 1 if playing, 0 if stopped.
+     */
+    void playbackState(int delay, int playbackState);
+    /**
      * @brief Render an block of audio data in the buffer. This call will reset
      * the synth in its waiting state for the next batch of events. The size of
      * the block is integrated in the AudioSpan object. You can build an

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -153,9 +153,24 @@ void sfz::Sfizz::aftertouch(int delay, uint8_t aftertouch) noexcept
     synth->aftertouch(delay, aftertouch);
 }
 
-void sfz::Sfizz::tempo(int delay, float secondsPerQuarter) noexcept
+void sfz::Sfizz::tempo(int delay, float secondsPerBeat) noexcept
 {
-    synth->tempo(delay, secondsPerQuarter);
+    synth->tempo(delay, secondsPerBeat);
+}
+
+void sfz::Sfizz::timeSignature(int delay, int beatsPerBar, int beatUnit)
+{
+    synth->timeSignature(delay, beatsPerBar, beatUnit);
+}
+
+void sfz::Sfizz::timePosition(int delay, int bar, float barBeat)
+{
+    synth->timePosition(delay, bar, barBeat);
+}
+
+void sfz::Sfizz::playbackState(int delay, int playbackState)
+{
+    synth->playbackState(delay, playbackState);
 }
 
 void sfz::Sfizz::renderBlock(float** buffers, size_t numSamples, int /*numOutputs*/) noexcept

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -160,6 +160,21 @@ void sfizz_send_tempo(sfizz_synth_t* synth, int delay, float seconds_per_quarter
     auto self = reinterpret_cast<sfz::Synth*>(synth);
     self->tempo(delay, seconds_per_quarter);
 }
+void sfizz_send_time_signature(sfizz_synth_t* synth, int delay, int beats_per_bar, int beat_unit)
+{
+    auto self = reinterpret_cast<sfz::Synth*>(synth);
+    self->timeSignature(delay, beats_per_bar, beat_unit);
+}
+void sfizz_send_time_position(sfizz_synth_t* synth, int delay, int bar, float bar_beat)
+{
+    auto self = reinterpret_cast<sfz::Synth*>(synth);
+    self->timePosition(delay, bar, bar_beat);
+}
+void sfizz_send_playback_state(sfizz_synth_t* synth, int delay, int playback_state)
+{
+    auto self = reinterpret_cast<sfz::Synth*>(synth);
+    self->playbackState(delay, playback_state);
+}
 
 void sfizz_render_block(sfizz_synth_t* synth, float** channels, int num_channels, int num_frames)
 {

--- a/vst/SfizzVstProcessor.cpp
+++ b/vst/SfizzVstProcessor.cpp
@@ -225,6 +225,8 @@ void SfizzVstProcessor::updateTimeInfo(const Vst::ProcessContext& context)
         beats -= int(bars) * _timeSigNumerator;
         synth.timePosition(0, int(bars), float(beats));
     }
+
+    synth.playbackState(0, (context.state & context.kPlaying) != 0);
 }
 
 void SfizzVstProcessor::processParameterChanges(Vst::IParameterChanges& pc)

--- a/vst/SfizzVstProcessor.cpp
+++ b/vst/SfizzVstProcessor.cpp
@@ -12,8 +12,6 @@
 #include "pluginterfaces/vst/ivstparameterchanges.h"
 #include <cstring>
 
-#pragma message("TODO: send tempo") // NOLINT
-
 template<class T>
 constexpr int fastRound(T x)
 {
@@ -54,6 +52,13 @@ tresult PLUGIN_API SfizzVstProcessor::initialize(FUnknown* context)
     _synth.reset(new sfz::Sfizz);
     _currentStretchedTuning = 0.0;
     loadSfzFileOrDefault(*_synth, {});
+
+    _synth->tempo(0, 0.5);
+    _timeSigNumerator = 4;
+    _timeSigDenominator = 4;
+    _synth->timeSignature(0, _timeSigNumerator, _timeSigDenominator);
+    _synth->timePosition(0, 0, 0);
+    _synth->playbackState(0, 0);
 
     return result;
 }
@@ -143,6 +148,9 @@ tresult PLUGIN_API SfizzVstProcessor::process(Vst::ProcessData& data)
 {
     sfz::Sfizz& synth = *_synth;
 
+    if (data.processContext)
+        updateTimeInfo(*data.processContext);
+
     if (Vst::IParameterChanges* pc = data.inputParameterChanges)
         processParameterChanges(*pc);
 
@@ -196,6 +204,27 @@ tresult PLUGIN_API SfizzVstProcessor::process(Vst::ProcessData& data)
     }
 
     return kResultTrue;
+}
+
+void SfizzVstProcessor::updateTimeInfo(const Vst::ProcessContext& context)
+{
+    sfz::Sfizz& synth = *_synth;
+
+    if (context.state & context.kTempoValid)
+        synth.tempo(0, 60.0f / context.tempo);
+
+    if (context.state & context.kTimeSigValid) {
+        _timeSigNumerator = context.timeSigNumerator;
+        _timeSigDenominator = context.timeSigDenominator;
+        synth.timeSignature(0, _timeSigNumerator, _timeSigDenominator);
+    }
+
+    if (context.state & context.kProjectTimeMusicValid) {
+        double beats = context.projectTimeMusic * 0.25 * _timeSigDenominator;
+        double bars = beats / _timeSigNumerator;
+        beats -= int(bars) * _timeSigNumerator;
+        synth.timePosition(0, int(bars), float(beats));
+    }
 }
 
 void SfizzVstProcessor::processParameterChanges(Vst::IParameterChanges& pc)

--- a/vst/SfizzVstProcessor.h
+++ b/vst/SfizzVstProcessor.h
@@ -64,6 +64,11 @@ private:
     uint32 _fileChangeCounter = 0;
     uint32 _fileChangePeriod = 0;
 
+    // time info
+    int _timeSigNumerator = 0;
+    int _timeSigDenominator = 0;
+    void updateTimeInfo(const Vst::ProcessContext& context);
+
     // messaging
     struct RTMessage {
         const char* type;


### PR DESCRIPTION
This lets plugins pass time information to sfizz by some new APIs.

- tempo
- time signature
- time position
- playback state on/off

APIs themselves are not yet implemented.:
- On sfizz side, there will be a clock which interpolates beat positions between the current time and the last position known.
This clock will have a beat counter with modulo to the numerator of the time signature.
- On receiving a time signature change or a change of playback state, the beat counter will reset
- On a change of the time position, it will update the beat counter according to the position.