### PR TITLE
Additional SIMD helpers

### DIFF
--- a/benchmarks/BM_allWithin.cpp
+++ b/benchmarks/BM_allWithin.cpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "SIMDHelpers.h"
+#include "Macros.h"
+#include <benchmark/benchmark.h>
+#include <random>
+#include <numeric>
+#include <vector>
+#include <cmath>
+#include <iostream>
+
+class WithinArray : public benchmark::Fixture {
+public:
+  void SetUp(const ::benchmark::State& state) {
+    std::random_device rd { };
+    std::mt19937 gen { rd() };
+    std::uniform_real_distribution<float> dist { 1, 10 };
+    input = std::vector<float>(state.range(0));
+    std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
+  }
+
+  void TearDown(const ::benchmark::State& state) {
+      UNUSED(state);
+  }
+
+  std::vector<float> input;
+};
+
+BENCHMARK_DEFINE_F(WithinArray, ScalarFalse)(benchmark::State& state) {
+    for (auto _ : state)
+    {
+        sfz::setSIMDOpStatus<float>(sfz::SIMDOps::allWithin, false);
+        sfz::allWithin<float>(input, 1.2f, 3.8f);
+    }
+}
+
+BENCHMARK_DEFINE_F(WithinArray, SIMDFalse)(benchmark::State& state) {
+    for (auto _ : state)
+    {
+        sfz::setSIMDOpStatus<float>(sfz::SIMDOps::allWithin, true);
+        sfz::allWithin<float>(input, 1.2f, 3.8f);
+    }
+}
+
+BENCHMARK_DEFINE_F(WithinArray, ScalarTrue)(benchmark::State& state) {
+    for (auto _ : state)
+    {
+        sfz::setSIMDOpStatus<float>(sfz::SIMDOps::allWithin, false);
+        sfz::allWithin<float>(input, 0.0f, 11.0f);
+    }
+}
+
+BENCHMARK_DEFINE_F(WithinArray, SIMDTrue)(benchmark::State& state) {
+    for (auto _ : state)
+    {
+        sfz::setSIMDOpStatus<float>(sfz::SIMDOps::allWithin, true);
+        sfz::allWithin<float>(input, 0.0f, 11.0f);
+    }
+}
+
+
+BENCHMARK_REGISTER_F(WithinArray, ScalarFalse)->RangeMultiplier(4)->Range(1 << 2, 1 << 12);
+BENCHMARK_REGISTER_F(WithinArray, SIMDFalse)->RangeMultiplier(4)->Range(1 << 2, 1 << 12);
+BENCHMARK_REGISTER_F(WithinArray, ScalarTrue)->RangeMultiplier(4)->Range(1 << 2, 1 << 12);
+BENCHMARK_REGISTER_F(WithinArray, SIMDTrue)->RangeMultiplier(4)->Range(1 << 2, 1 << 12);
+BENCHMARK_MAIN();

--- a/benchmarks/BM_clamp.cpp
+++ b/benchmarks/BM_clamp.cpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "SIMDHelpers.h"
+#include "Macros.h"
+#include <benchmark/benchmark.h>
+#include <random>
+#include <numeric>
+#include <vector>
+#include <cmath>
+#include <iostream>
+
+class ClampArray : public benchmark::Fixture {
+public:
+  void SetUp(const ::benchmark::State& state) {
+    std::random_device rd { };
+    std::mt19937 gen { rd() };
+    std::uniform_real_distribution<float> dist { 0, 10 };
+    input = std::vector<float>(state.range(0));
+    std::generate(input.begin(), input.end(), [&]() { return dist(gen); });
+  }
+
+  void TearDown(const ::benchmark::State& state) {
+      UNUSED(state);
+  }
+
+  std::vector<float> input;
+};
+
+BENCHMARK_DEFINE_F(ClampArray, Scalar)(benchmark::State& state) {
+    for (auto _ : state)
+    {
+        sfz::setSIMDOpStatus<float>(sfz::SIMDOps::clampAll, false);
+        sfz::clampAll<float>(absl::MakeSpan(input), 1.2f, 3.8f);
+    }
+}
+
+BENCHMARK_DEFINE_F(ClampArray, SIMD)(benchmark::State& state) {
+    for (auto _ : state)
+    {
+        sfz::setSIMDOpStatus<float>(sfz::SIMDOps::clampAll, true);
+        sfz::clampAll<float>(absl::MakeSpan(input), 1.2f, 3.8f);
+    }
+}
+
+
+BENCHMARK_REGISTER_F(ClampArray, Scalar)->RangeMultiplier(4)->Range(1 << 2, 1 << 12);
+BENCHMARK_REGISTER_F(ClampArray, SIMD)->RangeMultiplier(4)->Range(1 << 2, 1 << 12);
+BENCHMARK_MAIN();

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -59,6 +59,7 @@ sfizz_add_benchmark(bm_maps BM_maps.cpp)
 target_link_libraries(bm_maps PRIVATE absl::flat_hash_map)
 sfizz_add_benchmark(bm_mapVsArray BM_mapVsArray.cpp)
 sfizz_add_benchmark(bm_random BM_random.cpp)
+sfizz_add_benchmark(bm_clamp BM_clamp.cpp)
 
 sfizz_add_benchmark(bm_logger BM_logger.cpp)
 target_link_libraries(bm_logger PRIVATE sfizz::sfizz)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(bm_maps PRIVATE absl::flat_hash_map)
 sfizz_add_benchmark(bm_mapVsArray BM_mapVsArray.cpp)
 sfizz_add_benchmark(bm_random BM_random.cpp)
 sfizz_add_benchmark(bm_clamp BM_clamp.cpp)
+sfizz_add_benchmark(bm_allWithin BM_allWithin.cpp)
 
 sfizz_add_benchmark(bm_logger BM_logger.cpp)
 target_link_libraries(bm_logger PRIVATE sfizz::sfizz)

--- a/src/sfizz/SIMDHelpers.cpp
+++ b/src/sfizz/SIMDHelpers.cpp
@@ -41,6 +41,7 @@ struct SIMDDispatch {
     decltype(&meanScalar<T>) mean = &meanScalar<T>;
     decltype(&meanSquaredScalar<T>) meanSquared = &meanSquaredScalar<T>;
     decltype(&clampAllScalar<T>) clampAll = &clampAllScalar<T>;
+    decltype(&allWithinScalar<T>) allWithin = &allWithinScalar<T>;
 
 private:
     std::array<bool, static_cast<unsigned>(SIMDOps::_sentinel)> simdStatus;
@@ -86,6 +87,7 @@ void SIMDDispatch<float>::setStatus(SIMDOps op, bool enable)
             SIMD_OP(mean)
             SIMD_OP(meanSquared)
             SIMD_OP(clampAll)
+            SIMD_OP(allWithin)
         }
 #undef SIMD_OP
     }
@@ -122,6 +124,7 @@ void SIMDDispatch<float>::setStatus(SIMDOps op, bool enable)
             SIMD_OP(mean)
             SIMD_OP(meanSquared)
             SIMD_OP(clampAll)
+            SIMD_OP(allWithin)
         }
     }
 #undef SIMD_OP
@@ -163,6 +166,7 @@ void SIMDDispatch<float>::resetStatus()
     setStatus(SIMDOps::meanSquared, false);
     setStatus(SIMDOps::upsampling, true);
     setStatus(SIMDOps::clampAll, false);
+    setStatus(SIMDOps::allWithin, true);
 }
 
 ///
@@ -308,7 +312,13 @@ void diff<float>(const float* input, float* output, unsigned size) noexcept
 template <>
 void clampAll<float>(float* input, float low, float high, unsigned size) noexcept
 {
-    return simdDispatch<float>().clampAll(input, low, high, size);
+    simdDispatch<float>().clampAll(input, low, high, size);
+}
+
+template <>
+bool allWithin<float>(const float* input, float low, float high, unsigned size) noexcept
+{
+    return simdDispatch<float>().allWithin(input, low, high, size);
 }
 
 }

--- a/src/sfizz/SIMDHelpers.cpp
+++ b/src/sfizz/SIMDHelpers.cpp
@@ -40,6 +40,7 @@ struct SIMDDispatch {
     decltype(&diffScalar<T>) diff = &diffScalar<T>;
     decltype(&meanScalar<T>) mean = &meanScalar<T>;
     decltype(&meanSquaredScalar<T>) meanSquared = &meanSquaredScalar<T>;
+    decltype(&clampAllScalar<T>) clampAll = &clampAllScalar<T>;
 
 private:
     std::array<bool, static_cast<unsigned>(SIMDOps::_sentinel)> simdStatus;
@@ -84,6 +85,7 @@ void SIMDDispatch<float>::setStatus(SIMDOps op, bool enable)
             SIMD_OP(diff)
             SIMD_OP(mean)
             SIMD_OP(meanSquared)
+            SIMD_OP(clampAll)
         }
 #undef SIMD_OP
     }
@@ -119,6 +121,7 @@ void SIMDDispatch<float>::setStatus(SIMDOps op, bool enable)
             SIMD_OP(diff)
             SIMD_OP(mean)
             SIMD_OP(meanSquared)
+            SIMD_OP(clampAll)
         }
     }
 #undef SIMD_OP
@@ -159,6 +162,7 @@ void SIMDDispatch<float>::resetStatus()
     setStatus(SIMDOps::mean, false);
     setStatus(SIMDOps::meanSquared, false);
     setStatus(SIMDOps::upsampling, true);
+    setStatus(SIMDOps::clampAll, false);
 }
 
 ///
@@ -299,6 +303,12 @@ template <>
 void diff<float>(const float* input, float* output, unsigned size) noexcept
 {
     return simdDispatch<float>().diff(input, output, size);
+}
+
+template <>
+void clampAll<float>(float* input, float low, float high, unsigned size) noexcept
+{
+    return simdDispatch<float>().clampAll(input, low, high, size);
 }
 
 }

--- a/src/sfizz/SIMDHelpers.h
+++ b/src/sfizz/SIMDHelpers.h
@@ -59,6 +59,7 @@ enum class SIMDOps {
     mean,
     meanSquared,
     upsampling,
+    clampAll,
     _sentinel //
 };
 
@@ -620,6 +621,31 @@ void diff(absl::Span<const T> input, absl::Span<T> output) noexcept
 {
     CHECK_SPAN_SIZES(input, output);
     diff<T>(input.data(), output.data(), minSpanSize(input, output));
+}
+
+/**
+ * @brief Clamp a vector between a low and high bound
+ *
+ * @tparam T the underlying type
+ * @param input
+ * @param output
+ * @param low
+ * @param high
+ * @param size
+ */
+template <class T>
+void clampAll(T* input, T low, T high, unsigned size) noexcept
+{
+    clampAllScalar(input, low, high, size);
+}
+
+template <>
+void clampAll<float>(float* input, float low, float high, unsigned size) noexcept;
+
+template <class T>
+void clampAll(absl::Span<T> input, T low, T high) noexcept
+{
+    clampAll<T>(input.data(), low, high, input.size());
 }
 
 } // namespace sfz

--- a/src/sfizz/SIMDHelpers.h
+++ b/src/sfizz/SIMDHelpers.h
@@ -60,6 +60,7 @@ enum class SIMDOps {
     meanSquared,
     upsampling,
     clampAll,
+    allWithin,
     _sentinel //
 };
 
@@ -628,7 +629,6 @@ void diff(absl::Span<const T> input, absl::Span<T> output) noexcept
  *
  * @tparam T the underlying type
  * @param input
- * @param output
  * @param low
  * @param high
  * @param size
@@ -646,6 +646,30 @@ template <class T>
 void clampAll(absl::Span<T> input, T low, T high) noexcept
 {
     clampAll<T>(input.data(), low, high, input.size());
+}
+
+/**
+ * @brief Check that all values are within bounds (inclusive)
+ *
+ * @tparam T the underlying type
+ * @param input
+ * @param low
+ * @param high
+ * @param size
+ */
+template <class T>
+bool allWithin(const T* input, T low, T high, unsigned size) noexcept
+{
+    return allWithinScalar(input, low, high, size);
+}
+
+template <>
+bool allWithin<float>(const float* input, float low, float high, unsigned size) noexcept;
+
+template <class T>
+bool allWithin(absl::Span<const T> input, T low, T high) noexcept
+{
+    return allWithin<T>(input.data(), low, high, input.size());
 }
 
 } // namespace sfz

--- a/src/sfizz/simd/HelpersSSE.cpp
+++ b/src/sfizz/simd/HelpersSSE.cpp
@@ -472,3 +472,34 @@ void diffSSE(const float* input, float* output, unsigned size) noexcept
         incrementAll(input, output);
     }
 }
+
+void clampAllSSE(float* input, float low, float high, unsigned size) noexcept
+{
+    if (size == 0)
+        return;
+
+    const auto sentinel = input + size;
+
+#if SFIZZ_HAVE_SSE2
+    const auto* lastAligned = prevAligned<ByteAlignment>(sentinel);
+    while (unaligned<ByteAlignment>(input) && input < lastAligned){
+        const float clampedAbove = *input > high ? high : *input;
+        *input = clampedAbove < low ? low : clampedAbove;
+        incrementAll(input);
+    }
+
+    const auto mmLow = _mm_set1_ps(low);
+    const auto mmHigh = _mm_set1_ps(high);
+    while (input < lastAligned) {
+        const auto mmIn = _mm_load_ps(input);
+        _mm_store_ps(input, _mm_max_ps(_mm_min_ps(mmIn, mmHigh), mmLow));
+        incrementAll<TypeAlignment>(input);
+    }
+#endif
+
+    while (input < sentinel) {
+        const float clampedAbove = *input > high ? high : *input;
+        *input = clampedAbove < low ? low : clampedAbove;
+        incrementAll(input);
+    }
+}

--- a/src/sfizz/simd/HelpersSSE.h
+++ b/src/sfizz/simd/HelpersSSE.h
@@ -26,3 +26,4 @@ float meanSquaredSSE(const float* vector, unsigned size) noexcept;
 void cumsumSSE(const float* input, float* output, unsigned size) noexcept;
 void diffSSE(const float* input, float* output, unsigned size) noexcept;
 void clampAllSSE(float* input, float low, float high, unsigned size) noexcept;
+bool allWithinSSE(const float* input, float low, float high, unsigned size) noexcept;

--- a/src/sfizz/simd/HelpersSSE.h
+++ b/src/sfizz/simd/HelpersSSE.h
@@ -25,3 +25,4 @@ float meanSSE(const float* vector, unsigned size) noexcept;
 float meanSquaredSSE(const float* vector, unsigned size) noexcept;
 void cumsumSSE(const float* input, float* output, unsigned size) noexcept;
 void diffSSE(const float* input, float* output, unsigned size) noexcept;
+void clampAllSSE(float* input, float low, float high, unsigned size) noexcept;

--- a/src/sfizz/simd/HelpersScalar.h
+++ b/src/sfizz/simd/HelpersScalar.h
@@ -186,3 +186,17 @@ void diffScalar(const T* input, T* output, unsigned size) noexcept
         incrementAll(input, output);
     }
 }
+
+template <class T>
+void clampAllScalar(T* input, T low, T high, unsigned size ) noexcept
+{
+    if (size == 0)
+        return;
+
+    const auto sentinel = input + size;
+    while (input < sentinel) {
+        const float clampedAbove = *input > high ? high : *input;
+        *input = clampedAbove < low ? low : clampedAbove;
+        incrementAll(input);
+    }
+}

--- a/src/sfizz/simd/HelpersScalar.h
+++ b/src/sfizz/simd/HelpersScalar.h
@@ -200,3 +200,23 @@ void clampAllScalar(T* input, T low, T high, unsigned size ) noexcept
         incrementAll(input);
     }
 }
+
+template <class T>
+bool allWithinScalar(const T* input, T low, T high, unsigned size ) noexcept
+{
+    if (size == 0)
+        return true;
+
+    if (low > high)
+        std::swap(low, high);
+
+    const auto sentinel = input + size;
+    while (input < sentinel) {
+        if (*input < low || *input > high)
+            return false;
+
+        incrementAll(input);
+    }
+
+    return true;
+}

--- a/tests/SIMDHelpersT.cpp
+++ b/tests/SIMDHelpersT.cpp
@@ -839,3 +839,14 @@ TEST_CASE("[Helpers] clampAll (SIMD vs scalar)")
     sfz::clampAll<float>(absl::MakeSpan(inputSIMD), 10.0f, 50.0f);
     REQUIRE( approxEqual<float>(inputScalar, inputSIMD) );
 }
+
+TEST_CASE("[Helpers] allWithin")
+{
+    std::array<float, 10> input { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f };
+    sfz::setSIMDOpStatus<float>(sfz::SIMDOps::allWithin, false);
+    REQUIRE( sfz::allWithin<float>(input, 0.5f, 11.0f) );
+    REQUIRE( !sfz::allWithin<float>(input, 2.5f, 8.0f) );
+    sfz::setSIMDOpStatus<float>(sfz::SIMDOps::allWithin, true);
+    REQUIRE( sfz::allWithin<float>(input, 0.5f, 11.0f) );
+    REQUIRE( !sfz::allWithin<float>(input, 2.5f, 8.0f) );
+}

--- a/tests/SIMDHelpersT.cpp
+++ b/tests/SIMDHelpersT.cpp
@@ -812,3 +812,30 @@ TEST_CASE("[Helpers] Width Scalar")
         REQUIRE(right[0] == Approx(1.0f).margin(0.001f));
     }
 }
+
+TEST_CASE("[Helpers] clampAll")
+{
+    std::array<float, 10> inputScalar { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f };
+    std::array<float, 10> inputSIMD;
+    sfz::copy<float>(inputScalar, absl::MakeSpan(inputSIMD));
+    std::array<float, 10> expected { 2.5f, 2.5f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 8.0f, 8.0f };
+    sfz::setSIMDOpStatus<float>(sfz::SIMDOps::clampAll, false);
+    sfz::clampAll<float>(absl::MakeSpan(inputScalar), 2.5f, 8.0f);
+    REQUIRE(  approxEqual<float>(inputScalar, expected) );
+    sfz::setSIMDOpStatus<float>(sfz::SIMDOps::clampAll, true);
+    sfz::clampAll<float>(absl::MakeSpan(inputSIMD), 2.5f, 8.0f);
+    REQUIRE(  approxEqual<float>(inputSIMD, expected) );
+}
+
+TEST_CASE("[Helpers] clampAll (SIMD vs scalar)")
+{
+    std::vector<float> inputScalar(medBufferSize);
+    std::vector<float> inputSIMD(medBufferSize);
+    absl::c_iota(inputScalar, 2.0f);
+    sfz::copy<float>(inputScalar, absl::MakeSpan(inputSIMD));
+    sfz::setSIMDOpStatus<float>(sfz::SIMDOps::clampAll, false);
+    sfz::clampAll<float>(absl::MakeSpan(inputScalar), 10.0f, 50.0f);
+    sfz::setSIMDOpStatus<float>(sfz::SIMDOps::clampAll, true);
+    sfz::clampAll<float>(absl::MakeSpan(inputSIMD), 10.0f, 50.0f);
+    REQUIRE( approxEqual<float>(inputScalar, inputSIMD) );
+}

--- a/tests/SIMDHelpersT.cpp
+++ b/tests/SIMDHelpersT.cpp
@@ -846,7 +846,11 @@ TEST_CASE("[Helpers] allWithin")
     sfz::setSIMDOpStatus<float>(sfz::SIMDOps::allWithin, false);
     REQUIRE( sfz::allWithin<float>(input, 0.5f, 11.0f) );
     REQUIRE( !sfz::allWithin<float>(input, 2.5f, 8.0f) );
+    REQUIRE( !sfz::allWithin<float>(input, 0.0f, 5.0f) );
+    REQUIRE( !sfz::allWithin<float>(input, -1.0f, 7.0f) );
     sfz::setSIMDOpStatus<float>(sfz::SIMDOps::allWithin, true);
     REQUIRE( sfz::allWithin<float>(input, 0.5f, 11.0f) );
     REQUIRE( !sfz::allWithin<float>(input, 2.5f, 8.0f) );
+    REQUIRE( !sfz::allWithin<float>(input, 0.0f, 5.0f) );
+    REQUIRE( !sfz::allWithin<float>(input, -1.0f, 7.0f) );
 }


### PR DESCRIPTION
A couple SIMD helpers to use for clamping output modulation values down the line (instead of on input maybe), and to test if values are within some bounds (to check for shortcuts, in particular if the modulated gain is 0 or close to 0 then we can skip the voice).

The clamp accelerator is not super useful on my machine, but the within test goes nicely.

Clamp:
```
-----------------------------------------------------------------
Benchmark                       Time             CPU   Iterations
-----------------------------------------------------------------
ClampArray/Scalar/4          9.14 ns         9.12 ns     73378487
ClampArray/Scalar/16         11.8 ns         11.6 ns     64663920
ClampArray/Scalar/64         18.5 ns         18.3 ns     39703469
ClampArray/Scalar/256        49.0 ns         48.7 ns     13508740
ClampArray/Scalar/1024        177 ns          176 ns      3981719
ClampArray/Scalar/4096        680 ns          670 ns      1009230
ClampArray/SIMD/4            10.0 ns         9.99 ns     69088107
ClampArray/SIMD/16           13.2 ns         13.1 ns     59710171
ClampArray/SIMD/64           17.6 ns         17.6 ns     39889401
ClampArray/SIMD/256          48.1 ns         47.9 ns     13911152
ClampArray/SIMD/1024          177 ns          176 ns      3872199
ClampArray/SIMD/4096          676 ns          673 ns      1018009
```

All Within:
```
-----------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations
-----------------------------------------------------------------------
WithinArray/ScalarFalse/4          6.70 ns         6.69 ns    103154185
WithinArray/ScalarFalse/16         6.74 ns         6.73 ns     92665315
WithinArray/ScalarFalse/64         6.71 ns         6.70 ns    101789536
WithinArray/ScalarFalse/256        7.08 ns         7.07 ns    101730418
WithinArray/ScalarFalse/1024       8.62 ns         8.61 ns    101134264
WithinArray/ScalarFalse/4096       7.01 ns         6.99 ns    101676406
WithinArray/SIMDFalse/4            9.52 ns         9.51 ns     72951525
WithinArray/SIMDFalse/16           9.62 ns         9.61 ns     72657083
WithinArray/SIMDFalse/64           9.53 ns         9.52 ns     71562297
WithinArray/SIMDFalse/256          10.1 ns         10.1 ns     72387039
WithinArray/SIMDFalse/1024         9.60 ns         9.58 ns     70106311
WithinArray/SIMDFalse/4096         9.72 ns         9.71 ns     70634692
WithinArray/ScalarTrue/4           9.96 ns         9.94 ns     68181663
WithinArray/ScalarTrue/16          17.0 ns         16.9 ns     30922446
WithinArray/ScalarTrue/64          53.5 ns         53.4 ns     12756556
WithinArray/ScalarTrue/256          175 ns          175 ns      3979466
WithinArray/ScalarTrue/1024         660 ns          659 ns       993801
WithinArray/ScalarTrue/4096        2630 ns         2625 ns       266968
WithinArray/SIMDTrue/4             10.2 ns         10.2 ns     58293759
WithinArray/SIMDTrue/16            13.4 ns         13.4 ns     51708946
WithinArray/SIMDTrue/64            23.8 ns         23.7 ns     29380469
WithinArray/SIMDTrue/256           76.1 ns         75.9 ns      9061037
WithinArray/SIMDTrue/1024           240 ns          240 ns      2945988
WithinArray/SIMDTrue/4096           896 ns          894 ns       769746
```