### PR TITLE
Polyphony cleanups

### DIFF
--- a/src/sfizz/SisterVoiceRing.h
+++ b/src/sfizz/SisterVoiceRing.h
@@ -128,14 +128,6 @@ struct SisterVoiceRing {
  */
 class SisterVoiceRingBuilder {
 public:
-    ~SisterVoiceRingBuilder() noexcept {
-        if (lastStartedVoice != nullptr) {
-            ASSERT(firstStartedVoice);
-            lastStartedVoice->setNextSisterVoice(firstStartedVoice);
-            firstStartedVoice->setPreviousSisterVoice(lastStartedVoice);
-        }
-    }
-
     /**
      * @brief Add a voice to the sister ring
      *
@@ -144,6 +136,9 @@ public:
     void addVoiceToRing(Voice* voice) noexcept {
         if (firstStartedVoice == nullptr)
             firstStartedVoice = voice;
+
+        firstStartedVoice->setPreviousSisterVoice(voice);
+        voice->setNextSisterVoice(firstStartedVoice);
 
         if (lastStartedVoice != nullptr) {
             voice->setPreviousSisterVoice(lastStartedVoice);

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -976,7 +976,8 @@ void sfz::Synth::checkNotePolyphony(const Region* region, int delay, const Trigg
 
     for (Voice* voice : voiceViewArray) {
         const sfz::TriggerEvent& voiceTriggerEvent = voice->getTriggerEvent();
-        if (!voice->releasedOrFree()
+        const bool skipVoice = (triggerEvent.type == TriggerEventType::NoteOn && voice->releasedOrFree()) || voice->isFree();
+        if (!skipVoice
             && voice->getRegion()->group == region->group
             && voiceTriggerEvent.number == triggerEvent.number
             && voiceTriggerEvent.type == triggerEvent.type) {
@@ -984,8 +985,9 @@ void sfz::Synth::checkNotePolyphony(const Region* region, int delay, const Trigg
             switch (region->selfMask) {
             case SfzSelfMask::mask:
                 if (voiceTriggerEvent.value <= triggerEvent.value) {
-                    if (!selfMaskCandidate || selfMaskCandidate->getTriggerEvent().value > voiceTriggerEvent.value)
+                    if (!selfMaskCandidate || selfMaskCandidate->getTriggerEvent().value > voiceTriggerEvent.value) {
                         selfMaskCandidate = voice;
+                    }
                 }
                 break;
             case SfzSelfMask::dontMask:

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -665,6 +665,11 @@ sfz::Voice* sfz::Synth::findFreeVoice() noexcept
     if (stolenVoice == nullptr)
         return {};
 
+    // Never kill age 0 voices
+    if (stolenVoice->getAge() == 0)
+        return {};
+
+
     auto tempSpan = resources.bufferPool.getStereoBuffer(samplesPerBlock);
     SisterVoiceRing::applyToRing(stolenVoice, [&] (Voice* v) {
         renderVoiceToOutputs(*v, *tempSpan);
@@ -991,8 +996,9 @@ void sfz::Synth::checkNotePolyphony(const Region* region, int delay, const Trigg
         }
     }
 
-    if (notePolyphonyCounter >= *region->notePolyphony && selfMaskCandidate)
+    if (notePolyphonyCounter >= *region->notePolyphony && selfMaskCandidate) {
         SisterVoiceRing::offAllSisters(selfMaskCandidate, delay);
+    }
 }
 
 void sfz::Synth::checkGroupPolyphony(const Region* region, int delay) noexcept

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -932,16 +932,9 @@ void sfz::Synth::noteOnDispatch(int delay, int noteNumber, float velocity) noexc
         if (region->registerNoteOn(noteNumber, velocity, randValue)) {
             unsigned notePolyphonyCounter { 0 };
             Voice* selfMaskCandidate { nullptr };
-            Voice* selectedVoice { nullptr };
             regionPolyphonyArray.clear();
 
             for (auto& voice : voices) {
-                if (voice->isFree()) {
-                    if (selectedVoice == nullptr)
-                        selectedVoice = voice.get();
-                    continue;
-                }
-
                 if (voice->getRegion() == region && !voice->releasedOrFree()) {
                     regionPolyphonyArray.push_back(voice.get());
                 }
@@ -1002,6 +995,8 @@ void sfz::Synth::noteOnDispatch(int delay, int noteNumber, float velocity) noexc
                 }
                 parent = parent->getParent();
             }
+
+            Voice* selectedVoice = findFreeVoice();
 
             // Engine polyphony reached, we're stealing something
             if (selectedVoice == nullptr) {

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -911,7 +911,7 @@ void sfz::Synth::startVoice(Region* region, int delay, const TriggerEvent& trigg
     polyphonyGroups[region->group].registerVoice(selectedVoice);
 }
 
-bool sfz::Synth::matchAttackRegion(const Region* releaseRegion) noexcept
+bool sfz::Synth::playingAttackVoice(const Region* releaseRegion) noexcept
 {
     const auto compatibleVoice = [releaseRegion](const Voice* v) -> bool {
         const sfz::TriggerEvent& event = v->getTriggerEvent();
@@ -937,7 +937,7 @@ void sfz::Synth::noteOffDispatch(int delay, int noteNumber, float velocity) noex
 
     for (auto& region : noteActivationLists[noteNumber]) {
         if (region->registerNoteOff(noteNumber, velocity, randValue)) {
-            if (region->trigger == SfzTrigger::release && !region->rtDead && !matchAttackRegion(region))
+            if (region->trigger == SfzTrigger::release && !region->rtDead && !playingAttackVoice(region))
                 continue;
 
             startVoice(region, delay, triggerEvent, ring);
@@ -1058,7 +1058,7 @@ void sfz::Synth::noteOnDispatch(int delay, int noteNumber, float velocity) noexc
 
 void sfz::Synth::startDelayedReleaseVoices(Region* region, int delay, SisterVoiceRingBuilder& ring) noexcept
 {
-    if (!region->rtDead && !matchAttackRegion(region)) {
+    if (!region->rtDead && !playingAttackVoice(region)) {
         region->delayedReleases.clear();
         return;
     }

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -922,14 +922,13 @@ void sfz::Synth::noteOffDispatch(int delay, int noteNumber, float velocity) noex
                     continue;
             }
 
-            auto voice = findFreeVoice();
-            if (voice == nullptr)
-                continue;
-
-            voice->startVoice(region, delay, noteNumber, velocity, Voice::TriggerType::NoteOff);
-            ring.addVoiceToRing(voice);
-            RegionSet::registerVoiceInHierarchy(region, voice);
-            polyphonyGroups[region->group].registerVoice(voice);
+            if (Voice* selectedVoice = findFreeVoice()) {
+                ASSERT(selectedVoice->isFree());
+                selectedVoice->startVoice(region, delay, noteNumber, velocity, Voice::TriggerType::NoteOff);
+                ring.addVoiceToRing(selectedVoice);
+                RegionSet::registerVoiceInHierarchy(region, selectedVoice);
+                polyphonyGroups[region->group].registerVoice(selectedVoice);
+            }
         }
     }
 }
@@ -1007,17 +1006,13 @@ void sfz::Synth::noteOnDispatch(int delay, int noteNumber, float velocity) noexc
                 parent = parent->getParent();
             }
 
-            Voice* selectedVoice = findFreeVoice();
-            // For some reason we did not find a voice to use.
-            // This is a degraded case but we'll just drop the note on.
-            if (selectedVoice == nullptr)
-                continue;
-
-            ASSERT(selectedVoice->isFree());
-            selectedVoice->startVoice(region, delay, noteNumber, velocity, Voice::TriggerType::NoteOn);
-            ring.addVoiceToRing(selectedVoice);
-            RegionSet::registerVoiceInHierarchy(region, selectedVoice);
-            polyphonyGroups[region->group].registerVoice(selectedVoice);
+            if (Voice* selectedVoice = findFreeVoice()) {
+                ASSERT(selectedVoice->isFree());
+                selectedVoice->startVoice(region, delay, noteNumber, velocity, Voice::TriggerType::NoteOn);
+                ring.addVoiceToRing(selectedVoice);
+                RegionSet::registerVoiceInHierarchy(region, selectedVoice);
+                polyphonyGroups[region->group].registerVoice(selectedVoice);
+            }
         }
     }
 }
@@ -1090,16 +1085,13 @@ void sfz::Synth::hdcc(int delay, int ccNumber, float normValue) noexcept
         }
 
         if (region->registerCC(ccNumber, normValue)) {
-            auto voice = findFreeVoice();
-            if (voice == nullptr)
-                continue;
-
-
-            voice->startVoice(region, delay, ccNumber, normValue, Voice::TriggerType::CC);
-
-            ring.addVoiceToRing(voice);
-            RegionSet::registerVoiceInHierarchy(region, voice);
-            polyphonyGroups[region->group].registerVoice(voice);
+            if (Voice* selectedVoice = findFreeVoice()) {
+                ASSERT(selectedVoice->isFree());
+                selectedVoice->startVoice(region, delay, ccNumber, normValue, Voice::TriggerType::CC);
+                ring.addVoiceToRing(selectedVoice);
+                RegionSet::registerVoiceInHierarchy(region, selectedVoice);
+                polyphonyGroups[region->group].registerVoice(selectedVoice);
+            }
         }
     }
 }

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -979,7 +979,6 @@ void sfz::Synth::noteOnDispatch(int delay, int noteNumber, float velocity) noexc
                 SisterVoiceRing::offAllSisters(selfMaskCandidate, delay);
             }
 
-            auto parent = region->parent;
 
             // Polyphony reached on region
             if (regionPolyphonyArray.size() >= region->polyphony) {
@@ -995,6 +994,7 @@ void sfz::Synth::noteOnDispatch(int delay, int noteNumber, float velocity) noexc
             }
 
             // Polyphony reached some parent group/master/etc
+            auto parent = region->parent;
             while (parent != nullptr) {
                 if (parent->numPlayingVoices() >= parent->getPolyphonyLimit()) {
                     const auto activeVoices = absl::MakeSpan(parent->getActiveVoices());

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -725,8 +725,31 @@ private:
 
     fs::file_time_type checkModificationTime();
 
+    /**
+     * @brief Check all regions and start voices for note on events
+     *
+     * @param delay
+     * @param noteNumber
+     * @param velocity
+     */
     void noteOnDispatch(int delay, int noteNumber, float velocity) noexcept;
+
+    /**
+     * @brief Check all regions and start voices for note off events
+     *
+     * @param delay
+     * @param noteNumber
+     * @param velocity
+     */
     void noteOffDispatch(int delay, int noteNumber, float velocity) noexcept;
+
+    /**
+     * @brief Check all regions and start voices for cc events
+     *
+     * @param delay
+     * @param ccNumber
+     * @param value
+     */
     void ccDispatch(int delay, int ccNumber, float value) noexcept;
 
     template<class T>
@@ -781,14 +804,75 @@ private:
     VoiceViewVector voiceViewArray;
     VoiceStealing stealer;
 
+    /**
+     * @brief Check the region polyphony, releasing voices if necessary
+     *
+     * @param region
+     * @param delay
+     */
     void checkRegionPolyphony(const Region* region, int delay) noexcept;
+
+    /**
+     * @brief Check the note polyphony, releasing voices if necessary
+     *
+     * @param region
+     * @param delay
+     * @param triggerEvent
+     */
     void checkNotePolyphony(const Region* region, int delay, const TriggerEvent& triggerEvent) noexcept;
+
+    /**
+     * @brief Check the group polyphony, releasing voices if necessary
+     *
+     * @param region
+     * @param delay
+     */
     void checkGroupPolyphony(const Region* region, int delay) noexcept;
+
+    /**
+     * @brief Check the region set polyphony at all levels, releasing voices if necessary
+     *
+     * @param region
+     * @param delay
+     */
     void checkSetPolyphony(const Region* region, int delay) noexcept;
+
+    /**
+     * @brief Start a voice for a specific region.
+     * This will do the needed polyphony checks and voice stealing.
+     *
+     * @param region
+     * @param delay
+     * @param triggerEvent
+     * @param ring
+     */
     void startVoice(Region* region, int delay, const TriggerEvent& triggerEvent, SisterVoiceRingBuilder& ring) noexcept;
+
+    /**
+     * @brief Check the off groups of all playing voices, releasing if necessary
+     *
+     * @param region
+     * @param delay
+     */
     void checkOffGroups(Region* region, int delay) noexcept;
+
+    /**
+     * @brief Start all delayed release voices of the region if necessary
+     *
+     * @param region
+     * @param delay
+     * @param ring
+     */
     void startDelayedReleaseVoices(Region* region, int delay, SisterVoiceRingBuilder& ring) noexcept;
-    bool matchAttackRegion(const Region* region) noexcept;
+
+    /**
+     * @brief Check if a playing voice matches the release region
+     *
+     * @param releaseRegion
+     * @return true
+     * @return false
+     */
+    bool playingAttackVoice(const Region* releaseRegion) noexcept;
 
     std::array<RegionViewVector, 128> noteActivationLists;
     std::array<RegionViewVector, config::numCCs> ccActivationLists;

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -849,14 +849,6 @@ private:
     void startVoice(Region* region, int delay, const TriggerEvent& triggerEvent, SisterVoiceRingBuilder& ring) noexcept;
 
     /**
-     * @brief Check the off groups of all playing voices, releasing if necessary
-     *
-     * @param region
-     * @param delay
-     */
-    void checkOffGroups(Region* region, int delay) noexcept;
-
-    /**
      * @brief Start all delayed release voices of the region if necessary
      *
      * @param region

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -785,6 +785,7 @@ private:
     void checkGroupPolyphony(const Region* region, int delay) noexcept;
     void checkSetPolyphony(const Region* region, int delay) noexcept;
     void startVoice(Region* region, int delay, const TriggerEvent& triggerEvent, SisterVoiceRingBuilder& ring) noexcept;
+    void checkDelayedReleases(Region* region, int delay, SisterVoiceRingBuilder& ring) noexcept;
 
     std::array<RegionViewVector, 128> noteActivationLists;
     std::array<RegionViewVector, config::numCCs> ccActivationLists;

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -776,9 +776,14 @@ private:
 
     // Views to speed up iteration over the regions and voices when events
     // occur in the audio callback
-    VoiceViewVector regionPolyphonyArray;
+    VoiceViewVector tempPolyphonyArray;
     VoiceViewVector voiceViewArray;
     VoiceStealing stealer;
+
+    void checkRegionPolyphony(const Region* region, int delay) noexcept;
+    void checkNotePolyphony(const Region* region, int delay, int number, float value, Voice::TriggerType triggerType) noexcept;
+    void checkGroupPolyphony(const Region* region, int delay) noexcept;
+    void checkSetPolyphony(const Region* region, int delay) noexcept;
 
     std::array<RegionViewVector, 128> noteActivationLists;
     std::array<RegionViewVector, config::numCCs> ccActivationLists;

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -727,6 +727,7 @@ private:
 
     void noteOnDispatch(int delay, int noteNumber, float velocity) noexcept;
     void noteOffDispatch(int delay, int noteNumber, float velocity) noexcept;
+    void ccDispatch(int delay, int ccNumber, float value) noexcept;
 
     template<class T>
     static void updateUsedCCsFromCCMap(std::bitset<sfz::config::numCCs>& usedCCs, const CCMap<T> map)
@@ -785,7 +786,9 @@ private:
     void checkGroupPolyphony(const Region* region, int delay) noexcept;
     void checkSetPolyphony(const Region* region, int delay) noexcept;
     void startVoice(Region* region, int delay, const TriggerEvent& triggerEvent, SisterVoiceRingBuilder& ring) noexcept;
-    void checkDelayedReleases(Region* region, int delay, SisterVoiceRingBuilder& ring) noexcept;
+    void checkOffGroups(Region* region, int delay) noexcept;
+    void startDelayedReleaseVoices(Region* region, int delay, SisterVoiceRingBuilder& ring) noexcept;
+    bool matchAttackRegion(const Region* region) noexcept;
 
     std::array<RegionViewVector, 128> noteActivationLists;
     std::array<RegionViewVector, config::numCCs> ccActivationLists;

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -784,6 +784,7 @@ private:
     void checkNotePolyphony(const Region* region, int delay, const TriggerEvent& triggerEvent) noexcept;
     void checkGroupPolyphony(const Region* region, int delay) noexcept;
     void checkSetPolyphony(const Region* region, int delay) noexcept;
+    void startVoice(Region* region, int delay, const TriggerEvent& triggerEvent, SisterVoiceRingBuilder& ring) noexcept;
 
     std::array<RegionViewVector, 128> noteActivationLists;
     std::array<RegionViewVector, config::numCCs> ccActivationLists;

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -765,18 +765,21 @@ private:
     using RegionSetPtr = std::unique_ptr<RegionSet>;
     std::vector<RegionPtr> regions;
     std::vector<VoicePtr> voices;
+
     // These are more general "groups" than sfz and encapsulates the full hierarchy
     RegionSet* currentSet;
     OpcodeScope lastHeader { OpcodeScope::kOpcodeScopeGlobal };
     std::vector<RegionSetPtr> sets;
+
     // These are the `group=` groups where you can off voices
     std::vector<PolyphonyGroup> polyphonyGroups;
+
     // Views to speed up iteration over the regions and voices when events
     // occur in the audio callback
     VoiceViewVector regionPolyphonyArray;
+    VoiceViewVector voiceViewArray;
     VoiceStealing stealer;
 
-    VoiceViewVector voiceViewArray;
     std::array<RegionViewVector, 128> noteActivationLists;
     std::array<RegionViewVector, config::numCCs> ccActivationLists;
 

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -781,7 +781,7 @@ private:
     VoiceStealing stealer;
 
     void checkRegionPolyphony(const Region* region, int delay) noexcept;
-    void checkNotePolyphony(const Region* region, int delay, int number, float value, Voice::TriggerType triggerType) noexcept;
+    void checkNotePolyphony(const Region* region, int delay, const TriggerEvent& triggerEvent) noexcept;
     void checkGroupPolyphony(const Region* region, int delay) noexcept;
     void checkSetPolyphony(const Region* region, int delay) noexcept;
 

--- a/src/sfizz/TriggerEvent.h
+++ b/src/sfizz/TriggerEvent.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+
+namespace sfz
+{
+enum class TriggerEventType { NoteOn, NoteOff, CC };
+
+/**
+ * @brief Encapsulate a midi event with normalized values
+ *
+ */
+struct TriggerEvent
+{
+    TriggerEventType type;
+    int number;
+    float value;
+};
+
+}

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -708,12 +708,14 @@ void sfz::Voice::fillWithGenerator(AudioSpan<float> buffer) noexcept
 #endif
 }
 
-bool sfz::Voice::checkOffGroup(int delay, uint32_t group) noexcept
+bool sfz::Voice::checkOffGroup(const Region* other, int delay, int noteNumber) noexcept
 {
-    if (region == nullptr)
+    if (region == nullptr || other == nullptr)
         return false;
 
-    if (triggerEvent.type == TriggerEventType::NoteOn && region->offBy == group) {
+    if (triggerEvent.type == TriggerEventType::NoteOn 
+        && region->offBy == other->group
+        && noteNumber != triggerEvent.number) {
         off(delay);
         return true;
     }

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -193,7 +193,7 @@ void sfz::Voice::registerNoteOff(int delay, int noteNumber, float velocity) noex
     if (state != State::playing)
         return;
 
-    if (triggerEvent.number == noteNumber) {
+    if (triggerEvent.number == noteNumber && triggerEvent.type == TriggerEventType::NoteOn) {
         noteIsOff = true;
 
         if (region->loopMode == SfzLoopMode::one_shot)

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -5,6 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #pragma once
+#include "TriggerEvent.h"
 #include "Config.h"
 #include "ADSREnvelope.h"
 #include "HistoricalBuffer.h"
@@ -113,11 +114,9 @@ public:
      *
      * @param region
      * @param delay
-     * @param number
-     * @param value
-     * @param triggerType
+     * @param evebt
      */
-    void startVoice(Region* region, int delay, int number, float value, TriggerType triggerType) noexcept;
+    void startVoice(Region* region, int delay, const TriggerEvent& event) noexcept;
 
     /**
      * @brief Get the sample quality determined by the active region.
@@ -198,23 +197,11 @@ public:
      */
     bool releasedOrFree() const noexcept;
     /**
-     * @brief Get the number that triggered the voice (note number or cc number)
+     * @brief Get the event that triggered the voice
      *
      * @return int
      */
-    int getTriggerNumber() const noexcept { return triggerNumber; }
-    /**
-     * @brief Get the value that triggered the voice (note velocity or cc value)
-     *
-     * @return float
-     */
-    float getTriggerValue() const noexcept { return triggerValue; }
-    /**
-     * @brief Get the type of trigger
-     *
-     * @return TriggerType
-     */
-    TriggerType getTriggerType() const noexcept { return triggerType; }
+    const TriggerEvent& getTriggerEvent() const noexcept { return triggerEvent; }
 
     /**
      * @brief Reset the voice to its initial values
@@ -432,9 +419,7 @@ private:
     State state { State::idle };
     bool noteIsOff { false };
 
-    TriggerType triggerType;
-    int triggerNumber;
-    float triggerValue;
+    TriggerEvent triggerEvent;
     absl::optional<int> triggerDelay;
 
     float speedRatio { 1.0 };
@@ -496,13 +481,16 @@ inline bool sisterVoices(const Voice* lhs, const Voice* rhs)
     if (lhs->getAge() != rhs->getAge())
         return false;
 
-    if (lhs->getTriggerNumber() != rhs->getTriggerNumber())
+    const TriggerEvent& lhsTrigger = lhs->getTriggerEvent();
+    const TriggerEvent& rhsTrigger = rhs->getTriggerEvent();
+
+    if (lhsTrigger.number != rhsTrigger.number)
         return false;
 
-    if (lhs->getTriggerValue() != rhs->getTriggerValue())
+    if (lhsTrigger.value != rhsTrigger.value)
         return false;
 
-    if (lhs->getTriggerType() != rhs->getTriggerType())
+    if (lhsTrigger.type != rhsTrigger.type)
         return false;
 
     return true;
@@ -513,14 +501,17 @@ inline bool voiceOrdering(const Voice* lhs, const Voice* rhs)
     if (lhs->getAge() != rhs->getAge())
         return lhs->getAge() > rhs->getAge();
 
-    if (lhs->getTriggerNumber() != rhs->getTriggerNumber())
-        return lhs->getTriggerNumber() < rhs->getTriggerNumber();
+    const TriggerEvent& lhsTrigger = lhs->getTriggerEvent();
+    const TriggerEvent& rhsTrigger = rhs->getTriggerEvent();
 
-    if (lhs->getTriggerValue() != rhs->getTriggerValue())
-        return lhs->getTriggerValue() < rhs->getTriggerValue();
+    if (lhsTrigger.number != rhsTrigger.number)
+        return lhsTrigger.number < rhsTrigger.number;
 
-    if (lhs->getTriggerType() != rhs->getTriggerType())
-        return lhs->getTriggerType() > rhs->getTriggerType();
+    if (lhsTrigger.value != rhsTrigger.value)
+        return lhsTrigger.value < rhsTrigger.value;
+
+    if (lhsTrigger.type != rhsTrigger.type)
+        return lhsTrigger.type > rhsTrigger.type;
 
     return false;
 }

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -44,12 +44,6 @@ public:
 
     ~Voice();
 
-    enum class TriggerType {
-        NoteOn,
-        NoteOff,
-        CC
-    };
-
     /**
      * @brief Get the unique identifier of this voice in a synth
      */

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -163,11 +163,12 @@ public:
      * This will trigger the release if true.
      *
      * @param delay
+     * @param noteNumber
      * @param group
      * @return true
      * @return false
      */
-    bool checkOffGroup(int delay, uint32_t group) noexcept;
+    bool checkOffGroup(const Region* other, int delay, int noteNumber) noexcept;
 
     /**
      * @brief Render a block of data for this voice into the span

--- a/src/sfizz/VoiceStealing.cpp
+++ b/src/sfizz/VoiceStealing.cpp
@@ -25,7 +25,7 @@ sfz::Voice* sfz::VoiceStealing::steal(absl::Span<sfz::Voice*> voices) noexcept
     // their sound, but it's reasonable for sounds with a quick attack and longer
     // release.
     const auto ageThreshold =
-        static_cast<int>(voices.front()->getAge() * config::stealingAgeCoeff) + 1;
+        static_cast<int>(voices.front()->getAge() * config::stealingAgeCoeff);
 
     Voice* returnedVoice = voices.front();
     unsigned idx = 0;

--- a/tests/PolyphonyT.cpp
+++ b/tests/PolyphonyT.cpp
@@ -227,11 +227,11 @@ TEST_CASE("[Polyphony] Self-masking")
     REQUIRE( synth.getNumActiveVoices(true) == 3 ); // One of these is releasing
     synth.renderBlock(buffer);
     REQUIRE( numPlayingVoices(synth) == 2 );
-    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(0)->getTriggerEvent().value == 63_norm);
     REQUIRE(!synth.getVoiceView(0)->releasedOrFree());
-    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 62_norm);
+    REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 62_norm);
     REQUIRE( synth.getVoiceView(1)->releasedOrFree()); // The lowest velocity voice is the masking candidate
-    REQUIRE( synth.getVoiceView(2)->getTriggerValue() == 64_norm);
+    REQUIRE( synth.getVoiceView(2)->getTriggerEvent().value == 64_norm);
     REQUIRE(!synth.getVoiceView(2)->releasedOrFree());
 }
 
@@ -248,11 +248,11 @@ TEST_CASE("[Polyphony] Not self-masking")
     REQUIRE( synth.getNumActiveVoices(true) == 3 ); // One of these is releasing
     synth.renderBlock(buffer);
     REQUIRE( numPlayingVoices(synth) == 2 );
-    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(0)->getTriggerEvent().value == 63_norm);
     REQUIRE( synth.getVoiceView(0)->releasedOrFree());
-    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 62_norm);
+    REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 62_norm);
     REQUIRE(!synth.getVoiceView(1)->releasedOrFree());
-    REQUIRE( synth.getVoiceView(2)->getTriggerValue() == 64_norm);
+    REQUIRE( synth.getVoiceView(2)->getTriggerEvent().value == 64_norm);
     REQUIRE(!synth.getVoiceView(2)->releasedOrFree());
 }
 
@@ -269,11 +269,11 @@ TEST_CASE("[Polyphony] Self-masking with the exact same velocity")
     REQUIRE( synth.getNumActiveVoices(true) == 3 ); // One of these is releasing
     synth.renderBlock(buffer);
     REQUIRE( numPlayingVoices(synth) == 2 );
-    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 64_norm);
+    REQUIRE( synth.getVoiceView(0)->getTriggerEvent().value == 64_norm);
     REQUIRE(!synth.getVoiceView(0)->releasedOrFree());
-    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 63_norm);
     REQUIRE( synth.getVoiceView(1)->releasedOrFree()); // The first one is the masking candidate since they have the same velocity
-    REQUIRE( synth.getVoiceView(2)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(2)->getTriggerEvent().value == 63_norm);
     REQUIRE(!synth.getVoiceView(2)->releasedOrFree());
 }
 
@@ -286,9 +286,9 @@ TEST_CASE("[Polyphony] Self-masking only works from low to high")
     synth.noteOn(0, 64, 63 );
     synth.noteOn(0, 64, 62 );
     REQUIRE( synth.getNumActiveVoices(true) == 2 ); // Both notes are playing
-    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(0)->getTriggerEvent().value == 63_norm);
     REQUIRE(!synth.getVoiceView(0)->releasedOrFree());
-    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 62_norm);
+    REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 62_norm);
     REQUIRE(!synth.getVoiceView(1)->releasedOrFree());
 }
 
@@ -305,13 +305,13 @@ TEST_CASE("[Polyphony] Note polyphony checks works across regions in the same po
     REQUIRE( synth.getNumActiveVoices(true) == 4);
     synth.renderBlock(buffer);
     REQUIRE( numPlayingVoices(synth) == 1 );
-    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 62_norm);
+    REQUIRE( synth.getVoiceView(0)->getTriggerEvent().value == 62_norm);
     REQUIRE( synth.getVoiceView(0)->releasedOrFree()); // got killed
-    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 62_norm);
+    REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 62_norm);
     REQUIRE( synth.getVoiceView(1)->releasedOrFree()); // got killed
-    REQUIRE( synth.getVoiceView(2)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(2)->getTriggerEvent().value == 63_norm);
     REQUIRE( synth.getVoiceView(2)->releasedOrFree()); // got killed
-    REQUIRE( synth.getVoiceView(3)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(3)->getTriggerEvent().value == 63_norm);
     REQUIRE(!synth.getVoiceView(3)->releasedOrFree());
 }
 
@@ -333,9 +333,9 @@ TEST_CASE("[Polyphony] Note polyphony checks works across regions in the same po
     REQUIRE( synth.getNumActiveVoices(true) == 2 );
     synth.renderBlock(buffer);
     REQUIRE( numPlayingVoices(synth) == 1 );
-    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(0)->getTriggerEvent().value == 63_norm);
     REQUIRE( synth.getVoiceView(0)->releasedOrFree());
-    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 64_norm);
+    REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 64_norm);
     REQUIRE(!synth.getVoiceView(1)->releasedOrFree());
 }
 
@@ -353,13 +353,13 @@ TEST_CASE("[Polyphony] Note polyphony do not operate across polyphony groups")
     REQUIRE( synth.getNumActiveVoices(true) == 4); // Both notes are playing
     synth.renderBlock(buffer);
     REQUIRE(numPlayingVoices(synth) == 2 );
-    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 62_norm);
+    REQUIRE( synth.getVoiceView(0)->getTriggerEvent().value == 62_norm);
     REQUIRE( synth.getVoiceView(0)->releasedOrFree()); // got killed
-    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 62_norm);
+    REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 62_norm);
     REQUIRE( synth.getVoiceView(1)->releasedOrFree()); // got killed
-    REQUIRE( synth.getVoiceView(2)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(2)->getTriggerEvent().value == 63_norm);
     REQUIRE(!synth.getVoiceView(2)->releasedOrFree());
-    REQUIRE( synth.getVoiceView(3)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(3)->getTriggerEvent().value == 63_norm);
     REQUIRE(!synth.getVoiceView(3)->releasedOrFree());
 }
 
@@ -381,8 +381,8 @@ TEST_CASE("[Polyphony] Note polyphony do not operate across polyphony groups (wi
     REQUIRE( synth.getNumActiveVoices(true) == 2 );
     synth.renderBlock(buffer);
     REQUIRE(numPlayingVoices(synth) == 2 );
-    REQUIRE( synth.getVoiceView(0)->getTriggerValue() == 63_norm);
+    REQUIRE( synth.getVoiceView(0)->getTriggerEvent().value == 63_norm);
     REQUIRE(!synth.getVoiceView(0)->releasedOrFree());
-    REQUIRE( synth.getVoiceView(1)->getTriggerValue() == 64_norm);
+    REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 64_norm);
     REQUIRE(!synth.getVoiceView(1)->releasedOrFree());
 }

--- a/tests/PolyphonyT.cpp
+++ b/tests/PolyphonyT.cpp
@@ -429,3 +429,71 @@ TEST_CASE("[Polyphony] Note polyphony operates on release voices (masking works 
     REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 61_norm);
     REQUIRE(!synth.getVoiceView(1)->releasedOrFree());
 }
+
+TEST_CASE("[Polyphony] Note polyphony operates on release voices and sustain pedal")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
+        <region> key=48 sample=*silence
+        <region> key=48 note_polyphony=1 sample=*saw trigger=release ampeg_attack=1 ampeg_decay=1
+    )");
+    synth.cc(0, 64, 127);
+    synth.noteOn(0, 48, 61 );
+    synth.noteOff(1, 48, 0 );
+    synth.noteOn(2, 48, 62 );
+    synth.noteOff(3, 48, 0 );
+    synth.noteOn(4, 48, 63 );
+    synth.noteOff(5, 48, 0 );
+    REQUIRE( synth.getNumActiveVoices(true) == 3);
+    REQUIRE( numPlayingVoices(synth) == 3 );
+    synth.cc(20, 64, 0);
+    REQUIRE( synth.getNumActiveVoices(true) == 6 );
+    REQUIRE( numPlayingVoices(synth) == 1 );
+    REQUIRE( synth.getVoiceView(0)->getTriggerEvent().value == 61_norm);
+    REQUIRE( synth.getVoiceView(0)->releasedOrFree());
+    REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 62_norm);
+    REQUIRE( synth.getVoiceView(1)->releasedOrFree());
+    REQUIRE( synth.getVoiceView(2)->getTriggerEvent().value == 63_norm);
+    REQUIRE( synth.getVoiceView(2)->releasedOrFree());
+    REQUIRE( synth.getVoiceView(3)->getTriggerEvent().value == 61_norm);
+    REQUIRE( synth.getVoiceView(3)->releasedOrFree());
+    REQUIRE( synth.getVoiceView(4)->getTriggerEvent().value == 62_norm);
+    REQUIRE( synth.getVoiceView(4)->releasedOrFree());
+    REQUIRE( synth.getVoiceView(5)->getTriggerEvent().value == 63_norm);
+    REQUIRE(!synth.getVoiceView(5)->releasedOrFree());
+}
+
+TEST_CASE("[Polyphony] Note polyphony operates on release voices and sustain pedal (masking)")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
+        <region> key=48 sample=*silence
+        <region> key=48 note_polyphony=1 sample=*saw trigger=release ampeg_attack=1 ampeg_decay=1
+    )");
+    synth.cc(0, 64, 127);
+    synth.noteOn(0, 48, 63 );
+    synth.noteOff(1, 48, 0 );
+    synth.noteOn(2, 48, 62 );
+    synth.noteOff(3, 48, 0 );
+    synth.noteOn(4, 48, 61 );
+    synth.noteOff(5, 48, 0 );
+    REQUIRE( synth.getNumActiveVoices(true) == 3);
+    REQUIRE( numPlayingVoices(synth) == 3 );
+    synth.cc(20, 64, 0);
+    REQUIRE( synth.getNumActiveVoices(true) == 6 );
+    REQUIRE( numPlayingVoices(synth) == 3 );
+    REQUIRE( synth.getVoiceView(0)->getTriggerEvent().value == 63_norm);
+    REQUIRE( synth.getVoiceView(0)->releasedOrFree());
+    REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 62_norm);
+    REQUIRE( synth.getVoiceView(1)->releasedOrFree());
+    REQUIRE( synth.getVoiceView(2)->getTriggerEvent().value == 61_norm);
+    REQUIRE( synth.getVoiceView(2)->releasedOrFree());
+    REQUIRE( synth.getVoiceView(3)->getTriggerEvent().value == 63_norm);
+    REQUIRE(!synth.getVoiceView(3)->releasedOrFree());
+    REQUIRE( synth.getVoiceView(4)->getTriggerEvent().value == 62_norm);
+    REQUIRE(!synth.getVoiceView(4)->releasedOrFree());
+    REQUIRE( synth.getVoiceView(5)->getTriggerEvent().value == 61_norm);
+    REQUIRE(!synth.getVoiceView(5)->releasedOrFree());
+}

--- a/tests/PolyphonyT.cpp
+++ b/tests/PolyphonyT.cpp
@@ -286,6 +286,7 @@ TEST_CASE("[Polyphony] Self-masking only works from low to high")
     synth.noteOn(0, 64, 63 );
     synth.noteOn(0, 64, 62 );
     REQUIRE( synth.getNumActiveVoices(true) == 2 ); // Both notes are playing
+    REQUIRE( numPlayingVoices(synth) == 2 ); // id
     REQUIRE( synth.getVoiceView(0)->getTriggerEvent().value == 63_norm);
     REQUIRE(!synth.getVoiceView(0)->releasedOrFree());
     REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 62_norm);
@@ -384,5 +385,47 @@ TEST_CASE("[Polyphony] Note polyphony do not operate across polyphony groups (wi
     REQUIRE( synth.getVoiceView(0)->getTriggerEvent().value == 63_norm);
     REQUIRE(!synth.getVoiceView(0)->releasedOrFree());
     REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 64_norm);
+    REQUIRE(!synth.getVoiceView(1)->releasedOrFree());
+}
+
+TEST_CASE("[Polyphony] Note polyphony operates on release voices")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
+        <region> key=48 note_polyphony=1 sample=*saw trigger=release_key ampeg_attack=1 ampeg_decay=1
+    )");
+    synth.noteOn(0, 48, 63 );
+    synth.noteOff(10, 48, 0 );
+    REQUIRE( synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(20, 48, 65 );
+    synth.noteOff(30, 48, 10 );
+    REQUIRE( synth.getNumActiveVoices(true) == 2 );
+    synth.renderBlock(buffer);
+    REQUIRE(numPlayingVoices(synth) == 1 );
+    REQUIRE( synth.getVoiceView(0)->getTriggerEvent().value == 63_norm);
+    REQUIRE( synth.getVoiceView(0)->releasedOrFree());
+    REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 65_norm);
+    REQUIRE(!synth.getVoiceView(1)->releasedOrFree());
+}
+
+TEST_CASE("[Polyphony] Note polyphony operates on release voices (masking works from low to high but takes into account the replaced velocity)")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, blockSize };
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyphony.sfz", R"(
+        <region> key=48 note_polyphony=1 sample=*saw trigger=release_key ampeg_attack=1 ampeg_decay=1
+    )");
+    synth.noteOn(0, 48, 63 );
+    synth.noteOff(10, 48, 0 );
+    REQUIRE( synth.getNumActiveVoices(true) == 1);
+    REQUIRE( numPlayingVoices(synth) == 1 );
+    synth.noteOn(20, 48, 61 );
+    synth.noteOff(30, 48, 10 );
+    REQUIRE( synth.getNumActiveVoices(true) == 2 );
+    REQUIRE( numPlayingVoices(synth) == 2 );
+    REQUIRE( synth.getVoiceView(0)->getTriggerEvent().value == 63_norm);
+    REQUIRE(!synth.getVoiceView(0)->releasedOrFree());
+    REQUIRE( synth.getVoiceView(1)->getTriggerEvent().value == 61_norm);
     REQUIRE(!synth.getVoiceView(1)->releasedOrFree());
 }

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -660,7 +660,7 @@ TEST_CASE("[Synth] Apply function on sisters")
     REQUIRE( sfz::SisterVoiceRing::countSisterVoices(synth.getVoiceView(0)) == 3 );
     float start = 1.0f;
     sfz::SisterVoiceRing::applyToRing(synth.getVoiceView(0), [&](const sfz::Voice* v) {
-        start += static_cast<float>(v->getTriggerNumber());
+        start += static_cast<float>(v->getTriggerEvent().number);
     });
     REQUIRE( start == 1.0f + 3.0f * 63.0f );
 }
@@ -828,7 +828,7 @@ TEST_CASE("[Synth] Release (Multiple notes, release_key ignores the pedal)")
     std::vector<float> requiredVelocities { 34_norm, 78_norm, 85_norm};
     std::vector<float> actualVelocities;
     for (auto* v: getActiveVoices(synth)) {
-        actualVelocities.push_back(v->getTriggerValue());
+        actualVelocities.push_back(v->getTriggerEvent().value);
     }
     sortAll(requiredVelocities, actualVelocities);
     REQUIRE( requiredVelocities == actualVelocities );
@@ -856,7 +856,7 @@ TEST_CASE("[Synth] Release (Multiple notes, release, cleared the delayed voices 
     std::vector<float> requiredVelocities { 34_norm, 78_norm, 85_norm, 34_norm, 78_norm, 85_norm };
     std::vector<float> actualVelocities;
     for (auto* v: getActiveVoices(synth)) {
-        actualVelocities.push_back(v->getTriggerValue());
+        actualVelocities.push_back(v->getTriggerEvent().value);
     }
     sortAll(requiredVelocities, actualVelocities);
     REQUIRE( requiredVelocities == actualVelocities );
@@ -886,7 +886,7 @@ TEST_CASE("[Synth] Release (Multiple notes after pedal is down, release, cleared
     std::vector<float> requiredVelocities { 34_norm, 78_norm, 85_norm, 34_norm, 78_norm, 85_norm };
     std::vector<float> actualVelocities;
     for (auto* v: getActiveVoices(synth)) {
-        actualVelocities.push_back(v->getTriggerValue());
+        actualVelocities.push_back(v->getTriggerEvent().value);
     }
     sortAll(requiredVelocities, actualVelocities);
     REQUIRE( requiredVelocities == actualVelocities );
@@ -914,7 +914,7 @@ TEST_CASE("[Synth] Release (Multiple note ons during pedal down)")
     std::vector<float> requiredVelocities { 78_norm, 85_norm, 78_norm, 85_norm };
     std::vector<float> actualVelocities;
     for (auto* v: getActiveVoices(synth)) {
-        actualVelocities.push_back(v->getTriggerValue());
+        actualVelocities.push_back(v->getTriggerEvent().value);
     }
     sortAll(requiredVelocities, actualVelocities);
     REQUIRE( requiredVelocities == actualVelocities );

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -1256,8 +1256,24 @@ TEST_CASE("[Synth] Off by same group")
     REQUIRE( playingVoices.front()->getRegion()->keyRange.containsWithEnd(60) );
 }
 
+TEST_CASE("[Synth] Off by alone and repeated")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, 256 };
 
-TEST_CASE("[Synth] Off by same note")
+    synth.loadSfzString(fs::current_path(), R"(
+        <region> group=1 off_by=1 sample=*sine key=60
+    )");
+    synth.noteOn(0, 60, 85);
+    REQUIRE( numPlayingVoices(synth) == 1 );
+    synth.noteOn(0, 60, 85);
+    REQUIRE( numPlayingVoices(synth) == 2 );
+    synth.noteOn(0, 60, 85);
+    REQUIRE( numPlayingVoices(synth) == 3 );
+}
+
+
+TEST_CASE("[Synth] Off by same note and group")
 {
     sfz::Synth synth;
     sfz::AudioBuffer<float> buffer { 2, 256 };
@@ -1267,7 +1283,6 @@ TEST_CASE("[Synth] Off by same note")
         <region> group=1 off_by=1 sample=*triangle key=60
     )");
     synth.noteOn(0, 60, 85);
-    REQUIRE( numPlayingVoices(synth) == 1 );
-    auto playingVoices = getPlayingVoices(synth);
-    REQUIRE( playingVoices.front()->getRegion()->sampleId.filename() == "*triangle" );
+    REQUIRE( numPlayingVoices(synth) == 2 );
+    synth.noteOn(0, 60, 85);
 }


### PR DESCRIPTION
This is mostly splitting up the various polyphony checks and overall voice starting logic in the synth into smaller methods, and using them on all events instead of only note ons.

This should close #372.

I'll add some inbuilt tests from the sfz test suite before merging I think, to check that we do cover relevant behavior on all fronts.