### PR TITLE
Put default quality to 1

### DIFF
--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -245,7 +245,7 @@ namespace Default
 	constexpr Range<float> egOnCCPercentRange { -100.0, 100.0 };
 
     // ***** SFZ v2 ********
-    constexpr int sampleQuality { 2 };
+    constexpr int sampleQuality { 1 };
     constexpr int sampleQualityInFreewheelingMode { 10 }; // for future use, possibly excessive
     constexpr Range<int> sampleQualityRange { 1, 10 }; // sample_quality
 


### PR DESCRIPTION
For live use it does make sense to have linear interpolation by default unless explicitely overriden. With the advent of saner UIs, this could be an option there too. Freewheeling keeps the highest resampling quality.