### PR TITLE
Allow controller changes to be received by plugin UI

### DIFF
--- a/editor/src/editor/EditIds.h
+++ b/editor/src/editor/EditIds.h
@@ -24,6 +24,7 @@ enum class EditId : int {
     UINumPreloadedSamples,
     UINumActiveVoices,
     UIActivePanel,
+    ControllerChange,
 };
 
 struct EditRange {

--- a/editor/src/editor/Editor.cpp
+++ b/editor/src/editor/Editor.cpp
@@ -279,6 +279,16 @@ void Editor::Impl::uiReceiveValue(EditId id, const EditValue& v)
             setActivePanel(value);
         }
         break;
+    case EditId::ControllerChange:
+        {
+            const std::vector<float>& value = v.to_float_vector();
+
+            const int ccNumber = static_cast<int>(value.at(0));
+            const float ccValue = static_cast<float>(value.at(1));
+
+            #pragma message("UI: implement CC received")
+        }
+        break;
     }
 }
 

--- a/lv2/sfizz.c
+++ b/lv2/sfizz.c
@@ -133,6 +133,7 @@ typedef struct
     LV2_URID atom_long_uri;
     LV2_URID atom_urid_uri;
     LV2_URID atom_path_uri;
+    LV2_URID patch_request_uri;
     LV2_URID patch_set_uri;
     LV2_URID patch_get_uri;
     LV2_URID patch_put_uri;
@@ -226,6 +227,7 @@ sfizz_lv2_map_required_uris(sfizz_plugin_t *self)
     self->atom_urid_uri = map->map(map->handle, LV2_ATOM__URID);
     self->atom_object_uri = map->map(map->handle, LV2_ATOM__Object);
     self->atom_blank_uri = map->map(map->handle, LV2_ATOM__Blank);
+    self->patch_request_uri = map->map(map->handle, LV2_PATCH__Request);
     self->patch_set_uri = map->map(map->handle, LV2_PATCH__Set);
     self->patch_get_uri = map->map(map->handle, LV2_PATCH__Get);
     self->patch_put_uri = map->map(map->handle, LV2_PATCH__Put);
@@ -639,12 +641,12 @@ sfizz_lv2_send_cc_notification(sfizz_plugin_t *self)
     if (!self->have_cc_notification)
         return false;
 
-    LV2_Atom_Forge_Frame frame_patch_set;
+    LV2_Atom_Forge_Frame frame_patch_request;
     LV2_Atom_Forge_Frame frame_patch_value;
 
     bool write_ok =
         lv2_atom_forge_frame_time(&self->forge, 0) &&
-        lv2_atom_forge_object(&self->forge, &frame_patch_set, 0, self->patch_set_uri) &&
+        lv2_atom_forge_object(&self->forge, &frame_patch_request, 0, self->patch_request_uri) &&
         lv2_atom_forge_key(&self->forge, self->patch_property_uri) &&
         lv2_atom_forge_urid(&self->forge, self->sfizz_controller_change_uri) &&
         lv2_atom_forge_key(&self->forge, self->patch_value_uri) &&
@@ -656,7 +658,7 @@ sfizz_lv2_send_cc_notification(sfizz_plugin_t *self)
         return false;
 
     lv2_atom_forge_pop(&self->forge, &frame_patch_value);
-    lv2_atom_forge_pop(&self->forge, &frame_patch_set);
+    lv2_atom_forge_pop(&self->forge, &frame_patch_request);
     self->have_cc_notification = false;
     return true;
 }

--- a/lv2/sfizz.c
+++ b/lv2/sfizz.c
@@ -149,6 +149,7 @@ typedef struct
     LV2_URID sfizz_log_status_uri;
     LV2_URID sfizz_check_modification_uri;
     LV2_URID sfizz_controller_change_uri;
+    LV2_URID sfizz_recheck_controllers_uri;
     LV2_URID time_position_uri;
     LV2_URID time_bar_uri;
     LV2_URID time_bar_beat_uri;
@@ -244,6 +245,7 @@ sfizz_lv2_map_required_uris(sfizz_plugin_t *self)
     self->sfizz_log_status_uri = map->map(map->handle, SFIZZ__logStatus);
     self->sfizz_check_modification_uri = map->map(map->handle, SFIZZ__checkModification);
     self->sfizz_controller_change_uri = map->map(map->handle, SFIZZ__controllerChange);
+    self->sfizz_recheck_controllers_uri = map->map(map->handle, SFIZZ__recheckControllers);
     self->time_position_uri = map->map(map->handle, LV2_TIME__Position);
     self->time_bar_uri = map->map(map->handle, LV2_TIME__bar);
     self->time_bar_beat_uri = map->map(map->handle, LV2_TIME__barBeat);
@@ -924,6 +926,16 @@ run(LV2_Handle instance, uint32_t sample_count)
                 else if (property->body == self->sfizz_scala_file_uri)
                 {
                     sfizz_lv2_send_file_path(self, self->sfizz_scala_file_uri, self->scala_file_path);
+                }
+            }
+            else if (obj->body.otype == self->patch_request_uri)
+            {
+                const LV2_Atom_URID *property = NULL;
+                lv2_atom_object_get(obj, self->patch_property_uri, &property, 0);
+                if (property)
+                {
+                    if (property->body == self->sfizz_recheck_controllers_uri)
+                        sfizz_recheck_all_hdcc(self->synth);
                 }
             }
             else if (obj->body.otype == self->time_position_uri)

--- a/lv2/sfizz_lv2.h
+++ b/lv2/sfizz_lv2.h
@@ -19,7 +19,9 @@
 // These ones are just for the worker
 #define SFIZZ__logStatus SFIZZ_URI ":" "log_status"
 #define SFIZZ__checkModification SFIZZ_URI ":" "check_modification"
+// These ones are for information exchange with the editor
 #define SFIZZ__controllerChange SFIZZ_URI ":" "controller_change"
+#define SFIZZ__recheckControllers SFIZZ_URI ":" "recheck_controllers"
 
 enum
 {

--- a/lv2/sfizz_lv2.h
+++ b/lv2/sfizz_lv2.h
@@ -19,6 +19,7 @@
 // These ones are just for the worker
 #define SFIZZ__logStatus SFIZZ_URI ":" "log_status"
 #define SFIZZ__checkModification SFIZZ_URI ":" "check_modification"
+#define SFIZZ__controllerChange SFIZZ_URI ":" "controller_change"
 
 enum
 {

--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -405,6 +405,19 @@ SFIZZ_EXPORTED_API void sfizz_send_playback_state(sfizz_synth_t* synth, int dela
 SFIZZ_EXPORTED_API void sfizz_render_block(sfizz_synth_t* synth, float** channels, int num_channels, int num_frames);
 
 /**
+ * @brief Extract a controller change notification which occurred since the
+ * previous call of this function, or the startup of the synth otherwise.
+ * The notifications are not guaranteed to be received in order.
+ *
+ * @param synth           The synth.
+ * @param[out] cc_number  Number of the controller which has changed
+ *                        The special value -1 indicates all CC reset to zero.
+ * @param[out] cc_value   Value of the controller which has changed
+ * @return true if a controller change is extracted, otherwise false
+ */
+SFIZZ_EXPORTED_API bool sfizz_check_hdcc(sfizz_synth_t* synth, int* cc_number, float* cc_value);
+
+/**
  * @brief Get the size of the preloaded data.
  *
  * This returns the number of floats used in the preloading buffers.

--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -418,6 +418,14 @@ SFIZZ_EXPORTED_API void sfizz_render_block(sfizz_synth_t* synth, float** channel
 SFIZZ_EXPORTED_API bool sfizz_check_hdcc(sfizz_synth_t* synth, int* cc_number, float* cc_value);
 
 /**
+ * @brief Requests the entire controller state to be notified.
+ * The state will be received by subsequent calls to sfizz_check_hdcc().
+ *
+ * @param synth  The synth.
+ */
+SFIZZ_EXPORTED_API void sfizz_recheck_all_hdcc(sfizz_synth_t* synth);
+
+/**
  * @brief Get the size of the preloaded data.
  *
  * This returns the number of floats used in the preloading buffers.

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -367,6 +367,18 @@ public:
     void renderBlock(float** buffers, size_t numFrames, int numOutputs = 1) noexcept;
 
     /**
+     * @brief Extract a controller change notification which occurred since the
+     * previous call of this function, or the startup of the synth otherwise.
+     * The notifications are not guaranteed to be received in order.
+     *
+     * @param[out] ccNumber Number of the controller which has changed
+     *                      The special value -1 indicates all CC reset to zero.
+     * @param[out] ccValue Value of the controller which has changed
+     * @return true if a controller change is extracted, otherwise false
+     */
+    bool checkHdcc(int& ccNumber, float& ccValue) noexcept;
+
+    /**
      * @brief Return the number of active voices.
      * @since 0.2.0
      */

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -379,6 +379,12 @@ public:
     bool checkHdcc(int& ccNumber, float& ccValue) noexcept;
 
     /**
+     * @brief Requests the entire controller state to be notified.
+     * The state will be received by subsequent calls to checkHdcc().
+     */
+    void recheckAllHdcc() noexcept;
+
+    /**
      * @brief Return the number of active voices.
      * @since 0.2.0
      */

--- a/src/sfizz/MidiState.cpp
+++ b/src/sfizz/MidiState.cpp
@@ -170,6 +170,24 @@ void sfz::MidiState::resetAllControllers(int delay) noexcept
     pitchBendEvent(delay, 0.0f);
 }
 
+void sfz::MidiState::notifyAllControllers() noexcept
+{
+    auto* observer = ccObserver;
+    if (!observer)
+        return;
+
+    observer->onAllControllersReset();
+
+    for (int ccIdx = 0; ccIdx < config::numCCs; ++ccIdx) {
+        const auto& ccEvents = cc[ccIdx];
+        ASSERT(!ccEvents.empty()); // CC event vectors should never be empty
+
+        float value = ccEvents.back().value;
+        if (value != 0.0f)
+            observer->onControllerChange(ccIdx, value);
+    }
+}
+
 const sfz::EventVector& sfz::MidiState::getCCEvents(int ccIdx) const noexcept
 {
     if (ccIdx < 0 || ccIdx >= config::numCCs)
@@ -228,7 +246,7 @@ bool sfz::MidiState::ControllerChangeRecorder::getNextControllerChange(int& ccNu
     return true;
 }
 
-void sfz::MidiState::ControllerChangeRecorder::onAllControllersReset()
+void sfz::MidiState::ControllerChangeRecorder::onAllControllersReset() noexcept
 {
     Impl& impl = *impl_;
 
@@ -242,7 +260,7 @@ void sfz::MidiState::ControllerChangeRecorder::onAllControllersReset()
     impl.linkToLast = config::numCCs;
 }
 
-void sfz::MidiState::ControllerChangeRecorder::onControllerChange(int ccNumber, float ccValue)
+void sfz::MidiState::ControllerChangeRecorder::onControllerChange(int ccNumber, float ccValue) noexcept
 {
     Impl& impl = *impl_;
 

--- a/src/sfizz/MidiState.cpp
+++ b/src/sfizz/MidiState.cpp
@@ -164,6 +164,9 @@ void sfz::MidiState::resetAllControllers(int delay) noexcept
     for (int ccIdx = 0; ccIdx < config::numCCs; ++ccIdx)
         ccEvent(delay, ccIdx, 0.0f);
 
+    if (ccObserver)
+        ccObserver->onAllControllersReset();
+
     pitchBendEvent(delay, 0.0f);
 }
 

--- a/src/sfizz/MidiState.h
+++ b/src/sfizz/MidiState.h
@@ -136,6 +136,43 @@ public:
     const EventVector& getCCEvents(int ccIdx) const noexcept;
     const EventVector& getPitchEvents() const noexcept;
 
+    /**
+     * @brief Observer of controller change events
+     */
+    class ControllerChangeObserver {
+    public:
+        virtual ~ControllerChangeObserver() {}
+        virtual void onAllControllersReset() = 0;
+        virtual void onControllerChange(int ccNumber, float ccValue) = 0;
+    };
+
+    /**
+     * @brief Observer of controller change events, which records the
+     * information in a linked list of non-duplicated controller changes.
+     */
+    class ControllerChangeRecorder : public ControllerChangeObserver {
+    public:
+        ControllerChangeRecorder();
+        ~ControllerChangeRecorder();
+        bool getNextControllerChange(int& ccNumber, float& ccValue) noexcept; // O(1)
+
+    protected:
+        void onAllControllersReset() override;
+        void onControllerChange(int ccNumber, float ccValue) override;
+
+    private:
+        struct Impl;
+        std::unique_ptr<Impl> impl_;
+    };
+
+    /**
+     * @brief Set the controller change observer
+     */
+    void setControllerChangeObserver(ControllerChangeObserver* obs)
+    {
+        ccObserver = obs;
+    }
+
 private:
     int activeNotes { 0 };
 
@@ -178,5 +215,10 @@ private:
     float sampleRate { config::defaultSampleRate };
     int samplesPerBlock { config::defaultSamplesPerBlock };
     unsigned internalClock { 0 };
+
+    /**
+     * @brief Controller change observer
+     */
+    ControllerChangeObserver* ccObserver = nullptr;
 };
 }

--- a/src/sfizz/MidiState.h
+++ b/src/sfizz/MidiState.h
@@ -134,6 +134,11 @@ public:
      */
     void resetAllControllers(int delay) noexcept;
 
+    /**
+     * @brief Notify all the controllers to the observer
+     */
+    void notifyAllControllers() noexcept;
+
     const EventVector& getCCEvents(int ccIdx) const noexcept;
     const EventVector& getPitchEvents() const noexcept;
 
@@ -143,8 +148,8 @@ public:
     class ControllerChangeObserver {
     public:
         virtual ~ControllerChangeObserver() {}
-        virtual void onAllControllersReset() = 0;
-        virtual void onControllerChange(int ccNumber, float ccValue) = 0;
+        virtual void onAllControllersReset() noexcept = 0;
+        virtual void onControllerChange(int ccNumber, float ccValue) noexcept = 0;
     };
 
     /**
@@ -158,8 +163,8 @@ public:
         bool getNextControllerChange(int& ccNumber, float& ccValue) noexcept; // O(1)
 
     protected:
-        void onAllControllersReset() override;
-        void onControllerChange(int ccNumber, float ccValue) override;
+        void onAllControllersReset() noexcept override;
+        void onControllerChange(int ccNumber, float ccValue) noexcept override;
 
     private:
         struct Impl;

--- a/src/sfizz/MidiState.h
+++ b/src/sfizz/MidiState.h
@@ -5,9 +5,10 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #pragma once
-#include <array>
 #include "CCMap.h"
 #include "Range.h"
+#include <array>
+#include <memory>
 
 namespace sfz
 {

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -852,6 +852,11 @@ bool sfz::Synth::checkHdcc(int& ccNumber, float& ccValue) noexcept
     return ccRecorder->getNextControllerChange(ccNumber, ccValue);
 }
 
+void sfz::Synth::recheckAllHdcc() noexcept
+{
+    resources.midiState.notifyAllControllers();
+}
+
 void sfz::Synth::noteOn(int delay, int noteNumber, uint8_t velocity) noexcept
 {
     ASSERT(noteNumber < 128);

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -441,6 +441,12 @@ public:
     bool checkHdcc(int& ccNumber, float& ccValue) noexcept;
 
     /**
+     * @brief Requests the entire controller state to be notified.
+     * The state will be received by subsequent calls to checkHdcc().
+     */
+    void recheckAllHdcc() noexcept;
+
+    /**
      * @brief Get the number of active voices
      *
      * @return int

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -429,6 +429,18 @@ public:
     void renderBlock(AudioSpan<float> buffer) noexcept;
 
     /**
+     * @brief Extract a controller change notification which occurred since the
+     * previous call of this function, or the startup of the synth otherwise.
+     * The notifications are not guaranteed to be received in order.
+     *
+     * @param[out] ccNumber Number of the controller which has changed
+     *                      The special value -1 indicates all CC reset to zero.
+     * @param[out] ccValue Value of the controller which has changed
+     * @return true if a controller change is extracted, otherwise false
+     */
+    bool checkHdcc(int& ccNumber, float& ccValue) noexcept;
+
+    /**
      * @brief Get the number of active voices
      *
      * @return int
@@ -816,6 +828,9 @@ private:
         size_t maxLFOs { 0 };
     };
     SettingsPerVoice settingsPerVoice;
+
+    // Controller state
+    std::unique_ptr<MidiState::ControllerChangeRecorder> ccRecorder;
 
     Duration dispatchDuration { 0 };
 

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -178,6 +178,11 @@ void sfz::Sfizz::renderBlock(float** buffers, size_t numSamples, int /*numOutput
     synth->renderBlock({{buffers[0], buffers[1]}, numSamples});
 }
 
+bool sfz::Sfizz::checkHdcc(int& ccNumber, float& ccValue) noexcept
+{
+    return synth->checkHdcc(ccNumber, ccValue);
+}
+
 int sfz::Sfizz::getNumActiveVoices() const noexcept
 {
     return synth->getNumActiveVoices();

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -183,6 +183,11 @@ bool sfz::Sfizz::checkHdcc(int& ccNumber, float& ccValue) noexcept
     return synth->checkHdcc(ccNumber, ccValue);
 }
 
+void sfz::Sfizz::recheckAllHdcc() noexcept
+{
+    return synth->recheckAllHdcc();
+}
+
 int sfz::Sfizz::getNumActiveVoices() const noexcept
 {
     return synth->getNumActiveVoices();

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -185,6 +185,12 @@ void sfizz_render_block(sfizz_synth_t* synth, float** channels, int num_channels
     self->renderBlock({{channels[0], channels[1]}, static_cast<size_t>(num_frames)});
 }
 
+bool sfizz_check_hdcc(sfizz_synth_t* synth, int* cc_number, float* cc_value)
+{
+    auto self = reinterpret_cast<sfz::Synth*>(synth);
+    return self->checkHdcc(*cc_number, *cc_value);
+}
+
 unsigned int sfizz_get_preload_size(sfizz_synth_t* synth)
 {
     auto self = reinterpret_cast<sfz::Synth*>(synth);

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -191,6 +191,12 @@ bool sfizz_check_hdcc(sfizz_synth_t* synth, int* cc_number, float* cc_value)
     return self->checkHdcc(*cc_number, *cc_value);
 }
 
+void sfizz_recheck_all_hdcc(sfizz_synth_t* synth)
+{
+    auto self = reinterpret_cast<sfz::Synth*>(synth);
+    return self->recheckAllHdcc();
+}
+
 unsigned int sfizz_get_preload_size(sfizz_synth_t* synth)
 {
     auto self = reinterpret_cast<sfz::Synth*>(synth);

--- a/tests/MidiStateT.cpp
+++ b/tests/MidiStateT.cpp
@@ -130,4 +130,14 @@ TEST_CASE("[MidiState] Controller change recording")
     state.ccEvent(8, 1, 0.1f);
     state.resetAllControllers(9);
     REQUIRE(getCCList() == std::vector<Record>{{-1, 0.0f}});
+
+    // ordinary + recheck
+    state.advanceTime(10);
+    state.ccEvent(0, 1, 0.5f);
+    state.ccEvent(3, 2, 0.75f);
+    state.ccEvent(8, 3, 0.1f);
+    REQUIRE(getCCList() == std::vector<Record>{{1, 0.5f}, {2, 0.75f}, {3, 0.1f}});
+    REQUIRE(getCCList() == std::vector<Record>{});
+    state.notifyAllControllers();
+    REQUIRE(getCCList() == std::vector<Record>{{-1, 0.0f}, {1, 0.5f}, {2, 0.75f}, {3, 0.1f}});
 }

--- a/vst/SfizzVstController.cpp
+++ b/vst/SfizzVstController.cpp
@@ -293,6 +293,21 @@ tresult SfizzVstController::notify(Vst::IMessage* message)
 
         _playState = *static_cast<const SfizzPlayState*>(data);
     }
+    else if (!strcmp(id, "NotifiedController")) {
+        int64 ccNumber;
+        double ccValue;
+
+        result = attr->getInt("Number", ccNumber);
+        if (result != kResultTrue)
+            return result;
+
+        result = attr->getFloat("Value", ccValue);
+        if (result != kResultTrue)
+            return result;
+
+        for (ControllerChangeListener* listener : _ccListeners)
+            listener->onControllerChange(ccNumber, ccValue);
+    }
 
     for (StateListener* listener : _stateListeners)
         listener->onStateChanged();
@@ -310,6 +325,18 @@ void SfizzVstController::removeSfizzStateListener(StateListener* listener)
     auto it = std::find(_stateListeners.begin(), _stateListeners.end(), listener);
     if (it != _stateListeners.end())
         _stateListeners.erase(it);
+}
+
+void SfizzVstController::addSfizzControllerChangeListener(ControllerChangeListener* listener)
+{
+    _ccListeners.push_back(listener);
+}
+
+void SfizzVstController::removeSfizzControllerChangeListener(ControllerChangeListener* listener)
+{
+    auto it = std::find(_ccListeners.begin(), _ccListeners.end(), listener);
+    if (it != _ccListeners.end())
+        _ccListeners.erase(it);
 }
 
 FUnknown* SfizzVstController::createInstance(void*)

--- a/vst/SfizzVstController.h
+++ b/vst/SfizzVstController.h
@@ -49,6 +49,9 @@ public:
     struct StateListener {
         virtual void onStateChanged() = 0;
     };
+    struct ControllerChangeListener {
+        virtual void onControllerChange(int ccNumber, float ccValue) = 0;
+    };
 
     const SfizzVstState& getSfizzState() const { return _state; }
     SfizzVstState& getSfizzState() { return _state; }
@@ -62,6 +65,9 @@ public:
     void addSfizzStateListener(StateListener* listener);
     void removeSfizzStateListener(StateListener* listener);
 
+    void addSfizzControllerChangeListener(ControllerChangeListener* listener);
+    void removeSfizzControllerChangeListener(ControllerChangeListener* listener);
+
     ///
     static FUnknown* createInstance(void*);
 
@@ -72,4 +78,5 @@ private:
     SfizzUiState _uiState;
     SfizzPlayState _playState {};
     std::vector<StateListener*> _stateListeners;
+    std::vector<ControllerChangeListener*> _ccListeners;
 };

--- a/vst/SfizzVstEditor.cpp
+++ b/vst/SfizzVstEditor.cpp
@@ -20,11 +20,13 @@ SfizzVstEditor::SfizzVstEditor(void *controller)
     : VSTGUIEditor(controller, &sfizzUiViewRect)
 {
     getController()->addSfizzStateListener(this);
+    getController()->addSfizzControllerChangeListener(this);
 }
 
 SfizzVstEditor::~SfizzVstEditor()
 {
     getController()->removeSfizzStateListener(this);
+    getController()->removeSfizzControllerChangeListener(this);
 }
 
 bool PLUGIN_API SfizzVstEditor::open(void* parent, const VSTGUI::PlatformType& platformType)
@@ -103,6 +105,12 @@ CMessageResult SfizzVstEditor::notify(CBaseObject* sender, const char* message)
 void SfizzVstEditor::onStateChanged()
 {
     updateStateDisplay();
+}
+
+void SfizzVstEditor::onControllerChange(int ccNumber, float ccValue)
+{
+    std::vector<float> editValue { static_cast<float>(ccNumber), ccValue };
+    uiReceiveValue(EditId::ControllerChange, std::move(editValue));
 }
 
 ///

--- a/vst/SfizzVstEditor.cpp
+++ b/vst/SfizzVstEditor.cpp
@@ -61,6 +61,8 @@ bool PLUGIN_API SfizzVstEditor::open(void* parent, const VSTGUI::PlatformType& p
 
     editor->open(*frame);
 
+    requestControllerState();
+
     return true;
 }
 
@@ -220,6 +222,20 @@ void SfizzVstEditor::loadScalaFile(const std::string& filePath)
     msg->setMessageID("LoadScala");
     Vst::IAttributeList* attr = msg->getAttributes();
     attr->setBinary("File", filePath.data(), filePath.size());
+    ctl->sendMessage(msg);
+}
+
+void SfizzVstEditor::requestControllerState()
+{
+    SfizzVstController* ctl = getController();
+
+    Steinberg::OPtr<Vst::IMessage> msg { ctl->allocateMessage() };
+    if (!msg) {
+        fprintf(stderr, "[Sfizz] UI could not allocate message\n");
+        return;
+    }
+
+    msg->setMessageID("RequestControllerState");
     ctl->sendMessage(msg);
 }
 

--- a/vst/SfizzVstEditor.h
+++ b/vst/SfizzVstEditor.h
@@ -51,6 +51,7 @@ protected:
 private:
     void loadSfzFile(const std::string& filePath);
     void loadScalaFile(const std::string& filePath);
+    void requestControllerState();
 
     void updateStateDisplay();
 

--- a/vst/SfizzVstEditor.h
+++ b/vst/SfizzVstEditor.h
@@ -16,7 +16,10 @@ namespace VSTGUI { class RunLoop; }
 using namespace Steinberg;
 using namespace VSTGUI;
 
-class SfizzVstEditor : public Vst::VSTGUIEditor, public SfizzVstController::StateListener, public EditorController {
+class SfizzVstEditor : public Vst::VSTGUIEditor,
+                       public SfizzVstController::StateListener,
+                       public SfizzVstController::ControllerChangeListener,
+                       public EditorController {
 public:
     explicit SfizzVstEditor(void *controller);
     ~SfizzVstEditor();
@@ -34,6 +37,9 @@ public:
 
     // SfizzVstController::StateListener
     void onStateChanged() override;
+
+    // SfizzVstController::ControllerChangeListener
+    void onControllerChange(int ccNumber, float ccValue) override;
 
 protected:
     // EditorController

--- a/vst/SfizzVstProcessor.cpp
+++ b/vst/SfizzVstProcessor.cpp
@@ -222,6 +222,9 @@ tresult PLUGIN_API SfizzVstProcessor::process(Vst::ProcessData& data)
             _semaToWorker.post();
     }
 
+    if (_requestedControllerState.exchange(false))
+        synth.recheckAllHdcc();
+
     if (!_haveCCNotification)
         _haveCCNotification = synth.checkHdcc(_ccnNumber, _ccnValue);
 
@@ -445,6 +448,9 @@ tresult PLUGIN_API SfizzVstProcessor::notify(Vst::IMessage* message)
         reply->setMessageID("LoadedScala");
         reply->getAttributes()->setBinary("File", _state.scalaFile.data(), _state.scalaFile.size());
         sendMessage(reply);
+    }
+    else if (!std::strcmp(id, "RequestControllerState")) {
+        _requestedControllerState.store(true);
     }
 
     return result;

--- a/vst/SfizzVstProcessor.h
+++ b/vst/SfizzVstProcessor.h
@@ -73,6 +73,11 @@ private:
     int _timeSigDenominator = 0;
     void updateTimeInfo(const Vst::ProcessContext& context);
 
+    // controller state
+    bool _haveCCNotification = false;
+    int _ccnNumber = 0;
+    float _ccnValue = 0.0f;
+
     // messaging
     struct RTMessage {
         const char* type;

--- a/vst/SfizzVstProcessor.h
+++ b/vst/SfizzVstProcessor.h
@@ -77,6 +77,7 @@ private:
     bool _haveCCNotification = false;
     int _ccnNumber = 0;
     float _ccnValue = 0.0f;
+    std::atomic_bool _requestedControllerState { false };
 
     // messaging
     struct RTMessage {


### PR DESCRIPTION
This is the whole mechanism and API to receive controller change.
The value -1 for ccNumber indicates a reset of all controllers.
I will add some tests.