### PR TITLE
Modulation matrix tweaks

### DIFF
--- a/src/sfizz/modulations/ModKey.cpp
+++ b/src/sfizz/modulations/ModKey.cpp
@@ -7,7 +7,6 @@
 #include "ModKey.h"
 #include "../Debug.h"
 #include <absl/strings/str_cat.h>
-#include <cstring>
 
 namespace sfz {
 
@@ -29,16 +28,6 @@ ModKey::Parameters& ModKey::Parameters::operator=(const Parameters& other) noexc
     if (this != &other)
         std::memcpy(this, &other, sizeof(*this));
     return *this;
-}
-
-bool ModKey::Parameters::operator==(const Parameters& other) const noexcept
-{
-    return std::memcmp(this, &other, sizeof(*this)) == 0;
-}
-
-bool ModKey::Parameters::operator!=(const Parameters& other) const noexcept
-{
-    return std::memcmp(this, &other, sizeof(*this)) != 0;
 }
 
 ModKey ModKey::createCC(uint16_t cc, uint8_t curve, uint8_t smooth, float value, float step)
@@ -106,13 +95,3 @@ std::string ModKey::toString() const
 
 } // namespace sfz
 
-bool sfz::ModKey::operator==(const ModKey &other) const noexcept
-{
-    return id_ == other.id_ && region_ == other.region_ &&
-        parameters() == other.parameters();
-}
-
-bool sfz::ModKey::operator!=(const ModKey &other) const noexcept
-{
-    return !this->operator==(other);
-}

--- a/src/sfizz/modulations/ModKey.cpp
+++ b/src/sfizz/modulations/ModKey.cpp
@@ -5,7 +5,6 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "ModKey.h"
-#include "ModId.h"
 #include "../Debug.h"
 #include <absl/strings/str_cat.h>
 #include <cstring>
@@ -74,10 +73,6 @@ bool ModKey::isTarget() const noexcept
     return ModIds::isTarget(id_);
 }
 
-int ModKey::flags() const noexcept
-{
-    return ModIds::flags(id_);
-}
 
 std::string ModKey::toString() const
 {

--- a/src/sfizz/modulations/ModKey.h
+++ b/src/sfizz/modulations/ModKey.h
@@ -6,6 +6,7 @@
 
 #pragma once
 #include "ModKeyHash.h"
+#include "ModId.h"
 #include "../NumericId.h"
 #include <string>
 
@@ -24,7 +25,7 @@ public:
 
     ModKey() = default;
     explicit ModKey(ModId id, NumericId<Region> region = {}, Parameters params = {})
-        : id_(id), region_(region), params_(params) {}
+        : id_(id), region_(region), params_(params), flags_(ModIds::flags(id_)) {}
 
     static ModKey createCC(uint16_t cc, uint8_t curve, uint8_t smooth, float value, float step);
     static ModKey createNXYZ(ModId id, NumericId<Region> region, uint8_t N = 0, uint8_t X = 0, uint8_t Y = 0, uint8_t Z = 0);
@@ -34,10 +35,10 @@ public:
     const ModId& id() const noexcept { return id_; }
     NumericId<Region> region() const noexcept { return region_; }
     const Parameters& parameters() const noexcept { return params_; }
+    int flags() const noexcept { return flags_; }
 
     bool isSource() const noexcept;
     bool isTarget() const noexcept;
-    int flags() const noexcept;
     std::string toString() const;
 
     struct Parameters {
@@ -73,6 +74,8 @@ private:
     NumericId<Region> region_;
     //! List of values which identify the key uniquely, along with the hash and region
     Parameters params_ {};
+    // Memorize the flag
+    int flags_;
 };
 
 } // namespace sfz

--- a/src/sfizz/modulations/ModKey.h
+++ b/src/sfizz/modulations/ModKey.h
@@ -9,6 +9,7 @@
 #include "ModId.h"
 #include "../NumericId.h"
 #include <string>
+#include <cstring>
 
 namespace sfz {
 
@@ -49,8 +50,15 @@ public:
         Parameters(Parameters&&) = delete;
         Parameters &operator=(Parameters&&) = delete;
 
-        bool operator==(const Parameters& other) const noexcept;
-        bool operator!=(const Parameters& other) const noexcept;
+        bool operator==(const Parameters& other) const noexcept
+        {
+            return std::memcmp(this, &other, sizeof(*this)) == 0;
+        }
+
+        bool operator!=(const Parameters& other) const noexcept
+        {
+            return std::memcmp(this, &other, sizeof(*this)) != 0;
+        }
 
         union {
             //! Parameters if this key identifies a CC source
@@ -64,8 +72,17 @@ public:
     };
 
 public:
-    bool operator==(const ModKey &other) const noexcept;
-    bool operator!=(const ModKey &other) const noexcept;
+    bool operator==(const ModKey &other) const noexcept
+    {
+        return id_ == other.id_ && region_ == other.region_ &&
+            parameters() == other.parameters();
+    }
+
+    bool operator!=(const ModKey &other) const noexcept
+    {
+        return !this->operator==(other);
+    }
+
 
 private:
     //! Identifier

--- a/src/sfizz/modulations/ModMatrix.cpp
+++ b/src/sfizz/modulations/ModMatrix.cpp
@@ -364,8 +364,7 @@ float* ModMatrix::getModulation(TargetId targetId)
                 }
                 else {
                     ASSERT(targetFlags & kModIsAdditive);
-                    for (uint32_t i = 0; i < numFrames; ++i)
-                        buffer[i] += sourceDepth * sourceBuffer[i];
+                    sfz::multiplyAdd1<float>(sourceDepth, sourceBuffer, buffer);
                 }
             }
         }


### PR DESCRIPTION
Hiya,

I'm checking out the overall performance and regressions that possibly happened in the past months. I've identified some areas where we could improve, and I've started to chop it into smaller commits (e.g. #405 and #353 to disable completely the envelope follower). This is in the same vein.

The `flags()` function and the `operator==` are super hot code paths, being called literally billions of times over a couple minutes of rendering according to valgrind when there are many modulations/ccs/lfos in the file. I've tried here to:
- Memorize the flags on `ModKey` construction, so we avoid the big switch statement.
- Allow inlining of the operator by putting it in the header. I would have thought that LTO would catch such things but apparently not...

I did not test on other platforms yet but on my machine here it reduces the average callback duration by 25% on DSmolken's Big Rusty Drums. The binary size does not increase significantly.

https://box.ferrand.cc/sfizz-reports/2020-09-08-mm-tweaks.html