### PR TITLE
Regions on the same note but with different groups do get muted

### DIFF
--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -713,9 +713,9 @@ bool sfz::Voice::checkOffGroup(const Region* other, int delay, int noteNumber) n
     if (region == nullptr || other == nullptr)
         return false;
 
-    if (triggerEvent.type == TriggerEventType::NoteOn 
+    if (triggerEvent.type == TriggerEventType::NoteOn
         && region->offBy == other->group
-        && noteNumber != triggerEvent.number) {
+        && (region->group != other->group || noteNumber != triggerEvent.number)) {
         off(delay);
         return true;
     }

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -1286,3 +1286,27 @@ TEST_CASE("[Synth] Off by same note and group")
     REQUIRE( numPlayingVoices(synth) == 2 );
     synth.noteOn(0, 60, 85);
 }
+
+
+TEST_CASE("[Synth] Off by with CC switches")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, 256 };
+
+    synth.loadSfzString(fs::current_path(), R"(
+        <group> ampeg_decay=5 ampeg_sustain=0 ampeg_release=5 key=60
+        <region> sample=*saw transpose=12   group=1   off_by=2 hicc4=63
+        <region> sample=*triangle           group=2   off_by=1 locc4=64
+    )");
+    synth.noteOn(0, 60, 85);
+    REQUIRE( numPlayingVoices(synth) == 1 );
+    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId.filename() == "*saw" );
+    synth.cc(0, 4, 127);
+    synth.noteOn(0, 60, 85);
+    REQUIRE( numPlayingVoices(synth) == 1 );
+    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId.filename() == "*triangle" );
+    synth.cc(0, 4, 0);
+    synth.noteOn(0, 60, 85);
+    REQUIRE( numPlayingVoices(synth) == 1 );
+    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId.filename() == "*saw" );
+}


### PR DESCRIPTION
This happens e.g. with keyswitches. This behavior is slightly different from Cakewalk's apparently, I'll let @kinwie detail :)