### PR TITLE
MM tweaks still

### DIFF
--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -406,6 +406,12 @@ private:
      */
     void switchState(State s);
 
+    /**
+     * @brief Save the modulation targets to avoid recomputing them in every callback.
+     * Must be called during startVoice() ideally.
+     */
+    void saveModulationTargets(const Region* region) noexcept;
+
     const NumericId<Voice> id;
     StateListener* stateListener = nullptr;
 
@@ -465,6 +471,13 @@ private:
     Smoother bendSmoother;
     Smoother xfadeSmoother;
     void resetSmoothers() noexcept;
+
+    ModMatrix::TargetId amplitudeTarget;
+    ModMatrix::TargetId volumeTarget;
+    ModMatrix::TargetId panTarget;
+    ModMatrix::TargetId positionTarget;
+    ModMatrix::TargetId widthTarget;
+    ModMatrix::TargetId pitchTarget;
 
     PowerFollower powerFollower;
 

--- a/src/sfizz/modulations/ModMatrix.cpp
+++ b/src/sfizz/modulations/ModMatrix.cpp
@@ -49,7 +49,7 @@ struct ModMatrix::Impl {
     absl::flat_hash_map<ModKey, uint32_t> sourceIndex_;
     absl::flat_hash_map<ModKey, uint32_t> targetIndex_;
 
-    int maxRegionIdx { -1 };
+    int maxRegionIdx_ { -1 };
     std::vector<std::vector<uint32_t>> sourceRegionIndex_;
     std::vector<std::vector<uint32_t>> targetRegionIndex_;
 
@@ -78,7 +78,7 @@ void ModMatrix::clear()
     impl.targets_.clear();
     impl.sourceRegionIndex_.clear();
     impl.targetRegionIndex_.clear();
-    impl.maxRegionIdx = -1;
+    impl.maxRegionIdx_ = -1;
 }
 
 void ModMatrix::setSampleRate(double sampleRate)
@@ -131,8 +131,8 @@ ModMatrix::SourceId ModMatrix::registerSource(const ModKey& key, ModGenerator& g
     source.buffer.resize(impl.samplesPerBlock_);
 
     impl.sourceIndex_[key] = id.number();
-    if (key.region().number() > impl.maxRegionIdx)
-        impl.maxRegionIdx = key.region().number();
+    if (key.region().number() > impl.maxRegionIdx_)
+        impl.maxRegionIdx_ = key.region().number();
 
     gen.setSampleRate(impl.sampleRate_);
     gen.setSamplesPerBlock(impl.samplesPerBlock_);
@@ -157,8 +157,8 @@ ModMatrix::TargetId ModMatrix::registerTarget(const ModKey& key)
     target.buffer.resize(impl.samplesPerBlock_);
 
     impl.targetIndex_[key] = id.number();
-    if (key.region().number() > impl.maxRegionIdx)
-        impl.maxRegionIdx = key.region().number();
+    if (key.region().number() > impl.maxRegionIdx_)
+        impl.maxRegionIdx_ = key.region().number();
 
     return id;
 }
@@ -205,8 +205,8 @@ void ModMatrix::init()
 {
     Impl& impl = *impl_;
 
-    if (impl.maxRegionIdx >= 0) {
-        const size_t numRegions = impl.maxRegionIdx + 1;
+    if (impl.maxRegionIdx_ >= 0) {
+        const size_t numRegions = impl.maxRegionIdx_ + 1;
         impl.sourceRegionIndex_.resize(numRegions);
         impl.targetRegionIndex_.resize(numRegions);
     }

--- a/src/sfizz/modulations/ModMatrix.cpp
+++ b/src/sfizz/modulations/ModMatrix.cpp
@@ -243,8 +243,7 @@ void ModMatrix::initVoice(NumericId<Voice> voiceId, NumericId<Region> regionId, 
     const auto idNumber = static_cast<size_t>(regionId.number());
     for (auto idx: impl.sourceIndicesForRegion_[idNumber]) {
         const auto& source = impl.sources_[idx];
-        if (source.key.flags() & kModIsPerVoice)
-            source.gen->init(source.key, voiceId, delay);
+        source.gen->init(source.key, voiceId, delay);
     }
 }
 
@@ -257,8 +256,7 @@ void ModMatrix::releaseVoice(NumericId<Voice> voiceId, NumericId<Region> regionI
     const auto idNumber = static_cast<size_t>(regionId.number());
     for (auto idx: impl.sourceIndicesForRegion_[idNumber]) {
         const auto& source = impl.sources_[idx];
-        if (source.key.flags() & kModIsPerVoice)
-            source.gen->release(source.key, voiceId, delay);
+        source.gen->release(source.key, voiceId, delay);
     }
 }
 
@@ -303,14 +301,12 @@ void ModMatrix::beginVoice(NumericId<Voice> voiceId, NumericId<Region> regionId)
     const auto idNumber = static_cast<size_t>(regionId.number());
     for (auto idx: impl.sourceIndicesForRegion_[idNumber]) {
         auto& source = impl.sources_[idx];
-        if (source.key.flags() & kModIsPerVoice)
-            source.bufferReady = false;
+        source.bufferReady = false;
     }
 
     for (auto idx: impl.targetIndicesForRegion_[idNumber]) {
         auto& target = impl.targets_[idx];
-        if (target.key.flags() & kModIsPerVoice)
-            target.bufferReady = false;
+        target.bufferReady = false;
     }
 }
 
@@ -329,10 +325,8 @@ void ModMatrix::endVoice()
     for (auto idx: impl.sourceIndicesForRegion_[idNumber]) {
         const auto& source = impl.sources_[idx];
         if (!source.bufferReady) {
-            if (source.key.flags() & kModIsPerVoice) {
-                absl::Span<float> buffer(source.buffer.data(), numFrames);
-                source.gen->generateDiscarded(source.key, voiceId, buffer);
-            }
+            absl::Span<float> buffer(source.buffer.data(), numFrames);
+            source.gen->generateDiscarded(source.key, voiceId, buffer);
         }
     }
 

--- a/src/sfizz/modulations/ModMatrix.cpp
+++ b/src/sfizz/modulations/ModMatrix.cpp
@@ -216,14 +216,14 @@ void ModMatrix::init()
         if (source.key.flags() & kModIsPerCycle)
             source.gen->init(source.key, {}, 0);
 
-        if (source.key.region().number() >= 0) {
+        if (source.key.region()) {
             impl.sourceRegionIndex_[source.key.region().number()].push_back(i);
         }
     }
 
     for (unsigned i = 0; i < impl.targets_.size(); ++i) {
         Impl::Target& target = impl.targets_[i];
-        if (target.key.region().number() >= 0)
+        if (target.key.region())
             impl.targetRegionIndex_[target.key.region().number()].push_back(i);
     }
 }
@@ -231,7 +231,7 @@ void ModMatrix::init()
 void ModMatrix::initVoice(NumericId<Voice> voiceId, NumericId<Region> regionId, unsigned delay)
 {
     Impl& impl = *impl_;
-    ASSERT(regionId.number() >= 0);
+    ASSERT(regionId);
     ASSERT(static_cast<size_t>(regionId.number()) < impl.sourceRegionIndex_.size());
 
     const auto idNumber = static_cast<size_t>(regionId.number());
@@ -246,7 +246,7 @@ void ModMatrix::releaseVoice(NumericId<Voice> voiceId, NumericId<Region> regionI
 {
     Impl& impl = *impl_;
 
-    ASSERT(regionId.number() >= 0);
+    ASSERT(regionId);
 
     const auto idNumber = static_cast<size_t>(regionId.number());
     for (auto idx: impl.sourceRegionIndex_[idNumber]) {
@@ -292,7 +292,7 @@ void ModMatrix::beginVoice(NumericId<Voice> voiceId, NumericId<Region> regionId)
     impl.currentVoiceId_ = voiceId;
     impl.currentRegionId_ = regionId;
 
-    ASSERT(regionId.number() >= 0);
+    ASSERT(regionId);
 
     const auto idNumber = static_cast<size_t>(regionId.number());
     for (auto idx: impl.sourceRegionIndex_[idNumber]) {
@@ -315,7 +315,7 @@ void ModMatrix::endVoice()
     const NumericId<Voice> voiceId = impl.currentVoiceId_;
     const NumericId<Region> regionId = impl.currentRegionId_;
 
-    ASSERT(regionId.number() >= 0);
+    ASSERT(regionId);
     ASSERT(static_cast<size_t>(regionId.number()) < impl.sourceRegionIndex_.size());
 
     const auto idNumber = static_cast<size_t>(regionId.number());

--- a/src/sfizz/modulations/ModMatrix.cpp
+++ b/src/sfizz/modulations/ModMatrix.cpp
@@ -213,18 +213,24 @@ void ModMatrix::init()
 
     for (unsigned i = 0; i < impl.sources_.size(); ++i) {
         Impl::Source& source = impl.sources_[i];
-        if (source.key.flags() & kModIsPerCycle)
+        const int flags = source.key.flags();
+        if (flags & kModIsPerCycle) {
+            ASSERT(!source.key.region());
             source.gen->init(source.key, {}, 0);
-
-        if (source.key.region()) {
+        }
+        else if (flags & kModIsPerVoice) {
+            ASSERT(source.key.region());
             impl.sourceIndicesForRegion_[source.key.region().number()].push_back(i);
         }
     }
 
     for (unsigned i = 0; i < impl.targets_.size(); ++i) {
         Impl::Target& target = impl.targets_[i];
-        if (target.key.region())
+        const int flags = target.key.flags();
+        if (flags & kModIsPerVoice) {
+            ASSERT(target.key.region());
             impl.targetIndicesForRegion_[target.key.region().number()].push_back(i);
+        }
     }
 }
 


### PR DESCRIPTION
One of the consuming operation is looping through the sources for nothing since we're basically never hitting the right sources (or targets) for a given voice id. This patch adds a container that maps a `NumericId<Region>` to a set of source indices. This way we have one lookup through the container, and an iteration to go through all the relevant sources.

http://box.ferrand.cc/sfizz-reports/2020-09-09-mm-tweaks-still.html

Notice that this completely remove the "residual" part almost, which was where all these failed lookups were going to. What's left now is the lookup per-voice for each modulation target on rendering each block, but I think this could be memorized within the voice.