### PR TITLE
Remove the no-omit-frame-pointer option

### DIFF
--- a/cmake/SfizzConfig.cmake
+++ b/cmake/SfizzConfig.cmake
@@ -57,7 +57,6 @@ endif()
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     add_compile_options(-Wall)
     add_compile_options(-Wextra)
-    add_compile_options(-fno-omit-frame-pointer) # For debugging purposes
     add_compile_options(-Werror=return-type)
     if (SFIZZ_SYSTEM_PROCESSOR MATCHES "^(i.86|x86_64)$")
         add_compile_options(-msse2)


### PR DESCRIPTION
It's inconsequent in x64, but armv7 has less registers to spare. With sfizz-render we can rely on callgrind to track expensive stuff so the frame pointer is less needed overall.