### PR TITLE
Store the initial values of controllers

### DIFF
--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -370,6 +370,27 @@ public:
      */
     void hdcc(int delay, int ccNumber, float normValue) noexcept;
     /**
+     * @brief Set the initial value of a controller and send it to the synth
+     *
+     * @param ccNumber the cc number
+     * @param ccValue the cc value
+     */
+    void initCc(int ccNumber, uint8_t ccValue) noexcept;
+    /**
+     * @brief Set the initial value of a controller and send it to the synth
+     *
+     * @param ccNumber the cc number
+     * @param normValue the normalized cc value, in domain 0 to 1
+     */
+    void initHdcc(int ccNumber, float normValue) noexcept;
+    /**
+     * @brief Get the initial value of a controller under the current instrument
+     *
+     * @param ccNumber the cc number
+     * @return the initial value
+     */
+    float getHdccInit(int ccNumber);
+   /**
      * @brief Send a pitch bend event to the synth
      *
      * @param delay the delay at which the event occurs; this should be lower
@@ -908,6 +929,9 @@ private:
         size_t maxFlexEGs { 0 };
     };
     SettingsPerVoice settingsPerVoice;
+
+    // Controller initial values
+    std::array<float, config::numCCs> ccInitialValues;
 
     Duration dispatchDuration { 0 };
 

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -369,6 +369,7 @@ public:
      * @param normValue the normalized cc value, in domain 0 to 1
      */
     void hdcc(int delay, int ccNumber, float normValue) noexcept;
+private:
     /**
      * @brief Set the initial value of a controller and send it to the synth
      *
@@ -383,6 +384,7 @@ public:
      * @param normValue the normalized cc value, in domain 0 to 1
      */
     void initHdcc(int ccNumber, float normValue) noexcept;
+public:
     /**
      * @brief Get the initial value of a controller under the current instrument
      *

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -1348,3 +1348,24 @@ TEST_CASE("[Synth] Off by with CC switches")
     REQUIRE( numPlayingVoices(synth) == 1 );
     REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId.filename() == "*saw" );
 }
+
+TEST_CASE("[Synth] Initial values of CC")
+{
+    sfz::Synth synth;
+
+    synth.loadSfzString(fs::current_path() / "init_cc.sfz", R"(
+        <region> sample=*sine
+    )");
+
+    REQUIRE(synth.getHdccInit(111) == 0.0f);
+    REQUIRE(synth.getHdccInit(7) == Approx(100.0f / 127)); // default volume
+    REQUIRE(synth.getHdccInit(10) == 0.5f); // default pan
+
+    synth.loadSfzString(fs::current_path() / "init_cc.sfz", R"(
+        <control> set_hdcc111=0.1234 set_cc112=77
+        <region> sample=*sine
+    )");
+
+    REQUIRE(synth.getHdccInit(111) == Approx(0.1234f));
+    REQUIRE(synth.getHdccInit(112) == Approx(77.0f / 127));
+}


### PR DESCRIPTION
Keep the initial values of controllers for the active instrument.
Having this data will permit to make the UI aware about default values for the CC sliders.
