### PR TITLE
Adjust the level of *noise to match ARIA

### DIFF
--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -81,7 +81,7 @@ namespace config {
     constexpr int filtersPerVoice { 2 };
     constexpr int eqsPerVoice { 3 };
     constexpr int oscillatorsPerVoice { 9 };
-    constexpr float uniformNoiseBounds { 0.25f };
+    constexpr float uniformNoiseBounds { 1.0f };
     constexpr float noiseVariance { 0.25f };
     /**
        Minimum interval in frames between recomputations of coefficients of the


### PR DESCRIPTION
It's the generator we probably forgot scaling after matching the volumes.
Conveniently, this one appears to be unit scaled.