### PR TITLE
Add egN_ampeg

### DIFF
--- a/src/sfizz/FlexEGDescription.h
+++ b/src/sfizz/FlexEGDescription.h
@@ -34,6 +34,8 @@ struct FlexEGDescription {
     int dynamic { Default::flexEGDynamic }; // whether parameters can be modulated while EG runs
     int sustain { Default::flexEGSustain }; // index of the sustain point (default to 0 in ARIA)
     std::vector<FlexEGPoint> points;
+    // ARIA
+    bool ampeg = false; // replaces the SFZv1 AmpEG (lowest with this bit wins)
 };
 
 } // namespace sfz

--- a/src/sfizz/FlexEnvelope.cpp
+++ b/src/sfizz/FlexEnvelope.cpp
@@ -104,6 +104,25 @@ void FlexEnvelope::release(unsigned releaseDelay)
     impl.currentFramesUntilRelease_ = releaseDelay;
 }
 
+unsigned FlexEnvelope::getRemainingDelay() const noexcept
+{
+    const Impl& impl = *impl_;
+    return static_cast<unsigned>(impl.delayFramesLeft_);
+}
+
+bool FlexEnvelope::isReleased() const noexcept
+{
+    const Impl& impl = *impl_;
+    return impl.isReleased_;
+}
+
+bool FlexEnvelope::isFinished() const noexcept
+{
+    const Impl& impl = *impl_;
+    const FlexEGDescription& desc = *impl.desc_;
+    return impl.currentStageNumber_ >= desc.points.size();
+}
+
 void FlexEnvelope::process(absl::Span<float> out)
 {
     Impl& impl = *impl_;

--- a/src/sfizz/FlexEnvelope.cpp
+++ b/src/sfizz/FlexEnvelope.cpp
@@ -160,12 +160,24 @@ void FlexEnvelope::Impl::process(absl::Span<float> out)
         }
 
         // Perform stage transitions
-        const bool isReleased = isReleased_;
-        while ((!stageSustained_ && currentTime_ >= stageTime_) ||
-               (stageSustained_ && isReleased)) {
-            // If stage is of zero duration, immediate transition to level
-            if (!stageSustained_ && stageTime_ == 0)
+        if (isReleased_) {
+            // on release, fast forward past the sustain stage
+            const unsigned sustainStage = desc.sustain;
+            while (currentStageNumber_ <= sustainStage) {
+                if (!advanceToNextStage()) {
+                    out.remove_prefix(frameIndex);
+                    fill(out, 0.0f);
+                    return;
+                }
+            }
+        }
+        while (!stageSustained_ && currentTime_ >= stageTime_) {
+            // advance through completed timed stages
+            ASSERT(isReleased_ || !stageSustained_);
+            if (stageTime_ == 0) {
+                // if stage is of zero duration, immediate transition to level
                 currentLevel_ = stageTargetLevel_;
+            }
             if (!advanceToNextStage()) {
                 out.remove_prefix(frameIndex);
                 fill(out, 0.0f);

--- a/src/sfizz/FlexEnvelope.h
+++ b/src/sfizz/FlexEnvelope.h
@@ -41,6 +41,21 @@ public:
     void release(unsigned releaseDelay);
 
     /**
+       Get the remaining delay samples
+     */
+    unsigned getRemainingDelay() const noexcept;
+
+    /**
+       Is the envelope released?
+    */
+    bool isReleased() const noexcept;
+
+    /**
+       Is the envelope finished?
+    */
+    bool isFinished() const noexcept;
+
+    /**
        Process a cycle of the generator.
      */
     void process(absl::Span<float> out);

--- a/src/sfizz/Opcode.cpp
+++ b/src/sfizz/Opcode.cpp
@@ -210,16 +210,18 @@ absl::optional<ValueType> readOpcode(absl::string_view value, const Range<ValueT
 
 absl::optional<bool> readBooleanFromOpcode(const Opcode& opcode)
 {
-    switch (hash(opcode.value)) {
-    case hash("off"): // fallthrough
-    case hash("0"):
+    // Cakewalk-style booleans, case-insensitive
+    if (absl::EqualsIgnoreCase(opcode.value, "off"))
         return false;
-    case hash("on"):  // fallthrough
-    case hash("1"):
+    if (absl::EqualsIgnoreCase(opcode.value, "on"))
         return true;
-    default:
-        return {};
-    }
+
+    // ARIA-style booleans? (seen in egN_dynamic=1 for example)
+    // TODO check this
+    if (auto value = readOpcode(opcode.value, Range<int64_t>::wholeRange()))
+        return *value != 0;
+
+    return absl::nullopt;
 }
 
 template <class ValueType>

--- a/src/sfizz/Opcode.cpp
+++ b/src/sfizz/Opcode.cpp
@@ -211,9 +211,11 @@ absl::optional<ValueType> readOpcode(absl::string_view value, const Range<ValueT
 absl::optional<bool> readBooleanFromOpcode(const Opcode& opcode)
 {
     switch (hash(opcode.value)) {
-    case hash("off"):
+    case hash("off"): // fallthrough
+    case hash("0"):
         return false;
-    case hash("on"):
+    case hash("on"):  // fallthrough
+    case hash("1"):
         return true;
     default:
         return {};

--- a/src/sfizz/Range.h
+++ b/src/sfizz/Range.h
@@ -8,6 +8,7 @@
 #include "MathHelpers.h"
 #include <initializer_list>
 #include <type_traits>
+#include <limits>
 
 namespace sfz
 {
@@ -113,6 +114,17 @@ public:
         return Range<Other> {
             static_cast<Other>(_start),
             static_cast<Other>(_end),
+        };
+    }
+
+    /**
+     * @brief Construct a range which covers the whole numeric domain
+     */
+    static constexpr Range<Type> wholeRange() noexcept
+    {
+        return Range<Type> {
+            std::numeric_limits<Type>::min(),
+            std::numeric_limits<Type>::max(),
         };
     }
 

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -1169,11 +1169,10 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
             return false;
         if (!extendIfNecessary(flexEGs, egNumber, Default::numFlexEGs))
             return false;
-        if (auto value = readOpcode(opcode.value, Range<int> { 0, 1 })) {
+        if (auto ampeg = readBooleanFromOpcode(opcode)) {
             FlexEGDescription& desc = flexEGs[egNumber - 1];
-            bool ampeg = *value != 0;
-            if (desc.ampeg != ampeg) {
-                desc.ampeg = ampeg;
+            if (desc.ampeg != *ampeg) {
+                desc.ampeg = *ampeg;
                 flexAmpEG = absl::nullopt;
                 for (size_t i = 0, n = flexEGs.size(); i < n && !flexAmpEG; ++i) {
                     if (flexEGs[i].ampeg)

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -425,6 +425,7 @@ struct Region {
 
     // Envelopes
     std::vector<FlexEGDescription> flexEGs;
+    absl::optional<uint8_t> flexAmpEG; // egN_ampeg
 
     // LFOs
     std::vector<LFODescription> lfos;
@@ -445,6 +446,7 @@ struct Region {
         float velToDepth = 0.0f;
     };
     std::vector<Connection> connections;
+    Connection* getConnection(const ModKey& source, const ModKey& target);
     Connection& getOrCreateConnection(const ModKey& source, const ModKey& target);
 
     // Parent

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -159,6 +159,11 @@ void sfz::Synth::buildRegion(const std::vector<Opcode>& regionOpcodes)
         ModKey::createCC(10, 1, defaultSmoothness, 100, 0),
         ModKey::createNXYZ(ModId::Pan, lastRegion->id)).sourceDepth = 1.0f;
 
+    // Create the amplitude envelope
+    lastRegion->getOrCreateConnection(
+        ModKey::createNXYZ(ModId::AmpEG, lastRegion->id),
+        ModKey::createNXYZ(ModId::Amplitude, lastRegion->id)).sourceDepth = 100.0f;
+
     //
     auto parseOpcodes = [&](const std::vector<Opcode>& opcodes) {
         for (auto& opcode : opcodes) {
@@ -1530,6 +1535,7 @@ void sfz::Synth::setupModMatrix()
             case ModId::Envelope:
                 gen = genFlexEnvelope.get();
                 break;
+            case ModId::AmpEG:
             case ModId::PitchEG:
             case ModId::FilEG:
                 gen = genADSREnvelope.get();

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -178,17 +178,14 @@ void sfz::Synth::buildRegion(const std::vector<Opcode>& regionOpcodes)
     parseOpcodes(regionOpcodes);
 
     // Create the amplitude envelope
-    if (!lastRegion->flexAmpEG) {
+    if (!lastRegion->flexAmpEG)
         lastRegion->getOrCreateConnection(
             ModKey::createNXYZ(ModId::AmpEG, lastRegion->id),
-            ModKey::createNXYZ(ModId::Amplitude, lastRegion->id)).sourceDepth = 100.0f;
-    }
-    else {
-        ModKey source = ModKey::createNXYZ(ModId::Envelope, lastRegion->id, *lastRegion->flexAmpEG);
-        ModKey target = ModKey::createNXYZ(ModId::Amplitude, lastRegion->id);
-        if (!lastRegion->getConnection(source, target))
-            lastRegion->getOrCreateConnection(source, target).sourceDepth = 100.0f;
-    }
+            ModKey::createNXYZ(ModId::MasterAmplitude, lastRegion->id)).sourceDepth = 1.0f;
+    else
+        lastRegion->getOrCreateConnection(
+            ModKey::createNXYZ(ModId::Envelope, lastRegion->id, *lastRegion->flexAmpEG),
+            ModKey::createNXYZ(ModId::MasterAmplitude, lastRegion->id)).sourceDepth = 1.0f;
 
     if (octaveOffset != 0 || noteOffset != 0)
         lastRegion->offsetAllKeys(octaveOffset * 12 + noteOffset);

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -380,14 +380,16 @@ void sfz::Voice::amplitudeEnvelope(absl::Span<float> modulationSpan) noexcept
 
     ModMatrix& mm = resources.modMatrix;
 
+    // Amplitude EG
+    absl::Span<const float> ampegOut(mm.getModulation(masterAmplitudeTarget), numSamples);
+    ASSERT(ampegOut.data());
+    copy(ampegOut, modulationSpan);
+
     // Amplitude envelope
     applyGain1<float>(baseGain, modulationSpan);
     if (float* mod = mm.getModulation(amplitudeTarget)) {
         for (size_t i = 0; i < numSamples; ++i)
-            modulationSpan[i] = normalizePercents(mod[i]);
-    }
-    else {
-        ASSERTFALSE;
+            modulationSpan[i] *= normalizePercents(mod[i]);
     }
 
     // Volume envelope
@@ -1050,6 +1052,7 @@ void sfz::Voice::resetSmoothers() noexcept
 void sfz::Voice::saveModulationTargets(const Region* region) noexcept
 {
     ModMatrix& mm = resources.modMatrix;
+    masterAmplitudeTarget = mm.findTarget(ModKey::createNXYZ(ModId::MasterAmplitude, region->getId()));
     amplitudeTarget = mm.findTarget(ModKey::createNXYZ(ModId::Amplitude, region->getId()));
     volumeTarget = mm.findTarget(ModKey::createNXYZ(ModId::Volume, region->getId()));
     panTarget = mm.findTarget(ModKey::createNXYZ(ModId::Pan, region->getId()));

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -337,6 +337,10 @@ public:
     Duration getLastPanningDuration() const noexcept { return panningDuration; }
 
     /**
+     * @brief Get the SFZv1 amplitude EG, if existing
+     */
+    ADSREnvelope<float>* getAmplitudeEG() { return &egAmplitude; }
+    /**
      * @brief Get the SFZv1 pitch EG, if existing
      */
     ADSREnvelope<float>* getPitchEG() { return egPitch.get(); }

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -520,6 +520,7 @@ private:
     Smoother xfadeSmoother;
     void resetSmoothers() noexcept;
 
+    ModMatrix::TargetId masterAmplitudeTarget;
     ModMatrix::TargetId amplitudeTarget;
     ModMatrix::TargetId volumeTarget;
     ModMatrix::TargetId panTarget;

--- a/src/sfizz/modulations/ModId.cpp
+++ b/src/sfizz/modulations/ModId.cpp
@@ -38,6 +38,8 @@ int ModIds::flags(ModId id) noexcept
         return kModIsPerVoice;
 
         // targets
+    case ModId::MasterAmplitude:
+        return kModIsPerVoice|kModIsPercentMultiplicative;
     case ModId::Amplitude:
         return kModIsPerVoice|kModIsPercentMultiplicative;
     case ModId::Pan:

--- a/src/sfizz/modulations/ModId.cpp
+++ b/src/sfizz/modulations/ModId.cpp
@@ -30,6 +30,8 @@ int ModIds::flags(ModId id) noexcept
         return kModIsPerVoice;
     case ModId::LFO:
         return kModIsPerVoice;
+    case ModId::AmpEG:
+        return kModIsPerVoice;
     case ModId::PitchEG:
         return kModIsPerVoice;
     case ModId::FilEG:

--- a/src/sfizz/modulations/ModId.h
+++ b/src/sfizz/modulations/ModId.h
@@ -34,7 +34,8 @@ enum class ModId : int {
     //--------------------------------------------------------------------------
     _TargetsStart = _SourcesEnd,
 
-    Amplitude = _TargetsStart,
+    MasterAmplitude = _TargetsStart,
+    Amplitude,
     Pan,
     Width,
     Position,

--- a/src/sfizz/modulations/ModId.h
+++ b/src/sfizz/modulations/ModId.h
@@ -23,6 +23,7 @@ enum class ModId : int {
     Controller = _SourcesStart,
     Envelope,
     LFO,
+    AmpEG,
     PitchEG,
     FilEG,
 

--- a/src/sfizz/modulations/ModKey.cpp
+++ b/src/sfizz/modulations/ModKey.cpp
@@ -74,6 +74,8 @@ std::string ModKey::toString() const
         return absl::StrCat("EG ", 1 + params_.N, " {", region_.number(), "}");
     case ModId::LFO:
         return absl::StrCat("LFO ", 1 + params_.N, " {", region_.number(), "}");
+    case ModId::AmpEG:
+        return absl::StrCat("AmplitudeEG {", region_.number(), "}");
     case ModId::PitchEG:
         return absl::StrCat("PitchEG {", region_.number(), "}");
     case ModId::FilEG:

--- a/src/sfizz/modulations/ModKey.cpp
+++ b/src/sfizz/modulations/ModKey.cpp
@@ -81,6 +81,8 @@ std::string ModKey::toString() const
     case ModId::FilEG:
         return absl::StrCat("FilterEG {", region_.number(), "}");
 
+    case ModId::MasterAmplitude:
+        return absl::StrCat("MasterAmplitude {", region_.number(), "}");
     case ModId::Amplitude:
         return absl::StrCat("Amplitude {", region_.number(), "}");
     case ModId::Pan:

--- a/src/sfizz/modulations/sources/ADSREnvelope.cpp
+++ b/src/sfizz/modulations/sources/ADSREnvelope.cpp
@@ -35,6 +35,11 @@ void ADSREnvelopeSource::init(const ModKey& sourceKey, NumericId<Voice> voiceId,
     const EGDescription* desc = nullptr;
 
     switch (sourceKey.id()) {
+    case ModId::AmpEG:
+        eg = voice->getAmplitudeEG();
+        ASSERT(eg);
+        desc = &region->amplitudeEG;
+        break;
     case ModId::PitchEG:
         eg = voice->getPitchEG();
         ASSERT(eg);
@@ -69,6 +74,10 @@ void ADSREnvelopeSource::release(const ModKey& sourceKey, NumericId<Voice> voice
     ADSREnvelope<float>* eg = nullptr;
 
     switch (sourceKey.id()) {
+    case ModId::AmpEG:
+        eg = voice->getAmplitudeEG();
+        ASSERT(eg);
+        break;
     case ModId::PitchEG:
         eg = voice->getPitchEG();
         ASSERT(eg);
@@ -98,6 +107,10 @@ void ADSREnvelopeSource::generate(const ModKey& sourceKey, NumericId<Voice> voic
     ADSREnvelope<float>* eg = nullptr;
 
     switch (sourceKey.id()) {
+    case ModId::AmpEG:
+        eg = voice->getAmplitudeEG();
+        ASSERT(eg);
+        break;
     case ModId::PitchEG:
         eg = voice->getPitchEG();
         ASSERT(eg);

--- a/tests/FlexEGT.cpp
+++ b/tests/FlexEGT.cpp
@@ -41,7 +41,7 @@ TEST_CASE("[FlexEG] Values")
     REQUIRE( egDescription.points[4].time == .4_a );
     REQUIRE( egDescription.points[4].level == 1.0_a );
     REQUIRE( egDescription.sustain == 3 );
-    REQUIRE(synth.getResources().modMatrix.toDotGraph() == createReferenceGraph({
+    REQUIRE(synth.getResources().modMatrix.toDotGraph() == createDefaultGraph({
         R"("EG 1 {0}" -> "Amplitude {0}")",
     }));
 }
@@ -67,7 +67,7 @@ TEST_CASE("[FlexEG] Default values")
     REQUIRE( egDescription.points[1].level == 0.0_a );
     REQUIRE( egDescription.points[2].time == .1_a );
     REQUIRE( egDescription.points[2].level == .25_a );
-    REQUIRE( synth.getResources().modMatrix.toDotGraph() == createReferenceGraph({}) );
+    REQUIRE( synth.getResources().modMatrix.toDotGraph() == createDefaultGraph({}) );
 }
 
 TEST_CASE("[FlexEG] Connections")
@@ -85,7 +85,7 @@ TEST_CASE("[FlexEG] Connections")
     REQUIRE(synth.getNumRegions() == 6);
     REQUIRE( synth.getRegionView(0)->flexEGs.size() == 1 );
     REQUIRE( synth.getRegionView(0)->flexEGs[0].points.size() == 2 );
-    REQUIRE( synth.getResources().modMatrix.toDotGraph() == createReferenceGraph({
+    REQUIRE( synth.getResources().modMatrix.toDotGraph() == createDefaultGraph({
         R"("EG 1 {0}" -> "Amplitude {0}")",
         R"("EG 1 {1}" -> "Pan {1}")",
         R"("EG 1 {2}" -> "Width {2}")",

--- a/tests/ModulationsT.cpp
+++ b/tests/ModulationsT.cpp
@@ -92,7 +92,7 @@ width_oncc425=29
 )");
 
     const std::string graph = synth.getResources().modMatrix.toDotGraph();
-    REQUIRE(graph == createReferenceGraph({
+    REQUIRE(graph == createDefaultGraph({
         R"("Controller 20 {curve=3, smooth=0, value=59, step=0}" -> "Amplitude {0}")",
         R"("Controller 42 {curve=0, smooth=32, value=71, step=0}" -> "Pitch {0}")",
         R"("Controller 36 {curve=0, smooth=0, value=14.5, step=1.5}" -> "Pan {0}")",
@@ -111,7 +111,7 @@ TEST_CASE("[Modulations] Filter CC connections")
     )");
 
     const std::string graph = synth.getResources().modMatrix.toDotGraph();
-    REQUIRE(graph == createReferenceGraph({
+    REQUIRE(graph == createDefaultGraph({
         R"("Controller 1 {curve=0, smooth=10, value=2, step=0}" -> "FilterResonance {0, N=3}")",
         R"("Controller 2 {curve=2, smooth=0, value=100, step=0}" -> "FilterCutoff {0, N=2}")",
         R"("Controller 3 {curve=0, smooth=0, value=5, step=0.5}" -> "FilterGain {0, N=1}")",
@@ -129,7 +129,7 @@ TEST_CASE("[Modulations] EQ CC connections")
     )");
 
     const std::string graph = synth.getResources().modMatrix.toDotGraph();
-    REQUIRE(graph == createReferenceGraph({
+    REQUIRE(graph == createDefaultGraph({
         R"("Controller 1 {curve=0, smooth=10, value=2, step=0}" -> "EqBandwidth {0, N=3}")",
         R"("Controller 2 {curve=0, smooth=0, value=5, step=0.5}" -> "EqGain {0, N=1}")",
         R"("Controller 3 {curve=3, smooth=0, value=300, step=0}" -> "EqFrequency {0, N=2}")",
@@ -150,7 +150,7 @@ TEST_CASE("[Modulations] LFO Filter connections")
     )");
 
     const std::string graph = synth.getResources().modMatrix.toDotGraph();
-    REQUIRE(graph == createReferenceGraph({
+    REQUIRE(graph == createDefaultGraph({
         R"("LFO 1 {0}" -> "FilterCutoff {0, N=1}")",
         R"("LFO 2 {0}" -> "FilterCutoff {0, N=1}")",
         R"("LFO 3 {0}" -> "FilterResonance {0, N=1}")",
@@ -174,7 +174,7 @@ TEST_CASE("[Modulations] EG Filter connections")
     )");
 
     const std::string graph = synth.getResources().modMatrix.toDotGraph();
-    REQUIRE(graph == createReferenceGraph({
+    REQUIRE(graph == createDefaultGraph({
         R"("EG 1 {0}" -> "FilterCutoff {0, N=1}")",
         R"("EG 2 {0}" -> "FilterCutoff {0, N=1}")",
         R"("EG 3 {0}" -> "FilterResonance {0, N=1}")",
@@ -198,7 +198,7 @@ TEST_CASE("[Modulations] LFO EQ connections")
     )");
 
     const std::string graph = synth.getResources().modMatrix.toDotGraph();
-    REQUIRE(graph == createReferenceGraph({
+    REQUIRE(graph == createDefaultGraph({
         R"("LFO 1 {0}" -> "EqBandwidth {0, N=1}")",
         R"("LFO 2 {0}" -> "EqFrequency {0, N=2}")",
         R"("LFO 3 {0}" -> "EqGain {0, N=3}")",
@@ -222,7 +222,7 @@ TEST_CASE("[Modulations] EG EQ connections")
     )");
 
     const std::string graph = synth.getResources().modMatrix.toDotGraph();
-    REQUIRE(graph == createReferenceGraph({
+    REQUIRE(graph == createDefaultGraph({
         R"("EG 1 {0}" -> "EqBandwidth {0, N=1}")",
         R"("EG 2 {0}" -> "EqFrequency {0, N=2}")",
         R"("EG 3 {0}" -> "EqGain {0, N=3}")",
@@ -231,3 +231,76 @@ TEST_CASE("[Modulations] EG EQ connections")
         R"("EG 6 {0}" -> "EqFrequency {0, N=1}")",
     }));
 }
+
+
+TEST_CASE("[Modulations] FlexEG Ampeg target")
+{
+    sfz::Synth synth;
+
+    synth.loadSfzString(fs::current_path(), R"(
+        <region> sample=*sine
+        eg1_time1=0  eg1_level1=1
+        eg1_time2=1  eg1_level2=0
+        eg1_time3=1  eg1_level3=.5 eg1_sustain=3
+        eg1_time4=1  eg1_level4=1
+        eg1_ampeg=1
+    )");
+
+    const std::string graph = synth.getResources().modMatrix.toDotGraph();
+    REQUIRE(graph == createModulationDotGraph({
+        R"("Controller 10 {curve=1, smooth=10, value=100, step=0}" -> "Pan {0}")",
+  	    R"("Controller 7 {curve=4, smooth=10, value=100, step=0}" -> "Amplitude {0}")",
+        R"("EG 1 {0}" -> "MasterAmplitude {0}")",
+    }));
+}
+
+TEST_CASE("[Modulations] FlexEG Ampeg target with 2 FlexEGs")
+{
+    sfz::Synth synth;
+
+    synth.loadSfzString(fs::current_path(), R"(
+        <region> sample=*sine
+        eg1_time1=0  eg1_level1=1
+        eg1_time2=1  eg1_level2=0
+        eg1_time3=1  eg1_level3=.5 eg1_sustain=3
+        eg1_time4=1  eg1_level4=1
+        eg2_time1=0  eg2_level1=1
+        eg2_time2=1  eg2_level2=0
+        eg2_time3=1  eg2_level3=.5 eg1_sustain=3
+        eg2_ampeg=1
+    )");
+
+    const std::string graph = synth.getResources().modMatrix.toDotGraph();
+    REQUIRE(graph == createModulationDotGraph({
+        R"("Controller 10 {curve=1, smooth=10, value=100, step=0}" -> "Pan {0}")",
+  	    R"("Controller 7 {curve=4, smooth=10, value=100, step=0}" -> "Amplitude {0}")",
+        R"("EG 2 {0}" -> "MasterAmplitude {0}")",
+    }));
+}
+
+
+TEST_CASE("[Modulations] FlexEG Ampeg target with multiple EGs targeting ampeg")
+{
+    sfz::Synth synth;
+
+    synth.loadSfzString(fs::current_path(), R"(
+        <region> sample=*sine
+        eg1_time1=0  eg1_level1=1
+        eg1_time2=1  eg1_level2=0
+        eg1_time3=1  eg1_level3=.5 eg1_sustain=3
+        eg1_time4=1  eg1_level4=1
+        eg1_ampeg=1
+        eg2_time1=0  eg2_level1=1
+        eg2_time2=1  eg2_level2=0
+        eg2_time3=1  eg2_level3=.5 eg1_sustain=3
+        eg2_ampeg=1
+    )");
+
+    const std::string graph = synth.getResources().modMatrix.toDotGraph();
+    REQUIRE(graph == createModulationDotGraph({
+        R"("Controller 10 {curve=1, smooth=10, value=100, step=0}" -> "Pan {0}")",
+  	    R"("Controller 7 {curve=4, smooth=10, value=100, step=0}" -> "Amplitude {0}")",
+        R"("EG 1 {0}" -> "MasterAmplitude {0}")",
+    }));
+}
+

--- a/tests/OpcodeT.cpp
+++ b/tests/OpcodeT.cpp
@@ -280,3 +280,14 @@ TEST_CASE("[Opcode] readOpcode")
     REQUIRE( !sfz::readOpcode("garbage50.25", sfz::Range<int>(-20, 100)) );
     REQUIRE( !sfz::readOpcode("garbage", sfz::Range<int>(-20, 100)) );
 }
+
+TEST_CASE("[Opcode] readBooleanFromOpcode")
+{
+    REQUIRE(sfz::readBooleanFromOpcode({"", "1"}) == true);
+    REQUIRE(sfz::readBooleanFromOpcode({"", "0"}) == false);
+    REQUIRE(sfz::readBooleanFromOpcode({"", "777"}) == true);
+    REQUIRE(sfz::readBooleanFromOpcode({"", "on"}) == true);
+    REQUIRE(sfz::readBooleanFromOpcode({"", "off"}) == false);
+    REQUIRE(sfz::readBooleanFromOpcode({"", "On"}) == true);
+    REQUIRE(sfz::readBooleanFromOpcode({"", "oFf"}) == false);
+}

--- a/tests/TestHelpers.cpp
+++ b/tests/TestHelpers.cpp
@@ -69,7 +69,7 @@ unsigned numPlayingVoices(const sfz::Synth& synth)
     });
 }
 
-std::string createReferenceGraph(std::vector<std::string> lines, int numRegions)
+std::string createDefaultGraph(std::vector<std::string> lines, int numRegions)
 {
     for (int regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
         lines.push_back(absl::StrCat(
@@ -87,6 +87,11 @@ std::string createReferenceGraph(std::vector<std::string> lines, int numRegions)
         ));
     }
 
+    return createModulationDotGraph(lines);
+};
+
+std::string createModulationDotGraph(std::vector<std::string> lines)
+{
     std::sort(lines.begin(), lines.end());
 
     std::string graph;
@@ -101,4 +106,4 @@ std::string createReferenceGraph(std::vector<std::string> lines, int numRegions)
     graph += "}\n";
 
     return graph;
-};
+}

--- a/tests/TestHelpers.cpp
+++ b/tests/TestHelpers.cpp
@@ -73,6 +73,9 @@ std::string createReferenceGraph(std::vector<std::string> lines, int numRegions)
 {
     for (int regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
         lines.push_back(absl::StrCat(
+            R"("AmplitudeEG {)", regionIdx, R"(}" -> "MasterAmplitude {)", regionIdx, R"(}")"
+        ));
+        lines.push_back(absl::StrCat(
             R"("Controller 7 {curve=4, smooth=10, value=100, step=0}" -> "Amplitude {)",
             regionIdx,
             R"(}")"

--- a/tests/TestHelpers.h
+++ b/tests/TestHelpers.h
@@ -67,10 +67,17 @@ const std::vector<const sfz::Voice*> getPlayingVoices(const sfz::Synth& synth);
 unsigned numPlayingVoices(const sfz::Synth& synth);
 
 /**
- * @brief Create the dot graph representation from a list of strings
+ * @brief Create the default dot graph representation for standard regions
  *
  */
-std::string createReferenceGraph(std::vector<std::string> lines, int numRegions = 1);
+std::string createDefaultGraph(std::vector<std::string> lines, int numRegions = 1);
+
+/**
+ * @brief Create a dot graph with the specified lines.
+ * The lines are sorted.
+ *
+ */
+std::string createModulationDotGraph(std::vector<std::string> lines);
 
 template <class Type>
 inline bool approxEqual(absl::Span<const Type> lhs, absl::Span<const Type> rhs, Type eps = 1e-3)


### PR DESCRIPTION
This implements opcode `egN_ampeg`, allowing a flex EG to override the ampeg.

Notes:
- when multiple flex EG have `egN_ampeg`, the lowest one becomes the amp EG
- ampeg has been matrixed; depending if the sfz uses flex ampeg, either v1 ampeg or flex gets connected to amplitude
- under ARIA, one can have both `egN_ampeg` and `egN_amplitude` in a region, and they both take effect.
That means the equivalent of 2 independent connection (egN->amplitude) in the MM which must coexist.
Since we can't represent this, I created a special target `MasterAmplitude` which is reserved for ampeg and is always connected.
- this doesn't implement fast release, so I left in `Voice.cpp` some TODO comments "Flex AmpEG"

In this way, ARIA and sfizz work in equivalent way.

**Except**
There is a bug, which I'll do separately, it's that ARIA goes directly to the point after sustain on releasing the EG, whereas ours finishes to go through intermediate points first.

```
<region>
sample=*sine
eg15_ampeg=1
eg15_time1=.1  eg15_level1=.25
eg15_time2=.15  eg15_level2=1
eg15_time3=.2  eg15_level3=.5 eg15_sustain=3
eg15_time4=.4 eg15_level4=1
eg15_amplitude=100
```

On tapping the key, you can observe the problem on scope quite easily.
![Capture du 2020-09-26 17-18-59](https://user-images.githubusercontent.com/17614485/94343995-61832100-001c-11eb-9b1c-afc62db9e2ff.png)
