### PR TITLE
Make all the random opcodes bipolar

### DIFF
--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -160,7 +160,7 @@ namespace Default
     constexpr float filterGain { 0 };
     constexpr int filterKeytrack { 0 };
     constexpr uint8_t filterKeycenter { 60 };
-    constexpr int filterRandom { 0 };
+    constexpr float filterRandom { 0 };
     constexpr int filterVeltrack { 0 };
     constexpr float filterCutoffCC { 0 };
     constexpr float filterResonanceCC { 0 };
@@ -170,7 +170,7 @@ namespace Default
     constexpr Range<float> filterGainRange { -96.0f, 96.0f };
     constexpr Range<float> filterGainModRange { -96.0f, 96.0f };
     constexpr Range<int> filterKeytrackRange { 0, 1200 };
-    constexpr Range<int> filterRandomRange { 0, 9600 };
+    constexpr Range<float> filterRandomRange { 0, 9600 };
     constexpr Range<int> filterVeltrackRange { -9600, 9600 };
     constexpr Range<float> filterResonanceRange { 0.0f, 96.0f };
     constexpr Range<float> filterResonanceModRange { 0.0f, 96.0f };

--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -199,8 +199,8 @@ namespace Default
 	constexpr uint8_t pitchKeycenter { 60 };
 	constexpr int pitchKeytrack { 100 };
 	constexpr Range<int> pitchKeytrackRange { -1200, 1200 };
-	constexpr int pitchRandom { 0 };
-	constexpr Range<int> pitchRandomRange { 0, 9600 };
+	constexpr float pitchRandom { 0 };
+	constexpr Range<float> pitchRandomRange { 0, 9600 };
 	constexpr int pitchVeltrack { 0 };
 	constexpr Range<int> pitchVeltrackRange { -9600, 9600 };
 	constexpr int transpose { 0 };

--- a/src/sfizz/FilterDescription.h
+++ b/src/sfizz/FilterDescription.h
@@ -20,7 +20,7 @@ struct FilterDescription
     int keytrack { Default::filterKeytrack };
     uint8_t keycenter { Default::filterKeycenter };
     int veltrack { Default::filterVeltrack };
-    int random { Default::filterRandom };
+    float random { Default::filterRandom };
     FilterType type { FilterType::kFilterLpf2p };
 };
 }

--- a/src/sfizz/FilterPool.cpp
+++ b/src/sfizz/FilterPool.cpp
@@ -30,8 +30,8 @@ void sfz::FilterHolder::setup(const Region& region, unsigned filterId, int noteN
     // Setup the base values
     baseCutoff = description->cutoff;
     if (description->random != 0) {
-       dist.param(filterRandomDist::param_type(0, description->random));
-       baseCutoff *= centsFactor(dist(Random::randomGenerator));
+        fast_real_distribution<float> dist { -description->random, description->random };
+        baseCutoff *= centsFactor(dist(Random::randomGenerator));
     }
     const auto keytrack = description->keytrack * (noteNumber - description->keycenter);
     baseCutoff *= centsFactor(keytrack);

--- a/src/sfizz/FilterPool.h
+++ b/src/sfizz/FilterPool.h
@@ -54,8 +54,6 @@ private:
     ModMatrix::TargetId cutoffTarget;
     ModMatrix::TargetId resonanceTarget;
     bool prepared { false };
-    using filterRandomDist = std::uniform_int_distribution<int>;
-    filterRandomDist dist { 0, sfz::Default::filterRandom };
 };
 
 }

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -1714,7 +1714,7 @@ float sfz::Region::getBasePitchVariation(float noteNumber, float velocity) const
 {
     ASSERT(velocity >= 0.0f && velocity <= 1.0f);
 
-    std::uniform_int_distribution<int> pitchDistribution { -pitchRandom, pitchRandom };
+    fast_real_distribution<float> pitchDistribution { -pitchRandom, pitchRandom };
     auto pitchVariationInCents = pitchKeytrack * (noteNumber - pitchKeycenter); // note difference with pitch center
     pitchVariationInCents += tune; // sample tuning
     pitchVariationInCents += config::centPerSemitone * transpose; // sample transpose

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -409,7 +409,7 @@ struct Region {
     uint8_t pitchKeycenter { Default::pitchKeycenter }; // pitch_keycenter
     bool pitchKeycenterFromSample { false };
     int pitchKeytrack { Default::pitchKeytrack }; // pitch_keytrack
-    int pitchRandom { Default::pitchRandom }; // pitch_random
+    float pitchRandom { Default::pitchRandom }; // pitch_random
     int pitchVeltrack { Default::pitchVeltrack }; // pitch_veltrack
     int transpose { Default::transpose }; // transpose
     int tune { Default::tune }; // tune


### PR DESCRIPTION
Reported by @kinwie. It's an inconsistency between random opcodes.
- apparently Cakewalk uses bipolar for everything
- ARIA uses unipolar
bipolar may be considered as more useful, and probably it makes the most sense.
