### PR TITLE
Misc fixes: missing return, bad const qualification

### DIFF
--- a/src/sfizz/AudioSpan.h
+++ b/src/sfizz/AudioSpan.h
@@ -200,7 +200,7 @@ public:
      * @param channelIndex the channel
      * @return Type* the raw pointer to the channel
      */
-    Type* getChannel(size_t channelIndex)
+    Type* getChannel(size_t channelIndex) const
     {
         ASSERT(channelIndex < numChannels);
         if (channelIndex < numChannels)
@@ -231,7 +231,7 @@ public:
      * @param channelIndex the channel
      * @return absl::Span<Type>
      */
-    absl::Span<Type> getSpan(size_t channelIndex)
+    absl::Span<Type> getSpan(size_t channelIndex) const
     {
         ASSERT(channelIndex < numChannels);
         if (channelIndex < numChannels)
@@ -402,7 +402,7 @@ public:
      *
      * @param length the number of elements to take on each channel
      */
-    AudioSpan<Type> first(size_type length)
+    AudioSpan<Type> first(size_type length) const
     {
         ASSERT(length <= numFrames);
         return { spans, numChannels, 0, length };
@@ -413,7 +413,7 @@ public:
      *
      * @param length the number of elements to take on each channel
      */
-    AudioSpan<Type> last(size_type length)
+    AudioSpan<Type> last(size_type length) const
     {
         ASSERT(length <= numFrames);
         return { spans, numChannels, numFrames - length, length };
@@ -427,7 +427,7 @@ public:
      *
      * @param length the number of elements to take on each channel
      */
-    AudioSpan<Type> subspan(size_type offset, size_type length)
+    AudioSpan<Type> subspan(size_type offset, size_type length) const
     {
         ASSERT(length + offset <= numFrames);
         return { spans, numChannels, offset, length };
@@ -440,7 +440,7 @@ public:
      *
      * @param length the number of elements to take on each channel
      */
-    AudioSpan<Type> subspan(size_type offset)
+    AudioSpan<Type> subspan(size_type offset) const
     {
         ASSERT(offset <= numFrames);
         return { spans, numChannels, offset, numFrames - offset };

--- a/src/sfizz/BufferPool.h
+++ b/src/sfizz/BufferPool.h
@@ -36,6 +36,7 @@ public:
         this->value = other.value;
         this->available = other.available;
         other.available = nullptr;
+        return *this;
     }
     SpanHolder(T&& value, int* available)
         : value(std::forward<T>(value))

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -615,7 +615,7 @@ void sfz::Voice::fillWithData(AudioSpan<float> buffer) noexcept
 
 template <sfz::InterpolatorModel M>
 void sfz::Voice::fillInterpolated(
-    const sfz::AudioSpan<const float>& source, sfz::AudioSpan<float>& dest,
+    const sfz::AudioSpan<const float>& source, const sfz::AudioSpan<float>& dest,
     absl::Span<const int> indices, absl::Span<const float> coeffs)
 {
     auto ind = indices.data();

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -376,7 +376,7 @@ private:
      */
     template <InterpolatorModel M>
     static void fillInterpolated(
-        const AudioSpan<const float>& source, AudioSpan<float>& dest,
+        const AudioSpan<const float>& source, const AudioSpan<float>& dest,
         absl::Span<const int> indices, absl::Span<const float> coeffs);
 
     /**


### PR DESCRIPTION
Const qualification is invalid on some `AudioSpan` methods and is an obstacle in some cases.
For example it must be permitted to get a `float*` out of a `const AudioSpan<float>&`.
If undesired, it should be instead prevented by `AudioSpan<const float>`.
