### PR TITLE
Loop xfade

### DIFF
--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -126,6 +126,10 @@ namespace config {
        @brief Ratio to target under which smoothing is considered as completed
      */
     static constexpr float smoothingShortcutThreshold = 5e-3;
+    // loop crossfade settings
+    static constexpr int loopXfadeCurve = 2;    // 0: linear
+                                                // 1: use curves 5 & 6
+                                                // 2: use S-shaped curve
 } // namespace config
 
 } // namespace sfz

--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -31,7 +31,7 @@ namespace config {
     constexpr int maxBlockSize { 8192 };
     constexpr int bufferPoolSize { 6 };
     constexpr int stereoBufferPoolSize { 4 };
-    constexpr int indexBufferPoolSize { 2 };
+    constexpr int indexBufferPoolSize { 4 };
     constexpr int preloadSize { 8192 };
     constexpr int loggerQueueSize { 256 };
     constexpr int voiceLoggerQueueSize { 256 };

--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -54,6 +54,8 @@ namespace Default
 	constexpr Range<uint32_t> sampleCountRange { 0, std::numeric_limits<uint32_t>::max() };
 	constexpr SfzLoopMode loopMode { SfzLoopMode::no_loop };
 	constexpr Range<uint32_t> loopRange { 0, std::numeric_limits<uint32_t>::max() };
+	constexpr float loopCrossfade { 1e-3 };
+	constexpr Range<float> loopCrossfadeRange { loopCrossfade, 1.0 };
 
     // common defaults
     constexpr Range<uint8_t> midi7Range { 0, 127 };

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -138,6 +138,9 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
     case hash("loop_start"): // also loopstart
         setRangeStartFromOpcode(opcode, loopRange, Default::loopRange);
         break;
+    case hash("loop_crossfade"):
+        setValueFromOpcode(opcode, loopCrossfade, Default::loopCrossfadeRange);
+        break;
 
     // Wavetable oscillator
     case hash("oscillator_phase"):

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -319,6 +319,7 @@ struct Region {
     absl::optional<uint32_t> sampleCount {}; // count
     absl::optional<SfzLoopMode> loopMode {}; // loopmode
     Range<uint32_t> loopRange { Default::loopRange }; //loopstart and loopend
+    float loopCrossfade { Default::loopCrossfade }; // loop_crossfade
 
     // Wavetable oscillator
     float oscillatorPhase { Default::oscillatorPhase };

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -588,8 +588,7 @@ void sfz::Voice::fillWithData(AudioSpan<float> buffer) noexcept
         partitionStarts = absl::MakeSpan(const_cast<int*>(starts), 1);
         partitionTypes = absl::MakeSpan(const_cast<int*>(types), 1);
         numPartitions = 1;
-    }
-    else {
+    } else {
         for (auto& buf : partitionBuffers) {
             buf = resources.bufferPool.getIndexBuffer(numSamples);
             if (!buf)
@@ -600,11 +599,6 @@ void sfz::Voice::fillWithData(AudioSpan<float> buffer) noexcept
         // Note: partitions will be alternance of Normal/Xfade
         //       computed along with index processing below
     }
-
-    // loop crossfade settings
-    constexpr int loopXfadeUseCurves = 2; // 0: linear
-                                          // 1: use curves 5 & 6
-                                          // 2: use S-shaped curve
 
     // index preprocessing for loops
     if (isLooping) {
@@ -699,17 +693,17 @@ void sfz::Voice::fillWithData(AudioSpan<float> buffer) noexcept
             {
                 // compute out curve
                 absl::Span<float> xfCurve = xfTemp2->first(ptSize);
-                IF_CONSTEXPR (loopXfadeUseCurves == 2) {
+                IF_CONSTEXPR (config::loopXfadeCurve == 2) {
                     const Curve& xfIn = getSCurve();
                     for (unsigned i = 0; i < ptSize; ++i)
                         xfCurve[i] = xfIn.evalNormalized(1.0f - xfCurvePos[i]);
                 }
-                else IF_CONSTEXPR (loopXfadeUseCurves == 1) {
+                else IF_CONSTEXPR (config::loopXfadeCurve == 1) {
                     const Curve& xfOut = resources.curves.getCurve(6);
                     for (unsigned i = 0; i < ptSize; ++i)
                         xfCurve[i] = xfOut.evalNormalized(xfCurvePos[i]);
                 }
-                else IF_CONSTEXPR (loopXfadeUseCurves == 0) {
+                else IF_CONSTEXPR (config::loopXfadeCurve == 0) {
                     // TODO(jpc) vectorize this
                     for (unsigned i = 0; i < ptSize; ++i)
                         xfCurve[i] = clamp(1.0f - xfCurvePos[i], 0.0f, 1.0f);
@@ -749,17 +743,17 @@ void sfz::Voice::fillWithData(AudioSpan<float> buffer) noexcept
 
                 // compute in curve
                 absl::Span<float> xfCurve = xfTemp2->first(applySize);
-                IF_CONSTEXPR (loopXfadeUseCurves == 2) {
+                IF_CONSTEXPR (config::loopXfadeCurve == 2) {
                     const Curve& xfIn = getSCurve();
                     for (unsigned i = 0; i < applySize; ++i)
                         xfCurve[i] = xfIn.evalNormalized(xfInCurvePos[i]);
                 }
-                else IF_CONSTEXPR (loopXfadeUseCurves == 1) {
+                else IF_CONSTEXPR (config::loopXfadeCurve == 1) {
                     const Curve& xfIn = resources.curves.getCurve(5);
                     for (unsigned i = 0; i < applySize; ++i)
                         xfCurve[i] = xfIn.evalNormalized(xfInCurvePos[i]);
                 }
-                else IF_CONSTEXPR (loopXfadeUseCurves == 0) {
+                else IF_CONSTEXPR (config::loopXfadeCurve == 0) {
                     // TODO(jpc) vectorize this
                     for (unsigned i = 0; i < applySize; ++i)
                         xfCurve[i] = clamp(xfInCurvePos[i], 0.0f, 1.0f);

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -559,6 +559,7 @@ void sfz::Voice::fillWithData(AudioSpan<float> buffer) noexcept
     }
 
     // calculate loop characteristics
+    const auto loop = this->loop;
     const bool isLooping = region->shouldLoop()
         && (static_cast<size_t>(loop.end) < source.getNumFrames());
 

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -571,7 +571,7 @@ void sfz::Voice::fillWithData(AudioSpan<float> buffer) noexcept
     if (isLooping) {
         loopStart = static_cast<int>(region->loopStart(currentPromise->oversamplingFactor));
         loopSize = loopEnd + 1 - loopStart;
-        loopXfadeSize = static_cast<int>(region->loopCrossfade * sampleRate + 0.5);
+        loopXfadeSize = static_cast<int>(lroundPositive(region->loopCrossfade * sampleRate));
         loopXfOutStart = loopEnd + 1 - loopXfadeSize;
         loopXfInStart = loopStart - loopXfadeSize;
         for (auto& buf : xfadeTemp) {

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -574,7 +574,8 @@ void sfz::Voice::fillWithData(AudioSpan<float> buffer) noexcept
     if (isLooping) {
         loopStart = static_cast<int>(region->loopStart(currentPromise->oversamplingFactor));
         loopSize = loopEnd + 1 - loopStart;
-        loopXfadeSize = static_cast<int>(lroundPositive(region->loopCrossfade * sampleRate));
+        loopXfadeSize = static_cast<int>(
+            lroundPositive(region->loopCrossfade * static_cast<int>(currentPromise->oversamplingFactor) * currentPromise->sampleRate));
         loopXfOutStart = loopEnd + 1 - loopXfadeSize;
         loopXfInStart = loopStart - loopXfadeSize;
         for (auto& buf : xfadeTemp) {

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -710,11 +710,6 @@ void sfz::Voice::fillWithData(AudioSpan<float> buffer) noexcept
             // Crossfade Out
             //   -> fade out signal nearing the loop end
             {
-                // compute crossfade coeffs
-                for (unsigned i = 0; i < ptSize; ++i) {
-                    float pos = ptIndices[i] + ptCoeffs[i];
-                    xfCoeff[i] = (pos - loopXfOutStart) / loopXfadeSize;
-                }
                 // compute out curve
                 const Curve& xfOut = resources.curves.getCurve(6);
                 absl::Span<float> xfCurve = xfadeTemp[1]->first(ptSize);

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -737,16 +737,12 @@ void sfz::Voice::fillWithData(AudioSpan<float> buffer) noexcept
                         xfCurve[i] = clamp(1.0f - xfCurvePos[i], 0.0f, 1.0f);
                 }
                 // apply out curve
-                if (0)
-                    ptBuffer.applyGain(xfCurve);
-                else {
-                    // scalar fallback: buffer and curve not aligned
-                    size_t numChannels = ptBuffer.getNumChannels();
-                    for (size_t c = 0; c < numChannels; ++c) {
-                        absl::Span<float> channel = ptBuffer.getSpan(c);
-                        for (unsigned i = 0; i < ptSize; ++i)
-                            channel[i] *= xfCurve[i];
-                    }
+                // (scalar fallback: buffer and curve not aligned)
+                size_t numChannels = ptBuffer.getNumChannels();
+                for (size_t c = 0; c < numChannels; ++c) {
+                    absl::Span<float> channel = ptBuffer.getSpan(c);
+                    for (unsigned i = 0; i < ptSize; ++i)
+                        channel[i] *= xfCurve[i];
                 }
             }
             //----------------------------------------------------------------//

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -374,10 +374,27 @@ private:
      * @param indices the integral parts of the source positions
      * @param coeffs the fractional parts of the source positions
      */
-    template <InterpolatorModel M>
+    template <InterpolatorModel M, bool Adding>
     static void fillInterpolated(
         const AudioSpan<const float>& source, const AudioSpan<float>& dest,
-        absl::Span<const int> indices, absl::Span<const float> coeffs);
+        absl::Span<const int> indices, absl::Span<const float> coeffs,
+        absl::Span<const float> addingGains);
+
+    /**
+     * @brief Fill a destination with an interpolated source, selecting
+     *        interpolation type dynamically by quality level.
+     *
+     * @param source the source sample
+     * @param dest the destination buffer
+     * @param indices the integral parts of the source positions
+     * @param coeffs the fractional parts of the source positions
+     * @param quality the quality level 1-10
+     */
+    template <bool Adding>
+    static void fillInterpolatedWithQuality(
+        const AudioSpan<const float>& source, const AudioSpan<float>& dest,
+        absl::Span<const int> indices, absl::Span<const float> coeffs,
+        absl::Span<const float> addingGains, int quality);
 
     /**
      * @brief Compute the amplitude envelope, applied as a gain to a mono

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -496,6 +496,25 @@ private:
     int sourcePosition { 0 };
     int initialDelay { 0 };
     int age { 0 };
+    struct {
+        int start { 0 };
+        int end { 0 };
+        int size { 0 };
+        int xfSize { 0 };
+        int xfOutStart { 0 };
+        int xfInStart { 0 };
+    } loop;
+    /**
+     * @brief Reset the loop information
+     *
+     */
+    void resetLoopInformation() noexcept;
+    /**
+     * @brief Read the loop information data from the region.
+     * This requires that the region and promise is properly set.
+     *
+     */
+    void updateLoopInformation() noexcept;
 
     FilePromisePtr currentPromise { nullptr };
 

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -397,6 +397,11 @@ private:
         absl::Span<const float> addingGains, int quality);
 
     /**
+     * @brief Get a S-shaped curve that is applicable to loop crossfading.
+     */
+    static const Curve& getSCurve();
+
+    /**
      * @brief Compute the amplitude envelope, applied as a gain to a mono
      * or stereo buffer
      *

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -174,6 +174,14 @@ TEST_CASE("[Region] Parsing opcodes")
         REQUIRE(region.loopRange == Range<uint32_t>(0, 4294967295));
     }
 
+    SECTION("loop_crossfade")
+    {
+        region.parseOpcode({ "loop_crossfade", "0.5" });
+        REQUIRE(region.loopCrossfade == Approx(0.5f));
+        region.parseOpcode({ "loop_crossfade", "0" });
+        REQUIRE(region.loopCrossfade > 0);
+    }
+
     SECTION("group")
     {
         REQUIRE(region.group == 0);


### PR DESCRIPTION
#237
Support loop crossfading
- enforces a default minimum, set to 1ms, should resolve the ticking problem (#395)
- `loop_crossfade` opcode
- subdivide the render block into partitions
  - a partition is a block of frames where the indices increase monotonically, and also alternates between "normal" and "xfading" sections.
  - in normal mode, it's processing as usual
  - in xfading mode, two segments of the source audio are interpolated, and faded together with xfin/xfout curves
     the xfout section is that goes up to `loopend`, and xfin going up to loopstart. the size of these sections is determined by the amount `loop_crossfade`, it is rounded to the nearest frame.

