### PR TITLE
Audio reader benchmark in real conditions

### DIFF
--- a/src/sfizz/AudioReader.cpp
+++ b/src/sfizz/AudioReader.cpp
@@ -333,12 +333,6 @@ AudioReaderPtr createAudioReader(const fs::path& path, bool reverse, std::error_
     return createAudioReaderWithHandle(handle, reverse, ec);
 }
 
-AudioReaderPtr createAudioReaderWithFd(int fd, bool reverse, std::error_code* ec)
-{
-    SndfileHandle handle(fd, false);
-    return createAudioReaderWithHandle(handle, reverse, ec);
-}
-
 static AudioReaderPtr createExplicitAudioReaderWithHandle(SndfileHandle handle, AudioReaderType type, std::error_code* ec)
 {
     AudioReaderPtr reader;
@@ -375,12 +369,6 @@ AudioReaderPtr createExplicitAudioReader(const fs::path& path, AudioReaderType t
 #else
     SndfileHandle handle(path.c_str());
 #endif
-    return createExplicitAudioReaderWithHandle(handle, type, ec);
-}
-
-AudioReaderPtr createExplicitAudioReaderWithFd(int fd, AudioReaderType type, std::error_code* ec)
-{
-    SndfileHandle handle(fd, false);
     return createExplicitAudioReaderWithHandle(handle, type, ec);
 }
 

--- a/src/sfizz/AudioReader.h
+++ b/src/sfizz/AudioReader.h
@@ -53,18 +53,8 @@ typedef std::unique_ptr<AudioReader> AudioReaderPtr;
 AudioReaderPtr createAudioReader(const fs::path& path, bool reverse, std::error_code* ec = nullptr);
 
 /**
- * @brief Create a file reader of detected type.
- */
-AudioReaderPtr createAudioReaderWithFd(int fd, bool reverse, std::error_code* ec = nullptr);
-
-/**
  * @brief Create a file reader of explicit type. (for testing purposes)
  */
 AudioReaderPtr createExplicitAudioReader(const fs::path& path, AudioReaderType type, std::error_code* ec = nullptr);
-
-/**
- * @brief Create a file reader of explicit type. (for testing purposes)
- */
-AudioReaderPtr createExplicitAudioReaderWithFd(int fd, AudioReaderType type, std::error_code* ec = nullptr);
 
 } // namespace sfz


### PR DESCRIPTION
Implements the benchmark without using the sndfile "fd" API.
This uses system-dependent temporary file APIs.

```
2020-10-05T19:02:30+02:00
Running ./build/benchmarks/bm_audioReaders
Run on (8 X 3600 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 64 KiB (x4)
  L2 Unified 512 KiB (x4)
  L3 Unified 4096 KiB (x1)
Load Average: 2.16, 2.15, 2.17
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
AudioReaderFixture/ForwardWav/64       3521251 ns      3786957 ns          194
AudioReaderFixture/ForwardWav/128      2490579 ns      2690127 ns          296
AudioReaderFixture/ForwardWav/256      1778428 ns      1928346 ns          326
AudioReaderFixture/ForwardWav/512      1519909 ns      1643014 ns          435
AudioReaderFixture/ForwardWav/1024     1256620 ns      1361589 ns          453
AudioReaderFixture/ReverseWav/64       5991915 ns      6483079 ns           92
AudioReaderFixture/ReverseWav/128      4283389 ns      4702852 ns          145
AudioReaderFixture/ReverseWav/256      2873490 ns      3099028 ns          214
AudioReaderFixture/ReverseWav/512      2017710 ns      2171451 ns          325
AudioReaderFixture/ReverseWav/1024     1576041 ns      1693153 ns          364
AudioReaderFixture/EntireWav/1         2284620 ns      2454901 ns          256
AudioReaderFixture/ForwardFlac/64     11191259 ns     12156809 ns           68
AudioReaderFixture/ForwardFlac/128    10878925 ns     12127207 ns           70
AudioReaderFixture/ForwardFlac/256    12668212 ns     13927451 ns           53
AudioReaderFixture/ForwardFlac/512    12008224 ns     13295216 ns           59
AudioReaderFixture/ForwardFlac/1024   11370471 ns     12429546 ns           58
AudioReaderFixture/ReverseFlac/64    830275598 ns    904964751 ns            1
AudioReaderFixture/ReverseFlac/128   451794567 ns    500996439 ns            2
AudioReaderFixture/ReverseFlac/256   237033493 ns    259042225 ns            3
AudioReaderFixture/ReverseFlac/512   111708191 ns    124243552 ns            5
AudioReaderFixture/ReverseFlac/1024   67172820 ns     72990676 ns            8
AudioReaderFixture/EntireFlac/1       12170580 ns     13114561 ns           49
AudioReaderFixture/ForwardOgg/64      16495267 ns     18134861 ns           39
AudioReaderFixture/ForwardOgg/128     14966011 ns     16281466 ns           40
AudioReaderFixture/ForwardOgg/256     15045916 ns     16679321 ns           35
AudioReaderFixture/ForwardOgg/512     14904838 ns     16561429 ns           37
AudioReaderFixture/ForwardOgg/1024    14623176 ns     16147773 ns           51
AudioReaderFixture/EntireOgg/1        18186608 ns     19693445 ns           31
```