### PR TITLE
Overflow voices

### DIFF
--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -131,6 +131,13 @@ namespace config {
     static constexpr int loopXfadeCurve = 2;    // 0: linear
                                                 // 1: use curves 5 & 6
                                                 // 2: use S-shaped curve
+    /**
+     * @brief Overflow voices in the engine, relative to the required voices.
+     * These are additional voices that more or less hold the "dying" voices
+     * due to engine polyphony being reached.
+     */
+    static constexpr float overflowVoiceMultiplier { 1.5f };
+    static_assert(overflowVoiceMultiplier >= 1.0f);
 } // namespace config
 
 } // namespace sfz

--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -137,7 +137,7 @@ namespace config {
      * due to engine polyphony being reached.
      */
     static constexpr float overflowVoiceMultiplier { 1.5f };
-    static_assert(overflowVoiceMultiplier >= 1.0f);
+    static_assert(overflowVoiceMultiplier >= 1.0f, "This needs to add voices");
 } // namespace config
 
 } // namespace sfz

--- a/src/sfizz/RegionSet.cpp
+++ b/src/sfizz/RegionSet.cpp
@@ -53,3 +53,8 @@ unsigned sfz::RegionSet::numPlayingVoices() const noexcept
         return !v->releasedOrFree();
     });
 }
+
+void sfz::RegionSet::removeAllVoices() noexcept
+{
+    voices.clear();
+}

--- a/src/sfizz/RegionSet.h
+++ b/src/sfizz/RegionSet.h
@@ -122,6 +122,11 @@ public:
      * @return const std::vector<RegionSet*>&
      */
     const std::vector<RegionSet*>& getSubsets() const noexcept { return subsets; }
+
+    /**
+     * @brief Remove all voices from the set
+     */
+    void removeAllVoices() noexcept;
 private:
     RegionSet* parent { nullptr };
     OpcodeScope level { kOpcodeScopeGeneric };

--- a/src/sfizz/SisterVoiceRing.h
+++ b/src/sfizz/SisterVoiceRing.h
@@ -61,13 +61,14 @@ struct SisterVoiceRing {
      *
      * @param voice
      * @param delay
+     * @param fast whether to apply a fast release
      */
     template<class T,
         absl::enable_if_t<std::is_same<Voice, absl::remove_const_t<T>>::value, int> = 0>
-    static void offAllSisters(T* voice, int delay) {
+    static void offAllSisters(T* voice, int delay, bool fast = false) {
         if (voice != nullptr) {
             SisterVoiceRing::applyToRing(voice, [&] (Voice* v) {
-                v->off(delay);
+                v->off(delay, fast);
             });
         }
     }

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -819,6 +819,9 @@ private:
     // These are more general "groups" than sfz and encapsulates the full hierarchy
     RegionSet* currentSet { nullptr };
     std::vector<RegionSetPtr> sets;
+    // This region set holds the engine set of voices, which tries to respect the required
+    // engine polyphony
+    RegionSetPtr engineSet;
 
     // These are the `group=` groups where you can off voices
     std::vector<PolyphonyGroup> polyphonyGroups;
@@ -902,7 +905,8 @@ private:
     int samplesPerBlock { config::defaultSamplesPerBlock };
     float sampleRate { config::defaultSampleRate };
     float volume { Default::globalVolume };
-    int numVoices { config::numVoices };
+    int numRequiredVoices { config::numVoices };
+    int numActualVoices { static_cast<int>(config::numVoices * config::overflowVoiceMultiplier) };
     int activeVoices { 0 };
     Oversampling oversamplingFactor { config::defaultOversamplingFactor };
 

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -742,13 +742,10 @@ private:
     void setupModMatrix();
 
     /**
-     * @brief Render the voice to its designated outputs and effect busses.
+     * @brief Get the modification time of all included sfz files
      *
-     * @param voice
-     * @param tempSpan a temporary span used for rendering
+     * @return fs::file_time_type
      */
-    void renderVoiceToOutputs(Voice& voice, AudioSpan<float>& tempSpan) noexcept;
-
     fs::file_time_type checkModificationTime();
 
     /**

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -866,6 +866,13 @@ private:
     void checkSetPolyphony(const Region* region, int delay) noexcept;
 
     /**
+     * @brief Check the engine polyphony, fast releasing voices if necessary
+     *
+     * @param delay
+     */
+    void checkEnginePolyphony(int delay) noexcept;
+
+    /**
      * @brief Start a voice for a specific region.
      * This will do the needed polyphony checks and voice stealing.
      *

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -167,11 +167,11 @@ void sfz::Voice::release(int delay) noexcept
     resources.modMatrix.releaseVoice(id, region->getId(), delay);
 }
 
-void sfz::Voice::off(int delay) noexcept
+void sfz::Voice::off(int delay, bool fast) noexcept
 {
     if (!region->flexAmpEG) {
-        if (region->offMode == SfzOffMode::fast) {
-            egAmplitude.setReleaseTime( Default::offTime );
+        if (region->offMode == SfzOffMode::fast || fast) {
+            egAmplitude.setReleaseTime(Default::offTime);
         } else if (region->offMode == SfzOffMode::time) {
             egAmplitude.setReleaseTime(region->offTime);
         }

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -328,8 +328,9 @@ public:
      *      and set the envelopes if necessary.
      *
      * @param delay
+     * @param fast whether to apply a fast release regardless of the off mode
      */
-    void off(int delay) noexcept;
+    void off(int delay, bool fast = false) noexcept;
 
     /**
      * @brief gets the age of the Voice


### PR DESCRIPTION
This creates more voices that asked for using `setNumVoices(...)` for example. These "overflow" voices participate in the usual rendering, but a polyphony check is done so that the "required" number of voices is not reached. When the "required" polyphony is reached, stolen voices will be fast released, which avoids most clicking.

This solves a corruption problem lingering in the previous version due to the fact that before, stolen voices due to engine polyphony limits were rendered outside of the normal operation of the modulation matrix, leading to weird issues.