### PR TITLE
accept samplesPerBlock up to 8192 (inclusive)

### DIFF
--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -776,7 +776,7 @@ void sfz::Synth::garbageCollect() noexcept
 
 void sfz::Synth::setSamplesPerBlock(int samplesPerBlock) noexcept
 {
-    ASSERT(samplesPerBlock < config::maxBlockSize);
+    ASSERT(samplesPerBlock <= config::maxBlockSize);
 
     const std::lock_guard<SpinMutex> disableCallback { callbackGuard };
 


### PR DESCRIPTION
`ASSERT(samplesPerBlock < config::maxBlockSize)` (where `maxBlockSize` is 8192) means 
we cannot set 8192. But we don't want 8191 as the actual maximum size.