### PR TITLE
Modulation spans

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,7 @@ set (SFIZZ_HEADERS
     sfizz/MathHelpers.h
     sfizz/MidiState.h
     sfizz/ModifierHelpers.h
+    sfizz/ModulationSpan.h
     sfizz/OnePoleFilter.h
     sfizz/Oversampler.h
     sfizz/Panning.h

--- a/src/sfizz/FlexEnvelope.h
+++ b/src/sfizz/FlexEnvelope.h
@@ -5,6 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #pragma once
+#include "ModulationSpan.h"
 #include <absl/types/span.h>
 #include <memory>
 
@@ -58,7 +59,7 @@ public:
     /**
        Process a cycle of the generator.
      */
-    void process(absl::Span<float> out);
+    ModulationSpan process(absl::Span<float> out);
 
 private:
     struct Impl;

--- a/src/sfizz/LFO.h
+++ b/src/sfizz/LFO.h
@@ -5,6 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #pragma once
+#include "ModulationSpan.h"
 #include <absl/types/span.h>
 #include <memory>
 
@@ -74,7 +75,7 @@ public:
 
        TODO(jpc) frequency modulations
      */
-    void process(absl::Span<float> out);
+    ModulationSpan process(absl::Span<float> out);
 
 private:
     /**

--- a/src/sfizz/ModulationSpan.h
+++ b/src/sfizz/ModulationSpan.h
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include <absl/types/span.h>
+#include <cstddef>
+
+namespace sfz {
+
+/**
+ * @brief A modulation span stores the result of a modulation generator.
+ *
+ * If the result is none (does not modulate), the bool operator returns false.
+ *
+ * Otherwise, the * operator returns a span.
+ * In addition, if the modulation is invariant over the entire time span,
+ * the generator can mark the modulation as such, in order to enable more
+ * efficient code paths.
+ */
+class ModulationSpan {
+public:
+    constexpr ModulationSpan() noexcept = default;
+
+    enum {
+        kInvariant = 1 << 0,
+    };
+
+    explicit ModulationSpan(absl::Span<const float> span, int flags = 0)
+        : ModulationSpan(span.data(), span.size(), flags)
+    {
+    }
+    ModulationSpan(const float* data, size_t size, int flags = 0)
+        : data_(data), size_(size), flags_(flags)
+    {
+    }
+
+    explicit operator bool() const noexcept
+    {
+        return data_ != nullptr;
+    }
+
+    absl::Span<const float> operator*() const noexcept
+    {
+        return { data_, size_ };
+    }
+
+    bool isInvariant() const noexcept
+    {
+        return (flags_ & kInvariant) != 0;
+    }
+
+private:
+    const float* data_ = nullptr;
+    size_t size_ = 0;
+    int flags_ = 0;
+};
+
+} // namespace sfz

--- a/src/sfizz/Smoothers.h
+++ b/src/sfizz/Smoothers.h
@@ -45,8 +45,9 @@ public:
      * @param canShortcut whether we can have a fast path if the filter is within
      *                    a reasonable range around the first value of the input
      *                    span.
+     * @return whether the process did shortcut.
      */
-    void process(absl::Span<const float> input, absl::Span<float> output, bool canShortcut = false);
+    bool process(absl::Span<const float> input, absl::Span<float> output, bool canShortcut = false);
 
     float current() const { return filter.current(); }
 private:

--- a/src/sfizz/modulations/ModGenerator.h
+++ b/src/sfizz/modulations/ModGenerator.h
@@ -5,6 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #pragma once
+#include "ModulationSpan.h"
 #include "utility/NumericId.h"
 #include <absl/types/span.h>
 #include <cstdint>
@@ -55,8 +56,9 @@ public:
      * @param sourceKey source key
      * @param voiceNum voice number if the generator is per-voice, otherwise undefined
      * @param buffer output buffer
+     * @return modulation span
      */
-    virtual void generate(const ModKey& sourceKey, NumericId<Voice> voiceNum, absl::Span<float> buffer) = 0;
+    virtual ModulationSpan generate(const ModKey& sourceKey, NumericId<Voice> voiceNum, absl::Span<float> buffer) = 0;
 
     /**
      * @brief Advance the generator by a number of frames

--- a/src/sfizz/modulations/sources/ADSREnvelope.cpp
+++ b/src/sfizz/modulations/sources/ADSREnvelope.cpp
@@ -94,14 +94,15 @@ void ADSREnvelopeSource::release(const ModKey& sourceKey, NumericId<Voice> voice
     eg->startRelease(delay);
 }
 
-void ADSREnvelopeSource::generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer)
+ModulationSpan ADSREnvelopeSource::generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer)
 {
     Synth& synth = *synth_;
 
     Voice* voice = synth.getVoiceById(voiceId);
     if (!voice) {
         ASSERTFALSE;
-        return;
+        fill(buffer, 0.0f);
+        return ModulationSpan(buffer, ModulationSpan::kInvariant);
     }
 
     ADSREnvelope<float>* eg = nullptr;
@@ -121,10 +122,12 @@ void ADSREnvelopeSource::generate(const ModKey& sourceKey, NumericId<Voice> voic
         break;
     default:
         ASSERTFALSE;
-        return;
+        fill(buffer, 0.0f);
+        return ModulationSpan(buffer, ModulationSpan::kInvariant);
     }
 
     eg->getBlock(buffer);
+    return ModulationSpan(buffer);
 }
 
 } // namespace sfz

--- a/src/sfizz/modulations/sources/ADSREnvelope.h
+++ b/src/sfizz/modulations/sources/ADSREnvelope.h
@@ -15,7 +15,7 @@ public:
     explicit ADSREnvelopeSource(Synth &synth);
     void init(const ModKey& sourceKey, NumericId<Voice> voiceId, unsigned delay) override;
     void release(const ModKey& sourceKey, NumericId<Voice> voiceId, unsigned delay) override;
-    void generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer) override;
+    ModulationSpan generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer) override;
 
 private:
     Synth* synth_ = nullptr;

--- a/src/sfizz/modulations/sources/Controller.h
+++ b/src/sfizz/modulations/sources/Controller.h
@@ -19,7 +19,7 @@ public:
     void setSampleRate(double sampleRate) override;
     void setSamplesPerBlock(unsigned count) override;
     void init(const ModKey& sourceKey, NumericId<Voice> voiceId, unsigned delay) override;
-    void generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer) override;
+    ModulationSpan generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer) override;
 
 private:
     struct Impl;

--- a/src/sfizz/modulations/sources/FlexEnvelope.cpp
+++ b/src/sfizz/modulations/sources/FlexEnvelope.cpp
@@ -62,7 +62,7 @@ void FlexEnvelopeSource::release(const ModKey& sourceKey, NumericId<Voice> voice
     eg->release(delay);
 }
 
-void FlexEnvelopeSource::generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer)
+ModulationSpan FlexEnvelopeSource::generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer)
 {
     Synth& synth = *synth_;
     unsigned egIndex = sourceKey.parameters().N;
@@ -70,17 +70,19 @@ void FlexEnvelopeSource::generate(const ModKey& sourceKey, NumericId<Voice> voic
     Voice* voice = synth.getVoiceById(voiceId);
     if (!voice) {
         ASSERTFALSE;
-        return;
+        fill(buffer, 0.0f);
+        return ModulationSpan(buffer, ModulationSpan::kInvariant);
     }
 
     const Region* region = voice->getRegion();
     if (egIndex >= region->flexEGs.size()) {
         ASSERTFALSE;
-        return;
+        fill(buffer, 0.0f);
+        return ModulationSpan(buffer, ModulationSpan::kInvariant);
     }
 
     FlexEnvelope* eg = voice->getFlexEG(egIndex);
-    eg->process(buffer);
+    return eg->process(buffer);
 }
 
 } // namespace sfz

--- a/src/sfizz/modulations/sources/FlexEnvelope.h
+++ b/src/sfizz/modulations/sources/FlexEnvelope.h
@@ -15,7 +15,7 @@ public:
     explicit FlexEnvelopeSource(Synth &synth);
     void init(const ModKey& sourceKey, NumericId<Voice> voiceId, unsigned delay) override;
     void release(const ModKey& sourceKey, NumericId<Voice> voiceId, unsigned delay) override;
-    void generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer) override;
+    ModulationSpan generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer) override;
 
 private:
     Synth* synth_ = nullptr;

--- a/src/sfizz/modulations/sources/LFO.cpp
+++ b/src/sfizz/modulations/sources/LFO.cpp
@@ -41,7 +41,7 @@ void LFOSource::init(const ModKey& sourceKey, NumericId<Voice> voiceId, unsigned
     lfo->start(delay);
 }
 
-void LFOSource::generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer)
+ModulationSpan LFOSource::generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer)
 {
     Synth& synth = *synth_;
     const unsigned lfoIndex = sourceKey.parameters().N;
@@ -50,18 +50,18 @@ void LFOSource::generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl
     if (!voice) {
         ASSERTFALSE;
         fill(buffer, 0.0f);
-        return;
+        return ModulationSpan(buffer, ModulationSpan::kInvariant);
     }
 
     const Region* region = voice->getRegion();
     if (lfoIndex >= region->lfos.size()) {
         ASSERTFALSE;
         fill(buffer, 0.0f);
-        return;
+        return ModulationSpan(buffer, ModulationSpan::kInvariant);
     }
 
     LFO* lfo = voice->getLFO(lfoIndex);
-    lfo->process(buffer);
+    return lfo->process(buffer);
 }
 
 } // namespace sfz

--- a/src/sfizz/modulations/sources/LFO.h
+++ b/src/sfizz/modulations/sources/LFO.h
@@ -14,7 +14,7 @@ class LFOSource : public ModGenerator {
 public:
     explicit LFOSource(Synth &synth);
     void init(const ModKey& sourceKey, NumericId<Voice> voiceId, unsigned delay) override;
-    void generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer) override;
+    ModulationSpan generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer) override;
 
 private:
     Synth* synth_ = nullptr;


### PR DESCRIPTION
This is the introduction of a new concept, yet to be implement in MM. The idea is as follows:

We desire a generic helper that would enable shortcuts in case modulations are invariant signals.
refer to the file `ModulationSpan.h`

This avoids a code repetition at use sites of modulation, that go like:
- if the modulation is varying, multiply it with my signal
- otherwise, if it's ones, do nothing
- otherwise, if it's zeros, clear
- otherwise, `multiply1` signal with the scalar

While it's not yet implemented, the idea is we may write in one line all above operations
`modulationSpan.multiply(buffer)`
