### PR TITLE
Do not force a vcpkg update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,10 @@ install:
 - cmd: set PATH=C:\Program Files (x86)\Inno Setup 6;%PATH%
 - cmd: if %platform%==Win32 set VCPKG_TRIPLET=x86-windows-static
 - cmd: if %platform%==x64   set VCPKG_TRIPLET=x64-windows-static
-- cmd: cd c:\tools\vcpkg\
-- cmd: git pull
-- cmd: .\bootstrap-vcpkg.bat
-- cmd: cd %APPVEYOR_BUILD_FOLDER%
+# - cmd: cd c:\tools\vcpkg\
+# - cmd: git pull
+# - cmd: .\bootstrap-vcpkg.bat
+# - cmd: cd %APPVEYOR_BUILD_FOLDER%
 - cmd: vcpkg install libsndfile:%VCPKG_TRIPLET%
 
 before_build:


### PR DESCRIPTION
Skip updating vcpkg, in order to make Appveyor faster.
Uncomment the lines if it breaks again.