### PR TITLE
Set a fixed number of parallel tasks

### DIFF
--- a/.travis/script_library.sh
+++ b/.travis/script_library.sh
@@ -8,4 +8,4 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -DSFIZZ_TESTS=OFF \
       -DCMAKE_CXX_STANDARD=17 \
       ..
-make -j$(nproc)
+make -j2

--- a/.travis/script_mingw.sh
+++ b/.travis/script_mingw.sh
@@ -12,7 +12,7 @@ if [[ ${CROSS_COMPILE} == "mingw32" ]]; then
                                   -DSFIZZ_STATIC_DEPENDENCIES=ON \
                                   -DCMAKE_CXX_STANDARD=17 \
                                   ..
-  buildenv make -j$(nproc)
+  buildenv make -j2
 elif [[ ${CROSS_COMPILE} == "mingw64" ]]; then
   buildenv x86_64-w64-mingw32-cmake -DCMAKE_BUILD_TYPE=Release \
                                     -DENABLE_LTO=OFF \
@@ -21,5 +21,5 @@ elif [[ ${CROSS_COMPILE} == "mingw64" ]]; then
                                     -DSFIZZ_STATIC_DEPENDENCIES=ON \
                                     -DCMAKE_CXX_STANDARD=17 \
                                     ..
-  buildenv make -j$(nproc)
+  buildenv make -j2
 fi

--- a/.travis/script_moddevices.sh
+++ b/.travis/script_moddevices.sh
@@ -8,4 +8,4 @@ mkdir -p build/${INSTALL_DIR} && cd build
 buildenv mod-plugin-builder /usr/local/bin/cmake \
          -DSFIZZ_SYSTEM_PROCESSOR=armv7-a \
          -DCMAKE_BUILD_TYPE=Release -DSFIZZ_JACK=OFF -DSFIZZ_LV2_UI=OFF ..
-buildenv mod-plugin-builder make -j$(nproc)
+buildenv mod-plugin-builder make -j2

--- a/.travis/script_plugins.sh
+++ b/.travis/script_plugins.sh
@@ -11,4 +11,4 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -DSFIZZ_STATIC_DEPENDENCIES=ON \
       -DCMAKE_CXX_STANDARD=17 \
       ..
-make -j$(nproc)
+make -j2

--- a/.travis/script_test.sh
+++ b/.travis/script_test.sh
@@ -10,5 +10,5 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -DSFIZZ_LV2=OFF \
       -DCMAKE_CXX_STANDARD=17 \
       ..
-make -j$(nproc) sfizz_tests
+make -j2 sfizz_tests
 tests/sfizz_tests


### PR DESCRIPTION
In arm64 context, the value of `nproc` is 32.
This is the probable reason why these travis builds are crashing.