### PR TITLE
Add a mutex on the loading jobs to protect them in the case of freewheeling

### DIFF
--- a/src/sfizz/FilePool.cpp
+++ b/src/sfizz/FilePool.cpp
@@ -485,7 +485,7 @@ void sfz::FilePool::dispatchingJob() noexcept
 
         // Clear finished jobs
         swapAndPopAll(loadingJobs, [](std::future<void>& future) {
-            return future.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+            return is_ready(future);
         });
     }
 }

--- a/src/sfizz/FilePool.cpp
+++ b/src/sfizz/FilePool.cpp
@@ -482,6 +482,7 @@ void sfz::FilePool::dispatchingJob() noexcept
         }
 
         // Clear finished jobs
+        std::lock_guard<SpinMutex> guard { loadingJobsMutex };
         swapAndPopAll(loadingJobs, [](std::future<void>& future) {
             return future.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
         });
@@ -515,8 +516,11 @@ void sfz::FilePool::emptyFileLoadingQueues() noexcept
 
 void sfz::FilePool::waitForBackgroundLoading() noexcept
 {
+    std::lock_guard<SpinMutex> guard { loadingJobsMutex };
+
     for (auto& job : loadingJobs)
         job.wait();
+
     loadingJobs.clear();
 }
 

--- a/src/sfizz/FilePool.cpp
+++ b/src/sfizz/FilePool.cpp
@@ -476,7 +476,7 @@ void sfz::FilePool::dispatchingJob() noexcept
             continue;
         }
 
-        std::lock_guard<SpinMutex> guard { loadingJobsMutex };
+        std::lock_guard<std::mutex> guard { loadingJobsMutex };
         
         if (filesToLoad.try_pop(queuedData)) {
             loadingJobs.push_back(
@@ -517,7 +517,7 @@ void sfz::FilePool::emptyFileLoadingQueues() noexcept
 
 void sfz::FilePool::waitForBackgroundLoading() noexcept
 {
-    std::lock_guard<SpinMutex> guard { loadingJobsMutex };
+    std::lock_guard<std::mutex> guard { loadingJobsMutex };
 
     for (auto& job : loadingJobs)
         job.wait();

--- a/src/sfizz/FilePool.h
+++ b/src/sfizz/FilePool.h
@@ -354,7 +354,7 @@ private:
     void dispatchingJob() noexcept;
     void garbageJob() noexcept;
     void loadingJob(QueuedFileData data) noexcept;
-    SpinMutex loadingJobsMutex;
+    std::mutex loadingJobsMutex;
     std::vector<std::future<void>> loadingJobs;
     std::thread dispatchThread { &FilePool::dispatchingJob, this };
     std::thread garbageThread { &FilePool::garbageJob, this };

--- a/src/sfizz/FilePool.h
+++ b/src/sfizz/FilePool.h
@@ -354,6 +354,7 @@ private:
     void dispatchingJob() noexcept;
     void garbageJob() noexcept;
     void loadingJob(QueuedFileData data) noexcept;
+    SpinMutex loadingJobsMutex;
     std::vector<std::future<void>> loadingJobs;
     std::thread dispatchThread { &FilePool::dispatchingJob, this };
     std::thread garbageThread { &FilePool::garbageJob, this };


### PR DESCRIPTION
Seemed to create alot of problems for ARM builds which hit the race condition all the time.