### PR TITLE
Version bump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
     endif()
 endif()
 
-project (sfizz VERSION 0.4.1 LANGUAGES CXX C)
+project (sfizz VERSION 0.5.0 LANGUAGES CXX C)
 set (PROJECT_DESCRIPTION "A library to load SFZ description files and use them to render music.")
 
 # External configuration CMake scripts

--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -46,7 +46,7 @@ typedef enum {
 
 /**
  * @brief Processing mode
- * @since 0.4.1
+ * @since 0.5.0
  */
 typedef enum {
     SFIZZ_PROCESS_LIVE,
@@ -356,7 +356,7 @@ SFIZZ_EXPORTED_API void sfizz_send_tempo(sfizz_synth_t* synth, int delay, float 
 
 /**
  * @brief Send the time signature.
- * @since 0.4.1
+ * @since 0.5.0
  *
  * @param synth          The synth.
  * @param delay          The delay.
@@ -367,7 +367,7 @@ SFIZZ_EXPORTED_API void sfizz_send_time_signature(sfizz_synth_t* synth, int dela
 
 /**
  * @brief Send the time position.
- * @since 0.4.1
+ * @since 0.5.0
  *
  * @param synth     The synth.
  * @param delay     The delay.
@@ -378,7 +378,7 @@ SFIZZ_EXPORTED_API void sfizz_send_time_position(sfizz_synth_t* synth, int delay
 
 /**
  * @brief Send the playback state.
- * @since 0.4.1
+ * @since 0.5.0
  *
  * @param synth           The synth.
  * @param delay           The delay.

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -326,7 +326,7 @@ public:
 
     /**
      * @brief Send the time signature.
-     * @since 0.4.1
+     * @since 0.5.0
      *
      * @param delay       The delay.
      * @param beatsPerBar The number of beats per bar, or time signature numerator.
@@ -336,7 +336,7 @@ public:
 
     /**
      * @brief Send the time position.
-     * @since 0.4.1
+     * @since 0.5.0
      *
      * @param delay   The delay.
      * @param bar     The current bar.
@@ -346,7 +346,7 @@ public:
 
     /**
      * @brief Send the playback state.
-     * @since 0.4.1
+     * @since 0.5.0
      *
      * @param delay         The delay.
      * @param playbackState The playback state, 1 if playing, 0 if stopped.


### PR DESCRIPTION
Update the version number to 0.5.0
- project version in cmake
- no LV2 interface updates, no micro version bump (UI doesn't count)
- not VST interface updates
- update `@since 0.4.1` → `@since 0.5.0`, because 0.4.1 was skipped
