### PR TITLE
Fix race conditions (2)

### DIFF
--- a/src/sfizz/FilePool.cpp
+++ b/src/sfizz/FilePool.cpp
@@ -496,7 +496,7 @@ void sfz::FilePool::dispatchingJob() noexcept
         std::lock_guard<std::mutex> guard { loadingJobsMutex };
 
         if (filesToLoad.try_pop(queuedData)) {
-            if (!queuedData.id.lock()) {
+            if (queuedData.id.expired()) {
                 // file ID was nulled, it means the region was deleted, ignore
             }
             else

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -75,7 +75,7 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
             else
                 filename = absl::StrCat(defaultPath, absl::StrReplaceAll(trimmedSample, { { "\\", "/" } }));
 
-            sampleId = FileId(std::move(filename), sampleId.isReverse());
+            *sampleId = FileId(std::move(filename), sampleId->isReverse());
         }
         break;
     case hash("sample_quality"):
@@ -88,7 +88,7 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
         }
         break;
     case hash("direction"):
-        sampleId = sampleId.reversed(opcode.value == "reverse");
+        *sampleId = sampleId->reversed(opcode.value == "reverse");
         break;
     case hash("delay"):
         setValueFromOpcode(opcode, delay, Default::delayRange);

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -78,7 +78,7 @@ struct Region {
      * @return true
      * @return false
      */
-    bool isGenerator() const noexcept { return sampleId.filename().size() > 0 ? sampleId.filename()[0] == '*' : false; }
+    bool isGenerator() const noexcept { return sampleId->filename().size() > 0 ? sampleId->filename()[0] == '*' : false; }
     /**
      * @brief Is an oscillator (generator or wavetable)?
      *
@@ -308,7 +308,7 @@ struct Region {
     const NumericId<Region> id;
 
     // Sound source: sample playback
-    FileId sampleId {}; // Sample
+    std::shared_ptr<FileId> sampleId { new FileId }; // Sample
     absl::optional<int> sampleQuality {};
     float delay { Default::delay }; // delay
     float delayRandom { Default::delayRandom }; // delay_random

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -514,7 +514,7 @@ void sfz::Synth::finalizeSfzLoad()
     size_t currentRegionCount = regions.size();
 
     auto removeCurrentRegion = [this, &currentRegionIndex, &currentRegionCount]() {
-        DBG("Removing the region with sample " << regions[currentRegionIndex]->sampleId);
+        DBG("Removing the region with sample " << *regions[currentRegionIndex]->sampleId);
         regions.erase(regions.begin() + currentRegionIndex);
         --currentRegionCount;
     };
@@ -534,12 +534,12 @@ void sfz::Synth::finalizeSfzLoad()
         absl::optional<FileInformation> fileInformation;
 
         if (!region->isGenerator()) {
-            if (!resources.filePool.checkSampleId(region->sampleId)) {
+            if (!resources.filePool.checkSampleId(*region->sampleId)) {
                 removeCurrentRegion();
                 continue;
             }
 
-            fileInformation = resources.filePool.getFileInformation(region->sampleId);
+            fileInformation = resources.filePool.getFileInformation(*region->sampleId);
             if (!fileInformation) {
                 removeCurrentRegion();
                 continue;
@@ -583,11 +583,11 @@ void sfz::Synth::finalizeSfzLoad()
                 return Default::offsetCCRange.clamp(sumOffsetCC);
             }();
 
-            if (!resources.filePool.preloadFile(region->sampleId, maxOffset))
+            if (!resources.filePool.preloadFile(*region->sampleId, maxOffset))
                 removeCurrentRegion();
         }
         else if (!region->isGenerator()) {
-            if (!resources.wavePool.createFileWave(resources.filePool, std::string(region->sampleId.filename()))) {
+            if (!resources.wavePool.createFileWave(resources.filePool, std::string(region->sampleId->filename()))) {
                 removeCurrentRegion();
                 continue;
             }

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -94,7 +94,7 @@ void sfz::Voice::startVoice(Region* region, int delay, const TriggerEvent& event
         }
         setupOscillatorUnison();
     } else {
-        currentPromise = resources.filePool.getFilePromise(*region->sampleId);
+        currentPromise = resources.filePool.getFilePromise(region->sampleId);
         if (!currentPromise) {
             switchState(State::cleanMeUp);
             return;

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -64,9 +64,9 @@ void sfz::Voice::startVoice(Region* region, int delay, const TriggerEvent& event
     if (region->isOscillator()) {
         const WavetableMulti* wave = nullptr;
         if (!region->isGenerator())
-            wave = resources.wavePool.getFileWave(region->sampleId.filename());
+            wave = resources.wavePool.getFileWave(region->sampleId->filename());
         else {
-            switch (hash(region->sampleId.filename())) {
+            switch (hash(region->sampleId->filename())) {
             default:
             case hash("*silence"):
                 break;
@@ -94,7 +94,7 @@ void sfz::Voice::startVoice(Region* region, int delay, const TriggerEvent& event
         }
         setupOscillatorUnison();
     } else {
-        currentPromise = resources.filePool.getFilePromise(region->sampleId);
+        currentPromise = resources.filePool.getFilePromise(*region->sampleId);
         if (!currentPromise) {
             switchState(State::cleanMeUp);
             return;
@@ -658,7 +658,7 @@ void sfz::Voice::fillWithData(AudioSpan<float> buffer) noexcept
                     DBG("[sfizz] Underflow: source available samples "
                         << source.getNumFrames() << "/"
                         << currentPromise->information.end
-                        << " for sample " << region->sampleId);
+                        << " for sample " << *region->sampleId);
                 }
 #endif
                 if (!region->flexAmpEG) {
@@ -891,13 +891,13 @@ void sfz::Voice::fillWithGenerator(AudioSpan<float> buffer) noexcept
     const auto leftSpan = buffer.getSpan(0);
     const auto rightSpan  = buffer.getSpan(1);
 
-    if (region->sampleId.filename() == "*noise") {
+    if (region->sampleId->filename() == "*noise") {
         auto gen = [&]() {
             return uniformNoiseDist(Random::randomGenerator);
         };
         absl::c_generate(leftSpan, gen);
         absl::c_generate(rightSpan, gen);
-    } else if (region->sampleId.filename() == "*gnoise") {
+    } else if (region->sampleId->filename() == "*gnoise") {
         // You need to wrap in a lambda, otherwise generate will
         // make a copy of the gaussian distribution *along with its state*
         // leading to periodic behavior....

--- a/tests/FilesT.cpp
+++ b/tests/FilesT.cpp
@@ -23,7 +23,7 @@ TEST_CASE("[Files] Single region (regions_one.sfz)")
     Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Regions/regions_one.sfz");
     REQUIRE(synth.getNumRegions() == 1);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == "dummy.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == "dummy.wav");
 }
 
 
@@ -32,9 +32,9 @@ TEST_CASE("[Files] Multiple regions (regions_many.sfz)")
     Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Regions/regions_many.sfz");
     REQUIRE(synth.getNumRegions() == 3);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == "dummy.wav");
-    REQUIRE(synth.getRegionView(1)->sampleId.filename() == "dummy.1.wav");
-    REQUIRE(synth.getRegionView(2)->sampleId.filename() == "dummy.2.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == "dummy.wav");
+    REQUIRE(synth.getRegionView(1)->sampleId->filename() == "dummy.1.wav");
+    REQUIRE(synth.getRegionView(2)->sampleId->filename() == "dummy.2.wav");
 }
 
 TEST_CASE("[Files] Basic opcodes (regions_opcodes.sfz)")
@@ -58,8 +58,8 @@ TEST_CASE("[Files] (regions_bad.sfz)")
     Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Regions/regions_bad.sfz");
     REQUIRE(synth.getNumRegions() == 2);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == "dummy.wav");
-    REQUIRE(synth.getRegionView(1)->sampleId.filename() == "dummy.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == "dummy.wav");
+    REQUIRE(synth.getRegionView(1)->sampleId->filename() == "dummy.wav");
 }
 
 TEST_CASE("[Files] Local include")
@@ -67,7 +67,7 @@ TEST_CASE("[Files] Local include")
     Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Includes/root_local.sfz");
     REQUIRE(synth.getNumRegions() == 1);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == "dummy.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == "dummy.wav");
 }
 
 TEST_CASE("[Files] Multiple includes")
@@ -75,8 +75,8 @@ TEST_CASE("[Files] Multiple includes")
     Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Includes/multiple_includes.sfz");
     REQUIRE(synth.getNumRegions() == 2);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == "dummy.wav");
-    REQUIRE(synth.getRegionView(1)->sampleId.filename() == "dummy2.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == "dummy.wav");
+    REQUIRE(synth.getRegionView(1)->sampleId->filename() == "dummy2.wav");
 }
 
 TEST_CASE("[Files] Multiple includes with comments")
@@ -84,8 +84,8 @@ TEST_CASE("[Files] Multiple includes with comments")
     Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Includes/multiple_includes_with_comments.sfz");
     REQUIRE(synth.getNumRegions() == 2);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == "dummy.wav");
-    REQUIRE(synth.getRegionView(1)->sampleId.filename() == "dummy2.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == "dummy.wav");
+    REQUIRE(synth.getRegionView(1)->sampleId->filename() == "dummy2.wav");
 }
 
 TEST_CASE("[Files] Subdir include")
@@ -93,7 +93,7 @@ TEST_CASE("[Files] Subdir include")
     Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Includes/root_subdir.sfz");
     REQUIRE(synth.getNumRegions() == 1);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == "dummy_subdir.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == "dummy_subdir.wav");
 }
 
 TEST_CASE("[Files] Subdir include Win")
@@ -101,7 +101,7 @@ TEST_CASE("[Files] Subdir include Win")
     Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Includes/root_subdir_win.sfz");
     REQUIRE(synth.getNumRegions() == 1);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == "dummy_subdir.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == "dummy_subdir.wav");
 }
 
 TEST_CASE("[Files] Recursive include (with include guard)")
@@ -111,8 +111,8 @@ TEST_CASE("[Files] Recursive include (with include guard)")
     parser.setRecursiveIncludeGuardEnabled(true);
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Includes/root_recursive.sfz");
     REQUIRE(synth.getNumRegions() == 2);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == "dummy_recursive2.wav");
-    REQUIRE(synth.getRegionView(1)->sampleId.filename() == "dummy_recursive1.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == "dummy_recursive2.wav");
+    REQUIRE(synth.getRegionView(1)->sampleId->filename() == "dummy_recursive1.wav");
 }
 
 TEST_CASE("[Files] Include loops (with include guard)")
@@ -122,8 +122,8 @@ TEST_CASE("[Files] Include loops (with include guard)")
     parser.setRecursiveIncludeGuardEnabled(true);
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/Includes/root_loop.sfz");
     REQUIRE(synth.getNumRegions() == 2);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == "dummy_loop2.wav");
-    REQUIRE(synth.getRegionView(1)->sampleId.filename() == "dummy_loop1.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == "dummy_loop2.wav");
+    REQUIRE(synth.getRegionView(1)->sampleId->filename() == "dummy_loop1.wav");
 }
 
 TEST_CASE("[Files] Define test")
@@ -209,28 +209,28 @@ TEST_CASE("[Files] Full hierarchy with antislashes")
         Synth synth;
         synth.loadSfzFile(fs::current_path() / "tests/TestFiles/basic_hierarchy.sfz");
         REQUIRE(synth.getNumRegions() == 8);
-        REQUIRE(synth.getRegionView(0)->sampleId.filename() == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(1)->sampleId.filename() == "Regions/dummy.1.wav");
-        REQUIRE(synth.getRegionView(2)->sampleId.filename() == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(3)->sampleId.filename() == "Regions/dummy.1.wav");
-        REQUIRE(synth.getRegionView(4)->sampleId.filename() == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(5)->sampleId.filename() == "Regions/dummy.1.wav");
-        REQUIRE(synth.getRegionView(6)->sampleId.filename() == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(7)->sampleId.filename() == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(0)->sampleId->filename() == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(1)->sampleId->filename() == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(2)->sampleId->filename() == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(3)->sampleId->filename() == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(4)->sampleId->filename() == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(5)->sampleId->filename() == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(6)->sampleId->filename() == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(7)->sampleId->filename() == "Regions/dummy.1.wav");
     }
 
     {
         Synth synth;
         synth.loadSfzFile(fs::current_path() / "tests/TestFiles/basic_hierarchy_antislash.sfz");
         REQUIRE(synth.getNumRegions() == 8);
-        REQUIRE(synth.getRegionView(0)->sampleId.filename() == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(1)->sampleId.filename() == "Regions/dummy.1.wav");
-        REQUIRE(synth.getRegionView(2)->sampleId.filename() == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(3)->sampleId.filename() == "Regions/dummy.1.wav");
-        REQUIRE(synth.getRegionView(4)->sampleId.filename() == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(5)->sampleId.filename() == "Regions/dummy.1.wav");
-        REQUIRE(synth.getRegionView(6)->sampleId.filename() == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(7)->sampleId.filename() == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(0)->sampleId->filename() == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(1)->sampleId->filename() == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(2)->sampleId->filename() == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(3)->sampleId->filename() == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(4)->sampleId->filename() == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(5)->sampleId->filename() == "Regions/dummy.1.wav");
+        REQUIRE(synth.getRegionView(6)->sampleId->filename() == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(7)->sampleId->filename() == "Regions/dummy.1.wav");
     }
 }
 
@@ -249,10 +249,10 @@ TEST_CASE("[Files] Pizz basic")
     REQUIRE(synth.getRegionView(1)->randRange == Range<float>(0.25, 0.5));
     REQUIRE(synth.getRegionView(2)->randRange == Range<float>(0.5, 0.75));
     REQUIRE(synth.getRegionView(3)->randRange == Range<float>(0.75, 1.0));
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == R"(../Samples/pizz/a0_vl4_rr1.wav)");
-    REQUIRE(synth.getRegionView(1)->sampleId.filename() == R"(../Samples/pizz/a0_vl4_rr2.wav)");
-    REQUIRE(synth.getRegionView(2)->sampleId.filename() == R"(../Samples/pizz/a0_vl4_rr3.wav)");
-    REQUIRE(synth.getRegionView(3)->sampleId.filename() == R"(../Samples/pizz/a0_vl4_rr4.wav)");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == R"(../Samples/pizz/a0_vl4_rr1.wav)");
+    REQUIRE(synth.getRegionView(1)->sampleId->filename() == R"(../Samples/pizz/a0_vl4_rr2.wav)");
+    REQUIRE(synth.getRegionView(2)->sampleId->filename() == R"(../Samples/pizz/a0_vl4_rr3.wav)");
+    REQUIRE(synth.getRegionView(3)->sampleId->filename() == R"(../Samples/pizz/a0_vl4_rr4.wav)");
 }
 
 TEST_CASE("[Files] Channels (channels.sfz)")
@@ -260,9 +260,9 @@ TEST_CASE("[Files] Channels (channels.sfz)")
     Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/channels.sfz");
     REQUIRE(synth.getNumRegions() == 2);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == "mono_sample.wav");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == "mono_sample.wav");
     REQUIRE(!synth.getRegionView(0)->isStereo());
-    REQUIRE(synth.getRegionView(1)->sampleId.filename() == "stereo_sample.wav");
+    REQUIRE(synth.getRegionView(1)->sampleId->filename() == "stereo_sample.wav");
     REQUIRE(synth.getRegionView(1)->isStereo());
 }
 
@@ -277,7 +277,7 @@ TEST_CASE("[Files] Channels (channels_multi.sfz)")
 
     // generator only
     region = synth.getRegionView(regionNumber++);
-    REQUIRE(region->sampleId.filename() == "*sine");
+    REQUIRE(region->sampleId->filename() == "*sine");
     REQUIRE(!region->isStereo());
     REQUIRE(region->isGenerator());
     REQUIRE(region->isOscillator());
@@ -285,7 +285,7 @@ TEST_CASE("[Files] Channels (channels_multi.sfz)")
 
     // generator with multi
     region = synth.getRegionView(regionNumber++);
-    REQUIRE(region->sampleId.filename() == "*sine");
+    REQUIRE(region->sampleId->filename() == "*sine");
     REQUIRE(region->isStereo());
     REQUIRE(region->isGenerator());
     REQUIRE(region->isOscillator());
@@ -293,7 +293,7 @@ TEST_CASE("[Files] Channels (channels_multi.sfz)")
 
     // explicit wavetable
     region = synth.getRegionView(regionNumber++);
-    REQUIRE(region->sampleId.filename() == "ramp_wave.wav");
+    REQUIRE(region->sampleId->filename() == "ramp_wave.wav");
     REQUIRE(!region->isStereo());
     REQUIRE(!region->isGenerator());
     REQUIRE(region->isOscillator());
@@ -301,7 +301,7 @@ TEST_CASE("[Files] Channels (channels_multi.sfz)")
 
     // explicit wavetable with multi
     region = synth.getRegionView(regionNumber++);
-    REQUIRE(region->sampleId.filename() == "ramp_wave.wav");
+    REQUIRE(region->sampleId->filename() == "ramp_wave.wav");
     REQUIRE(region->isStereo());
     REQUIRE(!region->isGenerator());
     REQUIRE(region->isOscillator());
@@ -309,7 +309,7 @@ TEST_CASE("[Files] Channels (channels_multi.sfz)")
 
     // explicit disabled wavetable
     region = synth.getRegionView(regionNumber++);
-    REQUIRE(region->sampleId.filename() == "ramp_wave.wav");
+    REQUIRE(region->sampleId->filename() == "ramp_wave.wav");
     REQUIRE(!region->isStereo());
     REQUIRE(!region->isGenerator());
     REQUIRE(!region->isOscillator());
@@ -317,7 +317,7 @@ TEST_CASE("[Files] Channels (channels_multi.sfz)")
 
     // explicit disabled wavetable with multi
     region = synth.getRegionView(regionNumber++);
-    REQUIRE(region->sampleId.filename() == "ramp_wave.wav");
+    REQUIRE(region->sampleId->filename() == "ramp_wave.wav");
     REQUIRE(!region->isStereo());
     REQUIRE(!region->isGenerator());
     REQUIRE(!region->isOscillator());
@@ -325,7 +325,7 @@ TEST_CASE("[Files] Channels (channels_multi.sfz)")
 
     // implicit wavetable (sound file < 3000 frames)
     region = synth.getRegionView(regionNumber++);
-    REQUIRE(region->sampleId.filename() == "ramp_wave.wav");
+    REQUIRE(region->sampleId->filename() == "ramp_wave.wav");
     REQUIRE(!region->isStereo());
     REQUIRE(!region->isGenerator());
     REQUIRE(region->isOscillator());
@@ -333,7 +333,7 @@ TEST_CASE("[Files] Channels (channels_multi.sfz)")
 
     // implicit non-wavetable (sound file >= 3000 frames)
     region = synth.getRegionView(regionNumber++);
-    REQUIRE(region->sampleId.filename() == "snare.wav");
+    REQUIRE(region->sampleId->filename() == "snare.wav");
     REQUIRE(!region->isStereo());
     REQUIRE(!region->isGenerator());
     REQUIRE(!region->isOscillator());
@@ -341,7 +341,7 @@ TEST_CASE("[Files] Channels (channels_multi.sfz)")
 
     // generator with multi=1 (single)
     region = synth.getRegionView(regionNumber++);
-    REQUIRE(region->sampleId.filename() == "*sine");
+    REQUIRE(region->sampleId->filename() == "*sine");
     REQUIRE(!region->isStereo());
     REQUIRE(region->isGenerator());
     REQUIRE(region->isOscillator());
@@ -349,7 +349,7 @@ TEST_CASE("[Files] Channels (channels_multi.sfz)")
 
     // generator with multi=2 (ring modulation)
     region = synth.getRegionView(regionNumber++);
-    REQUIRE(region->sampleId.filename() == "*sine");
+    REQUIRE(region->sampleId->filename() == "*sine");
     REQUIRE(!region->isStereo());
     REQUIRE(region->isGenerator());
     REQUIRE(region->isOscillator());
@@ -424,7 +424,7 @@ TEST_CASE("[Files] Specific bug: relative path with backslashes")
     Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/SpecificBugs/win_backslashes.sfz");
     REQUIRE(synth.getNumRegions() == 1);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == R"(Xylo/Subfolder/closedhat.wav)");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == R"(Xylo/Subfolder/closedhat.wav)");
 }
 
 TEST_CASE("[Files] Default path")
@@ -432,10 +432,10 @@ TEST_CASE("[Files] Default path")
     Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/default_path.sfz");
     REQUIRE(synth.getNumRegions() == 4);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == R"(DefaultPath/SubPath1/sample1.wav)");
-    REQUIRE(synth.getRegionView(1)->sampleId.filename() == R"(DefaultPath/SubPath2/sample2.wav)");
-    REQUIRE(synth.getRegionView(2)->sampleId.filename() == R"(DefaultPath/SubPath1/sample1.wav)");
-    REQUIRE(synth.getRegionView(3)->sampleId.filename() == R"(DefaultPath/SubPath2/sample2.wav)");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == R"(DefaultPath/SubPath1/sample1.wav)");
+    REQUIRE(synth.getRegionView(1)->sampleId->filename() == R"(DefaultPath/SubPath2/sample2.wav)");
+    REQUIRE(synth.getRegionView(2)->sampleId->filename() == R"(DefaultPath/SubPath1/sample1.wav)");
+    REQUIRE(synth.getRegionView(3)->sampleId->filename() == R"(DefaultPath/SubPath2/sample2.wav)");
 }
 
 TEST_CASE("[Files] Default path reset when calling loadSfzFile again")
@@ -445,7 +445,7 @@ TEST_CASE("[Files] Default path reset when calling loadSfzFile again")
     REQUIRE(synth.getNumRegions() == 4);
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/default_path_reset.sfz");
     REQUIRE(synth.getNumRegions() == 1);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == R"(DefaultPath/SubPath2/sample2.wav)");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == R"(DefaultPath/SubPath2/sample2.wav)");
 }
 
 TEST_CASE("[Files] Default path is ignored for generators")
@@ -453,7 +453,7 @@ TEST_CASE("[Files] Default path is ignored for generators")
     Synth synth;
     synth.loadSfzFile(fs::current_path() / "tests/TestFiles/default_path_generator.sfz");
     REQUIRE(synth.getNumRegions() == 1);
-    REQUIRE(synth.getRegionView(0)->sampleId.filename() == R"(*sine)");
+    REQUIRE(synth.getRegionView(0)->sampleId->filename() == R"(*sine)");
 }
 
 TEST_CASE("[Files] Set CC applies properly")
@@ -616,10 +616,10 @@ TEST_CASE("[Files] Case sentitiveness")
         Synth synth;
         synth.loadSfzFile(sfzFilePath);
         REQUIRE(synth.getNumRegions() == 4);
-        REQUIRE(synth.getRegionView(0)->sampleId.filename() == "dummy1.wav");
-        REQUIRE(synth.getRegionView(1)->sampleId.filename() == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(2)->sampleId.filename() == "Regions/dummy.wav");
-        REQUIRE(synth.getRegionView(3)->sampleId.filename() == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(0)->sampleId->filename() == "dummy1.wav");
+        REQUIRE(synth.getRegionView(1)->sampleId->filename() == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(2)->sampleId->filename() == "Regions/dummy.wav");
+        REQUIRE(synth.getRegionView(3)->sampleId->filename() == "Regions/dummy.wav");
     }
 }
 

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -23,18 +23,18 @@ TEST_CASE("[Region] Parsing opcodes")
 
     SECTION("sample")
     {
-        REQUIRE(region.sampleId.filename() == "");
+        REQUIRE(region.sampleId->filename() == "");
         region.parseOpcode({ "sample", "dummy.wav" });
-        REQUIRE(region.sampleId.filename() == "dummy.wav");
+        REQUIRE(region.sampleId->filename() == "dummy.wav");
     }
 
     SECTION("direction")
     {
-        REQUIRE(!region.sampleId.isReverse());
+        REQUIRE(!region.sampleId->isReverse());
         region.parseOpcode({ "direction", "reverse" });
-        REQUIRE(region.sampleId.isReverse());
+        REQUIRE(region.sampleId->isReverse());
         region.parseOpcode({ "direction", "forward" });
-        REQUIRE(!region.sampleId.isReverse());
+        REQUIRE(!region.sampleId->isReverse());
     }
 
     SECTION("delay")

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -698,13 +698,13 @@ TEST_CASE("[Synth] Release (basic behavior with sample)")
     )");
     synth.noteOn(0, 62, 85);
     REQUIRE( numPlayingVoices(synth) == 1 );
-    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId.filename() == "*sine" );
+    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId->filename() == "*sine" );
     synth.noteOff(0, 62, 85);
     REQUIRE( numPlayingVoices(synth) == 1 );
-    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId.filename() == "closedhat.wav" );
+    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId->filename() == "closedhat.wav" );
     synth.renderBlock(buffer);
     REQUIRE( numPlayingVoices(synth) == 1 );
-    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId.filename() == "closedhat.wav" );
+    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId->filename() == "closedhat.wav" );
 }
 
 TEST_CASE("[Synth] Release key (basic behavior with sample)")
@@ -720,7 +720,7 @@ TEST_CASE("[Synth] Release key (basic behavior with sample)")
     REQUIRE( numPlayingVoices(synth) == 1 );
     synth.renderBlock(buffer);
     REQUIRE( numPlayingVoices(synth) == 1 );
-    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId.filename() == "closedhat.wav" );
+    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId->filename() == "closedhat.wav" );
 }
 
 TEST_CASE("[Synth] Release key (pedal)")
@@ -1338,15 +1338,15 @@ TEST_CASE("[Synth] Off by with CC switches")
     )");
     synth.noteOn(0, 60, 85);
     REQUIRE( numPlayingVoices(synth) == 1 );
-    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId.filename() == "*saw" );
+    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId->filename() == "*saw" );
     synth.cc(0, 4, 127);
     synth.noteOn(0, 60, 85);
     REQUIRE( numPlayingVoices(synth) == 1 );
-    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId.filename() == "*triangle" );
+    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId->filename() == "*triangle" );
     synth.cc(0, 4, 0);
     synth.noteOn(0, 60, 85);
     REQUIRE( numPlayingVoices(synth) == 1 );
-    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId.filename() == "*saw" );
+    REQUIRE( getPlayingVoices(synth).front()->getRegion()->sampleId->filename() == "*saw" );
 }
 
 TEST_CASE("[Synth] Initial values of CC")


### PR DESCRIPTION
expected to fix #511

It was observed that `QueuedFileData` has a `FileId` member, and it's copied, therefore not RT-safe.

This implements the file queue in a different strategy, and removed problematic code at the same time.

- replace `FileId Region::sampleId` with a shared pointer.
 That permits to pass it in the message queue, without worrying about a corruption in case the region gets removed while the FileId is still in the queue.

- the queued file data receives a `id` member of type `weak_ptr`, meaning it auto-nulls itself if the Region gets deleted.
  In this model, the `FilePool` must null-check the `id` at relevant places to check that the request is still valid.
  Since it auto-nulls on erasing regions, we don't need `emptyFileLoadingQueues`, loading jobs will clean themselves.
