### PR TITLE
Enable the resource fork again

### DIFF
--- a/vst/CMakeLists.txt
+++ b/vst/CMakeLists.txt
@@ -252,7 +252,7 @@ elseif(SFIZZ_AU)
         DESTINATION "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}")
 
     # Add the resource fork
-    if (FALSE) # optional, disabled because broken on CI
+    if (TRUE)
         execute_process(COMMAND "xcrun" "--find" "Rez"
             OUTPUT_VARIABLE OSX_REZ_COMMAND OUTPUT_STRIP_TRAILING_WHITESPACE)
         file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")


### PR DESCRIPTION
This was disabled for CI reasons.
Let's check if this works on the new OSX image.