### PR TITLE
Clearing concurrency issues

### DIFF
--- a/src/sfizz/FilePool.h
+++ b/src/sfizz/FilePool.h
@@ -362,9 +362,8 @@ private:
     std::thread dispatchThread { &FilePool::dispatchingJob, this };
     std::thread garbageThread { &FilePool::garbageJob, this };
 
-    SpinMutex lastUsedMutex;
+    SpinMutex garbageAndLastUsedMutex;
     std::vector<FileId> lastUsedFiles;
-    SpinMutex garbageMutex;
     std::vector<FileAudioBuffer> garbageToCollect;
 
     std::shared_ptr<ThreadPool> threadPool;

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -194,6 +194,9 @@ void sfz::Synth::clear()
 {
     const std::lock_guard<SpinMutex> disableCallback { callbackGuard };
 
+    // Clear the background queues before removing everyone
+    resources.filePool.waitForBackgroundLoading();
+
     for (auto& voice : voices)
         voice->reset();
     for (auto& list : noteActivationLists)


### PR DESCRIPTION
Closes #519 

What hurt was a mix of many things. My current analysis was that:
- The file pool was cleared but not the garbage to collect nor the last used files
- The background loaders could still be running while clearing the file pool
- The lock was released between clearing and loading a new file; no voices were running, but the garbage collection could be triggered
- There was no check in the garbage collection method if the "id" of the sample to check was indeed in the `preloadedFiles` data structure, thereby leading to UB.

The fix was to:
- wait for background loading to finish before clearing the `FilePool`
- clear all the `FilePool` structures (garbage, lastUsedFiles and preloadedFiles) under the callback lock in the `Synth::clear()` method.

I also added a couple sanity checks, and merged the FilePool mutex on garbage and used files into one.

I would ask for your pov @jpcima on the use of the callback lock in the loading functions of the synth. I wonder if it's a good idea to release the lock between `Synth::clear()` and the rest of the methods. We could remove the mutex hold in `clear()` and handle it only in the `loadSfz...()` ones: `clear()` is not in the public API and only called by the loading functions.

Still needs testing on various platforms to see if everything works as expected...