### PR TITLE
Build a set of "effective" keyswitches and use that instead of sw_lokey/sw_hikey

### DIFF
--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -1588,29 +1588,17 @@ bool sfz::Region::registerNoteOn(int noteNumber, float velocity, float randValue
 {
     ASSERT(velocity >= 0.0f && velocity <= 1.0f);
 
-    if (keyswitchDown && *keyswitchDown == noteNumber)
-        keySwitched = true;
-
-    if (keyswitchUp && *keyswitchUp == noteNumber)
-        keySwitched = false;
-
     const bool keyOk = keyRange.containsWithEnd(noteNumber);
     if (keyOk) {
         // Sequence activation
         sequenceSwitched =
             ((sequenceCounter++ % sequenceLength) == sequencePosition - 1);
-
-        if (previousNote)
-            previousKeySwitched = (*previousNote == noteNumber);
     }
 
     if (!isSwitchedOn())
         return false;
 
     if (!triggerOnNote)
-        return false;
-
-    if (previousNote && !(previousKeySwitched && noteNumber != *previousNote))
         return false;
 
     const bool velOk = velocityRange.containsWithEnd(velocity);
@@ -1625,12 +1613,6 @@ bool sfz::Region::registerNoteOn(int noteNumber, float velocity, float randValue
 bool sfz::Region::registerNoteOff(int noteNumber, float velocity, float randValue) noexcept
 {
     ASSERT(velocity >= 0.0f && velocity <= 1.0f);
-
-    if (keyswitchDown && *keyswitchDown == noteNumber)
-        keySwitched = false;
-
-    if (keyswitchUp && *keyswitchUp == noteNumber)
-        keySwitched = true;
 
     if (!isSwitchedOn())
         return false;

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -296,8 +296,32 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
     case hash("sw_hikey"):
         break;
     case hash("sw_last"):
-        setValueFromOpcode(opcode, lastKeyswitch, Default::keyRange);
-        keySwitched = false;
+        if (!lastKeyswitchRange) {
+            setValueFromOpcode(opcode, lastKeyswitch, Default::keyRange);
+            keySwitched = false;
+        }
+        break;
+    case hash("sw_lolast"):
+        if (auto value = readOpcode(opcode.value, Default::keyRange)) {
+            if (!lastKeyswitchRange)
+                lastKeyswitchRange.emplace(*value, *value);
+            else
+                lastKeyswitchRange->setStart(*value);
+
+            keySwitched = false;
+            lastKeyswitch = absl::nullopt;
+        }
+        break;
+    case hash("sw_hilast"):
+        if (auto value = readOpcode(opcode.value, Default::keyRange)) {
+            if (!lastKeyswitchRange)
+                lastKeyswitchRange.emplace(*value, *value);
+            else
+                lastKeyswitchRange->setEnd(*value);
+
+            keySwitched = false;
+            lastKeyswitch = absl::nullopt;
+        }
         break;
     case hash("sw_label"):
         keyswitchLabel = opcode.value;

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -296,21 +296,21 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
     case hash("sw_hikey"):
         break;
     case hash("sw_last"):
-        setValueFromOpcode(opcode, keyswitch, Default::keyRange);
+        setValueFromOpcode(opcode, lastKeyswitch, Default::keyRange);
         keySwitched = false;
         break;
     case hash("sw_label"):
         keyswitchLabel = opcode.value;
         break;
     case hash("sw_down"):
-        setValueFromOpcode(opcode, keyswitchDown, Default::keyRange);
+        setValueFromOpcode(opcode, downKeyswitch, Default::keyRange);
         keySwitched = false;
         break;
     case hash("sw_up"):
-        setValueFromOpcode(opcode, keyswitchUp, Default::keyRange);
+        setValueFromOpcode(opcode, upKeyswitch, Default::keyRange);
         break;
     case hash("sw_previous"):
-        setValueFromOpcode(opcode, previousNote, Default::keyRange);
+        setValueFromOpcode(opcode, previousKeyswitch, Default::keyRange);
         previousKeySwitched = false;
         break;
     case hash("sw_vel"):
@@ -1844,14 +1844,14 @@ void sfz::Region::offsetAllKeys(int offset) noexcept
     pitchKeycenter = offsetAndClampKey(pitchKeycenter, offset, Default::keyRange);
 
     // Offset key switches
-    if (keyswitchUp)
-        keyswitchUp = offsetAndClampKey(*keyswitchUp, offset, Default::keyRange);
-    if (keyswitch)
-        keyswitch = offsetAndClampKey(*keyswitch, offset, Default::keyRange);
-    if (keyswitchDown)
-        keyswitchDown = offsetAndClampKey(*keyswitchDown, offset, Default::keyRange);
-    if (previousNote)
-        previousNote = offsetAndClampKey(*previousNote, offset, Default::keyRange);
+    if (upKeyswitch)
+        upKeyswitch = offsetAndClampKey(*upKeyswitch, offset, Default::keyRange);
+    if (lastKeyswitch)
+        lastKeyswitch = offsetAndClampKey(*lastKeyswitch, offset, Default::keyRange);
+    if (downKeyswitch)
+        downKeyswitch = offsetAndClampKey(*downKeyswitch, offset, Default::keyRange);
+    if (previousKeyswitch)
+        previousKeyswitch = offsetAndClampKey(*previousKeyswitch, offset, Default::keyRange);
 
     // Offset crossfade ranges
     if (crossfadeKeyInRange != Default::crossfadeKeyInRange) {

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -347,11 +347,11 @@ struct Region {
     // Region logic: MIDI conditions
     Range<float> bendRange { Default::bendValueRange }; // hibend and lobend
     CCMap<Range<float>> ccConditions { Default::ccValueRange };
-    absl::optional<uint8_t> keyswitch {}; // sw_last
+    absl::optional<uint8_t> lastKeyswitch {}; // sw_last
     absl::optional<std::string> keyswitchLabel {};
-    absl::optional<uint8_t> keyswitchUp {}; // sw_up
-    absl::optional<uint8_t> keyswitchDown {}; // sw_down
-    absl::optional<uint8_t> previousNote {}; // sw_previous
+    absl::optional<uint8_t> upKeyswitch {}; // sw_up
+    absl::optional<uint8_t> downKeyswitch {}; // sw_down
+    absl::optional<uint8_t> previousKeyswitch {}; // sw_previous
     SfzVelocityOverride velocityOverride { Default::velocityOverride }; // sw_vel
     bool checkSustain { Default::checkSustain }; // sustain_sw
     bool checkSostenuto { Default::checkSostenuto }; // sostenuto_sw

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -348,6 +348,7 @@ struct Region {
     Range<float> bendRange { Default::bendValueRange }; // hibend and lobend
     CCMap<Range<float>> ccConditions { Default::ccValueRange };
     absl::optional<uint8_t> lastKeyswitch {}; // sw_last
+    absl::optional<Range<uint8_t>> lastKeyswitchRange {}; // sw_last
     absl::optional<std::string> keyswitchLabel {};
     absl::optional<uint8_t> upKeyswitch {}; // sw_up
     absl::optional<uint8_t> downKeyswitch {}; // sw_down

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -292,8 +292,6 @@ struct Region {
     uint32_t loopStart(Oversampling factor = Oversampling::x1) const noexcept;
     uint32_t loopEnd(Oversampling factor = Oversampling::x1) const noexcept;
 
-    bool hasKeyswitches() const noexcept { return keyswitchDown || keyswitchUp || keyswitch || previousNote; }
-
     /**
      * @brief Get the gain this region contributes into the input of the Nth
      *        effect bus
@@ -349,7 +347,6 @@ struct Region {
     // Region logic: MIDI conditions
     Range<float> bendRange { Default::bendValueRange }; // hibend and lobend
     CCMap<Range<float>> ccConditions { Default::ccValueRange };
-    Range<uint8_t> keyswitchRange { Default::keyRange }; // sw_hikey and sw_lokey
     absl::optional<uint8_t> keyswitch {}; // sw_last
     absl::optional<std::string> keyswitchLabel {};
     absl::optional<uint8_t> keyswitchUp {}; // sw_up
@@ -455,7 +452,7 @@ struct Region {
 
     // Started notes
     std::vector<std::pair<int, float>> delayedReleases;
-private:
+
     const MidiState& midiState;
     bool keySwitched { true };
     bool previousKeySwitched { true };

--- a/src/sfizz/Resources.h
+++ b/src/sfizz/Resources.h
@@ -33,6 +33,8 @@ struct Resources
     absl::optional<StretchTuning> stretch;
     ModMatrix modMatrix;
 
+    std::vector<uint8_t> keyswitches;
+
     void setSampleRate(float samplerate)
     {
         midiState.setSampleRate(samplerate);
@@ -54,6 +56,7 @@ struct Resources
         logger.clear();
         midiState.reset();
         modMatrix.clear();
+        keyswitches.clear();
     }
 };
 }

--- a/src/sfizz/Resources.h
+++ b/src/sfizz/Resources.h
@@ -33,8 +33,6 @@ struct Resources
     absl::optional<StretchTuning> stretch;
     ModMatrix modMatrix;
 
-    std::vector<uint8_t> keyswitches;
-
     void setSampleRate(float samplerate)
     {
         midiState.setSampleRate(samplerate);
@@ -56,7 +54,6 @@ struct Resources
         logger.clear();
         midiState.reset();
         modMatrix.clear();
-        keyswitches.clear();
     }
 };
 }

--- a/src/sfizz/SfzHelpers.h
+++ b/src/sfizz/SfzHelpers.h
@@ -177,6 +177,25 @@ constexpr float normalizeBend(float bendValue)
     return clamp(bendValue, -8191.0f, 8191.0f) / 8191.0f;
 }
 
+/**
+ * @brief Offset a key and clamp it to a reasonable range
+ *
+ * @param key
+ * @param offset
+ * @param range
+ * @return uint8_t
+ */
+inline CXX14_CONSTEXPR uint8_t offsetAndClampKey(uint8_t key, int offset, sfz::Range<uint8_t> range)
+{
+    const int offsetKey { key + offset };
+    if (offsetKey > std::numeric_limits<uint8_t>::max())
+        return range.getEnd();
+    if (offsetKey < std::numeric_limits<uint8_t>::min())
+        return range.getStart();
+
+    return range.clamp(static_cast<uint8_t>(offsetKey));
+}
+
 namespace literals {
     inline float operator""_norm(unsigned long long int value)
     {

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -628,6 +628,17 @@ void sfz::Synth::finalizeSfzLoad()
                 insertPairUniquely(keyswitchLabels, *region->lastKeyswitch, *region->keyswitchLabel);
         }
 
+        if (region->lastKeyswitchRange) {
+            auto& range = *region->lastKeyswitchRange;
+            if (currentSwitch)
+                region->keySwitched = range.containsWithEnd(*currentSwitch);
+
+            if (region->keyswitchLabel) {
+                for (uint8_t note = range.getStart(), end = range.getEnd(); note <= end; note++)
+                    insertPairUniquely(keyswitchLabels, note, *region->keyswitchLabel);
+            }
+        }
+
         // Some regions had group number but no "group-level" opcodes handled the polyphony
         while (polyphonyGroups.size() <= region->group) {
             polyphonyGroups.emplace_back();
@@ -1176,7 +1187,6 @@ void sfz::Synth::noteOnDispatch(int delay, int noteNumber, float velocity) noexc
         region->keySwitched = true;
 
     for (auto& region : noteActivationLists[noteNumber]) {
-
         if (region->registerNoteOn(noteNumber, velocity, randValue)) {
             for (auto& voice : voices) {
                 if (voice->checkOffGroup(region, delay, noteNumber)) {

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -178,6 +178,12 @@ void sfz::Synth::buildRegion(const std::vector<Opcode>& regionOpcodes)
     if (lastRegion->lastKeyswitch)
         lastKeyswitchLists[*lastRegion->lastKeyswitch].push_back(lastRegion.get());
 
+    if (lastRegion->lastKeyswitchRange) {
+        auto& range = *lastRegion->lastKeyswitchRange;
+        for (uint8_t note = range.getStart(), end = range.getEnd(); note <= end; note++)
+            lastKeyswitchLists[note].push_back(lastRegion.get());
+    }
+
     if (lastRegion->upKeyswitch)
         upKeyswitchLists[*lastRegion->upKeyswitch].push_back(lastRegion.get());
 

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -175,16 +175,16 @@ void sfz::Synth::buildRegion(const std::vector<Opcode>& regionOpcodes)
     if (octaveOffset != 0 || noteOffset != 0)
         lastRegion->offsetAllKeys(octaveOffset * 12 + noteOffset);
 
-    if (lastRegion->keyswitch)
-        lastKeyswitchLists[*lastRegion->keyswitch].push_back(lastRegion.get());
+    if (lastRegion->lastKeyswitch)
+        lastKeyswitchLists[*lastRegion->lastKeyswitch].push_back(lastRegion.get());
 
-    if (lastRegion->keyswitchUp)
-        upKeyswitchLists[*lastRegion->keyswitchUp].push_back(lastRegion.get());
+    if (lastRegion->upKeyswitch)
+        upKeyswitchLists[*lastRegion->upKeyswitch].push_back(lastRegion.get());
 
-    if (lastRegion->keyswitchDown)
-        downKeyswitchLists[*lastRegion->keyswitchDown].push_back(lastRegion.get());
+    if (lastRegion->downKeyswitch)
+        downKeyswitchLists[*lastRegion->downKeyswitch].push_back(lastRegion.get());
 
-    if (lastRegion->previousNote)
+    if (lastRegion->previousKeyswitch)
         previousKeyswitchLists.push_back(lastRegion.get());
 
     // There was a combination of group= and polyphony= on a region, so set the group polyphony
@@ -614,12 +614,12 @@ void sfz::Synth::finalizeSfzLoad()
             }
         }
 
-        if (region->keyswitch) {
+        if (region->lastKeyswitch) {
             if (currentSwitch)
-                region->keySwitched = (*currentSwitch == *region->keyswitch);
+                region->keySwitched = (*currentSwitch == *region->lastKeyswitch);
 
             if (region->keyswitchLabel)
-                insertPairUniquely(keyswitchLabels, *region->keyswitch, *region->keyswitchLabel);
+                insertPairUniquely(keyswitchLabels, *region->lastKeyswitch, *region->keyswitchLabel);
         }
 
         // Some regions had group number but no "group-level" opcodes handled the polyphony
@@ -1184,7 +1184,7 @@ void sfz::Synth::noteOnDispatch(int delay, int noteNumber, float velocity) noexc
     }
 
     for (auto& region : previousKeyswitchLists)
-        region->previousKeySwitched = (*region->previousNote == noteNumber);
+        region->previousKeySwitched = (*region->previousKeyswitch == noteNumber);
 }
 
 void sfz::Synth::startDelayedReleaseVoices(Region* region, int delay, SisterVoiceRingBuilder& ring) noexcept

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -803,8 +803,8 @@ private:
     std::vector<NoteNamePair> keyLabels;
     std::vector<NoteNamePair> keyswitchLabels;
 
-    // Default active switch if multiple keyswitchable regions are present
-    absl::optional<uint8_t> defaultSwitch;
+    // Set as sw_default if present in the file
+    absl::optional<uint8_t> currentSwitch;
     std::vector<std::string> unknownOpcodes;
     using RegionViewVector = std::vector<Region*>;
     using VoiceViewVector = std::vector<Voice*>;
@@ -899,6 +899,10 @@ private:
      */
     bool playingAttackVoice(const Region* releaseRegion) noexcept;
 
+    std::array<RegionViewVector, 128> lastKeyswitchLists;
+    std::array<RegionViewVector, 128> downKeyswitchLists;
+    std::array<RegionViewVector, 128> upKeyswitchLists;
+    RegionViewVector previousKeyswitchLists;
     std::array<RegionViewVector, 128> noteActivationLists;
     std::array<RegionViewVector, config::numCCs> ccActivationLists;
 

--- a/tests/FilesT.cpp
+++ b/tests/FilesT.cpp
@@ -463,14 +463,14 @@ TEST_CASE("[Files] Note and octave offsets")
     REQUIRE(synth.getRegionView(2)->crossfadeKeyOutRange == Range<uint8_t>(45, 49));
 
     REQUIRE(synth.getRegionView(3)->keyRange == Range<uint8_t>(62, 62));
-    REQUIRE( synth.getRegionView(3)->keyswitch );
-    REQUIRE( *synth.getRegionView(3)->keyswitch == 24 );
-    REQUIRE( synth.getRegionView(3)->keyswitchUp );
-    REQUIRE( *synth.getRegionView(3)->keyswitchUp == 24 );
-    REQUIRE( synth.getRegionView(3)->keyswitchDown );
-    REQUIRE( *synth.getRegionView(3)->keyswitchDown == 24 );
-    REQUIRE( synth.getRegionView(3)->previousNote );
-    REQUIRE( *synth.getRegionView(3)->previousNote == 61 );
+    REQUIRE( synth.getRegionView(3)->lastKeyswitch );
+    REQUIRE( *synth.getRegionView(3)->lastKeyswitch == 24 );
+    REQUIRE( synth.getRegionView(3)->upKeyswitch );
+    REQUIRE( *synth.getRegionView(3)->upKeyswitch == 24 );
+    REQUIRE( synth.getRegionView(3)->downKeyswitch );
+    REQUIRE( *synth.getRegionView(3)->downKeyswitch == 24 );
+    REQUIRE( synth.getRegionView(3)->previousKeyswitch );
+    REQUIRE( *synth.getRegionView(3)->previousKeyswitch == 61 );
 
     REQUIRE(synth.getRegionView(4)->keyRange == Range<uint8_t>(76, 76));
     REQUIRE( synth.getRegionView(4)->pitchKeycenter == 76 );

--- a/tests/FilesT.cpp
+++ b/tests/FilesT.cpp
@@ -356,46 +356,6 @@ TEST_CASE("[Files] Channels (channels_multi.sfz)")
     REQUIRE(region->oscillatorEnabled == Region::OscillatorEnabled::Auto);
 }
 
-TEST_CASE("[Files] sw_default")
-{
-    Synth synth;
-    synth.loadSfzFile(fs::current_path() / "tests/TestFiles/sw_default.sfz");
-    REQUIRE( synth.getNumRegions() == 4 );
-    REQUIRE( !synth.getRegionView(0)->isSwitchedOn() );
-    REQUIRE( synth.getRegionView(1)->isSwitchedOn() );
-    REQUIRE( !synth.getRegionView(2)->isSwitchedOn() );
-    REQUIRE( synth.getRegionView(3)->isSwitchedOn() );
-}
-
-TEST_CASE("[Files] sw_default and playing with switches")
-{
-    Synth synth;
-    synth.loadSfzFile(fs::current_path() / "tests/TestFiles/sw_default.sfz");
-    REQUIRE( synth.getNumRegions() == 4 );
-    REQUIRE( !synth.getRegionView(0)->isSwitchedOn() );
-    REQUIRE( synth.getRegionView(1)->isSwitchedOn() );
-    REQUIRE( !synth.getRegionView(2)->isSwitchedOn() );
-    REQUIRE( synth.getRegionView(3)->isSwitchedOn() );
-    synth.noteOn(0, 41, 64);
-    synth.noteOff(0, 41, 0);
-    REQUIRE( synth.getRegionView(0)->isSwitchedOn() );
-    REQUIRE( !synth.getRegionView(1)->isSwitchedOn() );
-    REQUIRE( synth.getRegionView(2)->isSwitchedOn() );
-    REQUIRE( !synth.getRegionView(3)->isSwitchedOn() );
-    synth.noteOn(0, 42, 64);
-    synth.noteOff(0, 42, 0);
-    REQUIRE( !synth.getRegionView(0)->isSwitchedOn() );
-    REQUIRE( !synth.getRegionView(1)->isSwitchedOn() );
-    REQUIRE( !synth.getRegionView(2)->isSwitchedOn() );
-    REQUIRE( !synth.getRegionView(3)->isSwitchedOn() );
-    synth.noteOn(0, 40, 64);
-    synth.noteOff(0, 40, 64);
-    REQUIRE( !synth.getRegionView(0)->isSwitchedOn() );
-    REQUIRE( synth.getRegionView(1)->isSwitchedOn() );
-    REQUIRE( !synth.getRegionView(2)->isSwitchedOn() );
-    REQUIRE( synth.getRegionView(3)->isSwitchedOn() );
-}
-
 TEST_CASE("[Files] wrong (overlapping) replacement for defines")
 {
     Synth synth;
@@ -491,7 +451,6 @@ TEST_CASE("[Files] Note and octave offsets")
 
     REQUIRE(synth.getRegionView(0)->keyRange == Range<uint8_t>(64, 64));
     REQUIRE( synth.getRegionView(0)->pitchKeycenter == 64 );
-    REQUIRE(synth.getRegionView(0)->keyswitchRange == Default::keyRange);
     REQUIRE(synth.getRegionView(0)->crossfadeKeyInRange == Default::crossfadeKeyInRange);
     REQUIRE(synth.getRegionView(0)->crossfadeKeyOutRange == Default::crossfadeKeyOutRange);
 
@@ -504,7 +463,6 @@ TEST_CASE("[Files] Note and octave offsets")
     REQUIRE(synth.getRegionView(2)->crossfadeKeyOutRange == Range<uint8_t>(45, 49));
 
     REQUIRE(synth.getRegionView(3)->keyRange == Range<uint8_t>(62, 62));
-    REQUIRE(synth.getRegionView(3)->keyswitchRange == Range<uint8_t>(23, 27));
     REQUIRE( synth.getRegionView(3)->keyswitch );
     REQUIRE( *synth.getRegionView(3)->keyswitch == 24 );
     REQUIRE( synth.getRegionView(3)->keyswitchUp );

--- a/tests/RegionActivationT.cpp
+++ b/tests/RegionActivationT.cpp
@@ -402,7 +402,6 @@ TEST_CASE("[Keyswitches] sw_previous in range")
     REQUIRE(synth.getRegionView(0)->isSwitchedOn());
 }
 
-
 TEST_CASE("[Keyswitches] sw_previous out of range")
 {
     // The behavior is the same in this case, regardless of the keyrange
@@ -424,4 +423,67 @@ TEST_CASE("[Keyswitches] sw_previous out of range")
     REQUIRE(synth.getRegionView(0)->isSwitchedOn());
     synth.noteOn(0, 61, 64);
     REQUIRE(!synth.getRegionView(0)->isSwitchedOn());
+}
+
+TEST_CASE("[Keyswitches] sw_lolast and sw_hilast")
+{
+    // The behavior is the same in this case, regardless of the keyrange
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/sw_previous.sfz", R"(
+        <region> sw_lolast=57 sw_hilast=59 key=70 sample=*saw
+        <region> sw_lolast=60 sw_hilast=62 key=72 sample=*sine
+    )");
+    REQUIRE(!synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(!synth.getRegionView(1)->isSwitchedOn());
+    synth.noteOn(0, 51, 64);
+    REQUIRE(!synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(!synth.getRegionView(1)->isSwitchedOn());
+    synth.noteOn(0, 57, 64);
+    REQUIRE(synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(!synth.getRegionView(1)->isSwitchedOn());
+    synth.noteOn(0, 60, 64);
+    REQUIRE(!synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(synth.getRegionView(1)->isSwitchedOn());
+    synth.noteOn(0, 58, 64);
+    REQUIRE(synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(!synth.getRegionView(1)->isSwitchedOn());
+    synth.noteOn(0, 61, 64);
+    REQUIRE(!synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(synth.getRegionView(1)->isSwitchedOn());
+    synth.noteOn(0, 59, 64);
+    REQUIRE(synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(!synth.getRegionView(1)->isSwitchedOn());
+    synth.noteOn(0, 62, 64);
+    REQUIRE(!synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(synth.getRegionView(1)->isSwitchedOn());
+}
+
+TEST_CASE("[Keyswitches] sw_lolast and sw_hilast with sw_last")
+{
+    // The behavior is the same in this case, regardless of the keyrange
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/sw_previous.sfz", R"(
+        <region> sw_last=40 sw_lolast=57 sw_hilast=59 key=70 sample=*saw
+        <region> sw_lolast=60 sw_hilast=62 sw_last=41 key=72 sample=*sine
+    )");
+    REQUIRE(!synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(!synth.getRegionView(1)->isSwitchedOn());
+    synth.noteOn(0, 40, 64);
+    REQUIRE(!synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(!synth.getRegionView(1)->isSwitchedOn());
+    synth.noteOn(0, 41, 64);
+    REQUIRE(!synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(!synth.getRegionView(1)->isSwitchedOn());
+    synth.noteOn(0, 57, 64);
+    REQUIRE(synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(!synth.getRegionView(1)->isSwitchedOn());
+    synth.noteOn(0, 41, 64);
+    REQUIRE(synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(!synth.getRegionView(1)->isSwitchedOn());
+    synth.noteOn(0, 60, 64);
+    REQUIRE(!synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(synth.getRegionView(1)->isSwitchedOn());
+    synth.noteOn(0, 40, 64);
+    REQUIRE(!synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(synth.getRegionView(1)->isSwitchedOn());
 }

--- a/tests/RegionActivationT.cpp
+++ b/tests/RegionActivationT.cpp
@@ -5,6 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "sfizz/Region.h"
+#include "sfizz/Synth.h"
 #include "sfizz/SfzHelpers.h"
 #include "catch2/catch.hpp"
 using namespace Catch::literals;
@@ -113,83 +114,6 @@ TEST_CASE("Region activation", "Region tests")
         REQUIRE(!region.isSwitchedOn());
     }
 
-    // TODO: add keyswitches
-    SECTION("Keyswitches: sw_last")
-    {
-        region.parseOpcode({ "sw_last", "40" });
-        REQUIRE(!region.isSwitchedOn());
-        region.registerNoteOn(40, 64_norm, 0.5f);
-        REQUIRE(region.isSwitchedOn());
-        region.registerNoteOff(40, 64_norm, 0.5f);
-        REQUIRE(region.isSwitchedOn());
-        region.registerNoteOn(41, 64_norm, 0.5f);
-        REQUIRE(!region.isSwitchedOn());
-        region.registerNoteOff(41, 0_norm, 0.5f);
-    }
-
-    SECTION("Keyswitches: sw_last with non-default keyswitch range")
-    {
-        region.parseOpcode({ "sw_lokey", "30" });
-        region.parseOpcode({ "sw_hikey", "50" });
-        region.parseOpcode({ "sw_last", "40" });
-        REQUIRE(!region.isSwitchedOn());
-        region.registerNoteOn(60, 64_norm, 0.5f);
-        REQUIRE(!region.isSwitchedOn());
-        region.registerNoteOff(60, 0_norm, 0.5f);
-        REQUIRE(!region.isSwitchedOn());
-        region.registerNoteOn(40, 64_norm, 0.5f);
-        REQUIRE(region.isSwitchedOn());
-        region.registerNoteOff(40, 0_norm, 0.5f);
-        REQUIRE(region.isSwitchedOn());
-        region.registerNoteOn(60, 64_norm, 0.5f);
-        REQUIRE(region.isSwitchedOn());
-        region.registerNoteOff(60, 0_norm, 0.5f);
-        region.registerNoteOn(41, 64_norm, 0.5f);
-        REQUIRE(!region.isSwitchedOn());
-        region.registerNoteOff(41, 0_norm, 0.5f);
-    }
-
-    SECTION("Keyswitches: sw_down with non-default keyswitch range")
-    {
-        region.parseOpcode({ "sw_lokey", "30" });
-        region.parseOpcode({ "sw_hikey", "50" });
-        region.parseOpcode({ "sw_down", "40" });
-        REQUIRE(!region.isSwitchedOn());
-        region.registerNoteOn(60, 64_norm, 0.5f);
-        REQUIRE(!region.isSwitchedOn());
-        region.registerNoteOff(60, 0_norm, 0.5f);
-        REQUIRE(!region.isSwitchedOn());
-        region.registerNoteOn(40, 64_norm, 0.5f);
-        REQUIRE(region.isSwitchedOn());
-        region.registerNoteOff(40, 0_norm, 0.5f);
-        REQUIRE(!region.isSwitchedOn());
-        region.registerNoteOn(60, 64_norm, 0.5f);
-        REQUIRE(!region.isSwitchedOn());
-        region.registerNoteOff(60, 0_norm, 0.5f);
-        region.registerNoteOn(41, 64_norm, 0.5f);
-        REQUIRE(!region.isSwitchedOn());
-        region.registerNoteOff(41, 0_norm, 0.5f);
-    }
-
-    SECTION("Keyswitches: sw_up with non-default keyswitch range")
-    {
-        region.parseOpcode({ "sw_lokey", "30" });
-        region.parseOpcode({ "sw_hikey", "50" });
-        region.parseOpcode({ "sw_up", "40" });
-        REQUIRE(region.isSwitchedOn());
-        region.registerNoteOn(40, 64_norm, 0.5f);
-        REQUIRE(!region.isSwitchedOn());
-        region.registerNoteOff(40, 0_norm, 0.5f);
-        REQUIRE(region.isSwitchedOn());
-        region.registerNoteOn(41, 64_norm, 0.5f);
-        REQUIRE(region.isSwitchedOn());
-        region.registerNoteOn(40, 64_norm, 0.5f);
-        REQUIRE(!region.isSwitchedOn());
-        region.registerNoteOff(40, 0_norm, 0.5f);
-        region.registerNoteOff(41, 0_norm, 0.5f);
-        REQUIRE(region.isSwitchedOn());
-    }
-
     SECTION("Keyswitches: sw_previous")
     {
         region.parseOpcode({ "sw_previous", "40" });
@@ -272,4 +196,203 @@ TEST_CASE("Region activation", "Region tests")
         region.registerNoteOff(40, 0_norm, 0.5f);
         REQUIRE(!region.isSwitchedOn());
     }
+}
+
+TEST_CASE("[Keyswitches] Normal keyswitch range")
+{
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/keyswitches.sfz", R"(
+        <global> sw_lokey=40 sw_hikey=42 sw_default=40
+        <region> sw_last=40 key=60 sample=*sine
+        <region> sw_last=41 key=62 sample=*saw
+    )");
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 62, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 41, 64);
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 62, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 2);
+}
+
+TEST_CASE("[Keyswitches] No keyswitch range")
+{
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/keyswitches.sfz", R"(
+        <region> sw_last=40 key=60 sample=*sine
+        <region> sw_last=41 key=62 sample=*saw
+    )");
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 0);
+    synth.noteOn(0, 62, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 0);
+    synth.noteOn(0, 40, 64);
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 62, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 41, 64);
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 62, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 2);
+}
+
+TEST_CASE("[Keyswitches] Out of keyswitch range")
+{
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/keyswitches.sfz", R"(
+        <global> sw_lokey=40 sw_hikey=42 sw_default=40
+        <region> sw_last=40 key=60 sample=*sine
+        <region> sw_last=43 key=62 sample=*saw
+    )");
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 62, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 43, 64);
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 62, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 2);
+}
+
+TEST_CASE("[Keyswitches] Overlapping key and keyswitch range")
+{
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/keyswitches.sfz", R"(
+        <global> sw_lokey=1 sw_hikey=127 sw_default=40
+        <region> sw_last=40 key=60 sample=*sine
+        <region> sw_last=41 key=62 sample=*saw
+    )");
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 62, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 41, 64);
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 62, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 2);
+    synth.noteOn(0, 43, 64);
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 2);
+    synth.noteOn(0, 62, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 3);
+}
+
+TEST_CASE("[Keyswitches] sw_down, in range")
+{
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/keyswitches.sfz", R"(
+        <global> sw_lokey=1 sw_hikey=127 sw_default=40
+        <region> sw_down=40 key=60 sample=*sine
+    )");
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 0);
+    synth.noteOn(0, 40, 64);
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOff(0, 40, 64);
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+}
+
+TEST_CASE("[Keyswitches] sw_down, out of range")
+{
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/keyswitches.sfz", R"(
+        <global> sw_lokey=1 sw_hikey=10 sw_default=40
+        <region> sw_down=40 key=60 sample=*sine
+    )");
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 0);
+    synth.noteOn(0, 40, 64);
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOff(0, 40, 64);
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+}
+
+TEST_CASE("[Keyswitches] sw_up, in range")
+{
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/keyswitches.sfz", R"(
+        <global> sw_lokey=1 sw_hikey=127 sw_default=40
+        <region> sw_up=40 key=60 sample=*sine
+    )");
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 40, 64);
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOff(0, 40, 64);
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 2);
+}
+
+TEST_CASE("[Keyswitches] sw_up, out of range")
+{
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/keyswitches.sfz", R"(
+        <global> sw_lokey=1 sw_hikey=127 sw_default=40
+        <region> sw_up=40 key=60 sample=*sine
+    )");
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOn(0, 40, 64);
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 1);
+    synth.noteOff(0, 40, 64);
+    synth.noteOn(0, 60, 64);
+    REQUIRE(synth.getNumActiveVoices(true) == 2);
+}
+
+TEST_CASE("[Keyswitches] sw_default")
+{
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/sw_default.sfz", R"(
+        <global> sw_lokey=30 sw_hikey=50 sw_default=40
+        <region> sw_last=41 key=51 sample=*sine
+        <region> sw_last=40 key=52 sample=*sine
+        <region> sw_last=41 key=53 sample=*sine
+        <region> sw_last=40 key=54 sample=*sine
+    )");
+    REQUIRE( synth.getNumRegions() == 4 );
+    REQUIRE( !synth.getRegionView(0)->isSwitchedOn() );
+    REQUIRE( synth.getRegionView(1)->isSwitchedOn() );
+    REQUIRE( !synth.getRegionView(2)->isSwitchedOn() );
+    REQUIRE( synth.getRegionView(3)->isSwitchedOn() );
+}
+
+TEST_CASE("[Keyswitches] sw_default and playing with switches")
+{
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/sw_default.sfz", R"(
+        <global> sw_lokey=30 sw_hikey=50 sw_default=40
+        <region> sw_last=41 key=51 sample=*sine
+        <region> sw_last=40 key=52 sample=*sine
+        <region> sw_last=41 key=53 sample=*sine
+        <region> sw_last=40 key=54 sample=*sine
+    )");
+    REQUIRE( synth.getNumRegions() == 4 );
+    REQUIRE( !synth.getRegionView(0)->isSwitchedOn() );
+    REQUIRE( synth.getRegionView(1)->isSwitchedOn() );
+    REQUIRE( !synth.getRegionView(2)->isSwitchedOn() );
+    REQUIRE( synth.getRegionView(3)->isSwitchedOn() );
+    synth.noteOn(0, 41, 64);
+    synth.noteOff(0, 41, 0);
+    REQUIRE( synth.getRegionView(0)->isSwitchedOn() );
+    REQUIRE( !synth.getRegionView(1)->isSwitchedOn() );
+    REQUIRE( synth.getRegionView(2)->isSwitchedOn() );
+    REQUIRE( !synth.getRegionView(3)->isSwitchedOn() );
+    synth.noteOn(0, 40, 64);
+    synth.noteOff(0, 40, 64);
+    REQUIRE( !synth.getRegionView(0)->isSwitchedOn() );
+    REQUIRE( synth.getRegionView(1)->isSwitchedOn() );
+    REQUIRE( !synth.getRegionView(2)->isSwitchedOn() );
+    REQUIRE( synth.getRegionView(3)->isSwitchedOn() );
 }

--- a/tests/RegionActivationT.cpp
+++ b/tests/RegionActivationT.cpp
@@ -177,7 +177,7 @@ TEST_CASE("Region activation", "Region tests")
     }
 }
 
-TEST_CASE("[Keyswitches] Normal keyswitch range")
+TEST_CASE("[Keyswitches] Normal lastKeyswitch range")
 {
     sfz::Synth synth;
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/keyswitches.sfz", R"(
@@ -196,7 +196,7 @@ TEST_CASE("[Keyswitches] Normal keyswitch range")
     REQUIRE(synth.getNumActiveVoices(true) == 2);
 }
 
-TEST_CASE("[Keyswitches] No keyswitch range")
+TEST_CASE("[Keyswitches] No lastKeyswitch range")
 {
     sfz::Synth synth;
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/keyswitches.sfz", R"(
@@ -219,7 +219,7 @@ TEST_CASE("[Keyswitches] No keyswitch range")
     REQUIRE(synth.getNumActiveVoices(true) == 2);
 }
 
-TEST_CASE("[Keyswitches] Out of keyswitch range")
+TEST_CASE("[Keyswitches] Out of lastKeyswitch range")
 {
     sfz::Synth synth;
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/keyswitches.sfz", R"(
@@ -238,7 +238,7 @@ TEST_CASE("[Keyswitches] Out of keyswitch range")
     REQUIRE(synth.getNumActiveVoices(true) == 2);
 }
 
-TEST_CASE("[Keyswitches] Overlapping key and keyswitch range")
+TEST_CASE("[Keyswitches] Overlapping key and lastKeyswitch range")
 {
     sfz::Synth synth;
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/keyswitches.sfz", R"(

--- a/tests/RegionActivationT.cpp
+++ b/tests/RegionActivationT.cpp
@@ -427,7 +427,6 @@ TEST_CASE("[Keyswitches] sw_previous out of range")
 
 TEST_CASE("[Keyswitches] sw_lolast and sw_hilast")
 {
-    // The behavior is the same in this case, regardless of the keyrange
     sfz::Synth synth;
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/sw_previous.sfz", R"(
         <region> sw_lolast=57 sw_hilast=59 key=70 sample=*saw
@@ -460,7 +459,6 @@ TEST_CASE("[Keyswitches] sw_lolast and sw_hilast")
 
 TEST_CASE("[Keyswitches] sw_lolast and sw_hilast with sw_last")
 {
-    // The behavior is the same in this case, regardless of the keyrange
     sfz::Synth synth;
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/sw_previous.sfz", R"(
         <region> sw_last=40 sw_lolast=57 sw_hilast=59 key=70 sample=*saw
@@ -486,4 +484,16 @@ TEST_CASE("[Keyswitches] sw_lolast and sw_hilast with sw_last")
     synth.noteOn(0, 40, 64);
     REQUIRE(!synth.getRegionView(0)->isSwitchedOn());
     REQUIRE(synth.getRegionView(1)->isSwitchedOn());
+}
+
+TEST_CASE("[Keyswitches] sw_lolast and sw_hilast with sw_default")
+{
+    sfz::Synth synth;
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/sw_previous.sfz", R"(
+        <global> sw_default=58
+        <region> sw_lolast=57 sw_hilast=59 key=70 sample=*saw
+        <region> sw_lolast=60 sw_hilast=62 key=72 sample=*sine
+    )");
+    REQUIRE(synth.getRegionView(0)->isSwitchedOn());
+    REQUIRE(!synth.getRegionView(1)->isSwitchedOn());
 }

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -350,58 +350,58 @@ TEST_CASE("[Region] Parsing opcodes")
 
     SECTION("sw_last")
     {
-        REQUIRE(!region.keyswitch);
+        REQUIRE(!region.lastKeyswitch);
         region.parseOpcode({ "sw_last", "4" });
-        REQUIRE(region.keyswitch);
-        REQUIRE(*region.keyswitch == 4);
+        REQUIRE(region.lastKeyswitch);
+        REQUIRE(*region.lastKeyswitch == 4);
         region.parseOpcode({ "sw_last", "128" });
-        REQUIRE(region.keyswitch);
-        REQUIRE(*region.keyswitch == 127);
+        REQUIRE(region.lastKeyswitch);
+        REQUIRE(*region.lastKeyswitch == 127);
         region.parseOpcode({ "sw_last", "-1" });
-        REQUIRE(region.keyswitch);
-        REQUIRE(*region.keyswitch == 0);
+        REQUIRE(region.lastKeyswitch);
+        REQUIRE(*region.lastKeyswitch == 0);
     }
 
     SECTION("sw_up")
     {
-        REQUIRE(!region.keyswitchUp);
+        REQUIRE(!region.upKeyswitch);
         region.parseOpcode({ "sw_up", "4" });
-        REQUIRE(region.keyswitchUp);
-        REQUIRE(*region.keyswitchUp == 4);
+        REQUIRE(region.upKeyswitch);
+        REQUIRE(*region.upKeyswitch == 4);
         region.parseOpcode({ "sw_up", "128" });
-        REQUIRE(region.keyswitchUp);
-        REQUIRE(*region.keyswitchUp == 127);
+        REQUIRE(region.upKeyswitch);
+        REQUIRE(*region.upKeyswitch == 127);
         region.parseOpcode({ "sw_up", "-1" });
-        REQUIRE(region.keyswitchUp);
-        REQUIRE(*region.keyswitchUp == 0);
+        REQUIRE(region.upKeyswitch);
+        REQUIRE(*region.upKeyswitch == 0);
     }
 
     SECTION("sw_down")
     {
-        REQUIRE(!region.keyswitchDown);
+        REQUIRE(!region.downKeyswitch);
         region.parseOpcode({ "sw_down", "4" });
-        REQUIRE(region.keyswitchDown);
-        REQUIRE(*region.keyswitchDown == 4);
+        REQUIRE(region.downKeyswitch);
+        REQUIRE(*region.downKeyswitch == 4);
         region.parseOpcode({ "sw_down", "128" });
-        REQUIRE(region.keyswitchDown);
-        REQUIRE(*region.keyswitchDown == 127);
+        REQUIRE(region.downKeyswitch);
+        REQUIRE(*region.downKeyswitch == 127);
         region.parseOpcode({ "sw_down", "-1" });
-        REQUIRE(region.keyswitchDown);
-        REQUIRE(*region.keyswitchDown == 0);
+        REQUIRE(region.downKeyswitch);
+        REQUIRE(*region.downKeyswitch == 0);
     }
 
     SECTION("sw_previous")
     {
-        REQUIRE(!region.previousNote);
+        REQUIRE(!region.previousKeyswitch);
         region.parseOpcode({ "sw_previous", "4" });
-        REQUIRE(region.previousNote);
-        REQUIRE(*region.previousNote == 4);
+        REQUIRE(region.previousKeyswitch);
+        REQUIRE(*region.previousKeyswitch == 4);
         region.parseOpcode({ "sw_previous", "128" });
-        REQUIRE(region.previousNote);
-        REQUIRE(*region.previousNote == 127);
+        REQUIRE(region.previousKeyswitch);
+        REQUIRE(*region.previousKeyswitch == 127);
         region.parseOpcode({ "sw_previous", "-1" });
-        REQUIRE(region.previousNote);
-        REQUIRE(*region.previousNote == 0);
+        REQUIRE(region.previousKeyswitch);
+        REQUIRE(*region.previousKeyswitch == 0);
     }
 
     SECTION("sw_vel")

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -339,23 +339,6 @@ TEST_CASE("[Region] Parsing opcodes")
         REQUIRE(region.ccConditions[125] == sfz::Range<float>(0.0f, 1.0f));
     }
 
-    SECTION("sw_lokey, sw_hikey")
-    {
-        REQUIRE(region.keyswitchRange == Range<uint8_t>(0, 127));
-        region.parseOpcode({ "sw_lokey", "4" });
-        REQUIRE(region.keyswitchRange == Range<uint8_t>(4, 127));
-        region.parseOpcode({ "sw_lokey", "128" });
-        REQUIRE(region.keyswitchRange == Range<uint8_t>(127, 127));
-        region.parseOpcode({ "sw_lokey", "0" });
-        REQUIRE(region.keyswitchRange == Range<uint8_t>(0, 127));
-        region.parseOpcode({ "sw_hikey", "39" });
-        REQUIRE(region.keyswitchRange == Range<uint8_t>(0, 39));
-        region.parseOpcode({ "sw_hikey", "135" });
-        REQUIRE(region.keyswitchRange == Range<uint8_t>(0, 127));
-        region.parseOpcode({ "sw_hikey", "-1" });
-        REQUIRE(region.keyswitchRange == Range<uint8_t>(0, 0));
-    }
-
     SECTION("sw_label")
     {
         REQUIRE(!region.keyswitchLabel);

--- a/tests/RegionT.cpp
+++ b/tests/RegionT.cpp
@@ -362,6 +362,48 @@ TEST_CASE("[Region] Parsing opcodes")
         REQUIRE(*region.lastKeyswitch == 0);
     }
 
+    SECTION("sw_lolast/hilast")
+    {
+        REQUIRE(!region.lastKeyswitchRange);
+        region.parseOpcode({ "sw_lolast", "4" });
+        REQUIRE(region.lastKeyswitchRange);
+        REQUIRE(*region.lastKeyswitchRange == Range<uint8_t>(4, 4));
+        region.parseOpcode({ "sw_hilast", "128" });
+        REQUIRE(*region.lastKeyswitchRange == Range<uint8_t>(4, 127));
+        region.parseOpcode({ "sw_hilast", "63" });
+        REQUIRE(*region.lastKeyswitchRange == Range<uint8_t>(4, 63));
+        region.parseOpcode({ "sw_lolast", "64" });
+        REQUIRE(*region.lastKeyswitchRange == Range<uint8_t>(64, 64));
+        region.parseOpcode({ "sw_lolast", "-1" });
+        REQUIRE(*region.lastKeyswitchRange == Range<uint8_t>(0, 64));
+    }
+
+    SECTION("sw_hilast disables sw_last")
+    {
+        REQUIRE(!region.lastKeyswitchRange);
+        REQUIRE(!region.lastKeyswitch);
+        region.parseOpcode({ "sw_last", "4" });
+        REQUIRE(region.lastKeyswitch);
+        region.parseOpcode({ "sw_hilast", "63" });
+        REQUIRE(region.lastKeyswitchRange);
+        REQUIRE(!region.lastKeyswitch);
+        region.parseOpcode({ "sw_last", "4" });
+        REQUIRE(!region.lastKeyswitch);
+    }
+
+    SECTION("sw_lolast disables sw_last")
+    {
+        REQUIRE(!region.lastKeyswitchRange);
+        REQUIRE(!region.lastKeyswitch);
+        region.parseOpcode({ "sw_last", "4" });
+        REQUIRE(region.lastKeyswitch);
+        region.parseOpcode({ "sw_lolast", "63" });
+        REQUIRE(region.lastKeyswitchRange);
+        REQUIRE(!region.lastKeyswitch);
+        region.parseOpcode({ "sw_last", "4" });
+        REQUIRE(!region.lastKeyswitch);
+    }
+
     SECTION("sw_up")
     {
         REQUIRE(!region.upKeyswitch);

--- a/tests/RegionValueComputationsT.cpp
+++ b/tests/RegionValueComputationsT.cpp
@@ -7,7 +7,6 @@
 #include "sfizz/Defaults.h"
 #include "sfizz/Region.h"
 #include "sfizz/SfzHelpers.h"
-#include "sfizz/MidiState.h"
 #include "catch2/catch.hpp"
 #include <chrono>
 #include <thread>

--- a/tests/TestFiles/sw_default.sfz
+++ b/tests/TestFiles/sw_default.sfz
@@ -1,5 +1,0 @@
-<global> sw_lokey=30 sw_hikey=50 sw_default=40
-<region> sw_last=41 key=51 sample=*silence
-<region> sw_last=40 key=52 sample=*silence
-<region> sw_last=41 key=53 sample=*silence
-<region> sw_last=40 key=54 sample=*silence


### PR DESCRIPTION
Closes: #423 #389 
Also works towards #341 by letting the synth activate and deactivate regions as needed regarding keyswitches.

Still needs testing, all corner cases should go in the test suite. I will go through the official test suite to integrate as needed.

This reworks keyswitches overall. 

- `sw_lokey` and `sw_hikey` are now ignored more or less, and only effective keyswitches are taken into account for `sw_last`.
- New views are built upon loading to let the synth go through keyswitched regions faster. These may be used later on to gather the set of keyswitches (last, down and up) for UI display if needed.
- `sw_up`, `sw_down`, and `sw_previous` are handled at the synth level too.
- Support for `sw_lolast` and `sw_hilast`. If a label is given, the label is applied to all keys in the keyswitch range.
- Added and shuffled tests around for keyswitches.
