### PR TITLE
Free the audiofile structs on `st_close`

### DIFF
--- a/external/st_audiofile/src/st_audiofile.c
+++ b/external/st_audiofile/src/st_audiofile.c
@@ -155,7 +155,7 @@ void st_close(st_audio_file* af)
         break;
     }
 
-    af->type = st_audio_file_null;
+    free(af);
 }
 
 int st_get_type(st_audio_file* af)

--- a/external/st_audiofile/src/st_audiofile_sndfile.c
+++ b/external/st_audiofile/src/st_audiofile_sndfile.c
@@ -52,10 +52,10 @@ st_audio_file* st_open_file_w(const wchar_t* filename)
 
 void st_close(st_audio_file* af)
 {
-    if (af->snd) {
+    if (af->snd)
         sf_close(af->snd);
-        af->snd = NULL;
-    }
+
+    free(af);
 }
 
 int st_get_type(st_audio_file* af)


### PR DESCRIPTION
Otherwise they leak. Alternative would be an `st_free` on top of `st_close`.