### PR TITLE
Support AIFF files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,3 +27,6 @@
 	path = external/st_audiofile/thirdparty/stb_vorbis
 	url = https://github.com/sfztools/stb_vorbis.git
 	shallow = true
+[submodule "external/st_audiofile/thirdparty/libaiff"]
+	path = external/st_audiofile/thirdparty/libaiff
+	url = https://github.com/sfztools/libaiff.git

--- a/benchmarks/BM_audioReaders.cpp
+++ b/benchmarks/BM_audioReaders.cpp
@@ -94,6 +94,7 @@ public:
 
     static TemporaryFile fileWav;
     static TemporaryFile fileFlac;
+    static TemporaryFile fileAiff;
     static TemporaryFile fileOgg;
 
     std::vector<float> workBuffer;
@@ -101,6 +102,7 @@ public:
 
 TemporaryFile AudioReaderFixture::fileWav = createAudioFile(SF_FORMAT_WAV|SF_FORMAT_PCM_16);
 TemporaryFile AudioReaderFixture::fileFlac = createAudioFile(SF_FORMAT_FLAC|SF_FORMAT_PCM_16);
+TemporaryFile AudioReaderFixture::fileAiff = createAudioFile(SF_FORMAT_AIFF|SF_FORMAT_PCM_16);
 TemporaryFile AudioReaderFixture::fileOgg = createAudioFile(SF_FORMAT_OGG|SF_FORMAT_VORBIS);
 
 TemporaryFile AudioReaderFixture::createAudioFile(int format)
@@ -196,6 +198,27 @@ BENCHMARK_DEFINE_F(AudioReaderFixture, ReverseFlac)(benchmark::State& state)
     }
 }
 
+BENCHMARK_DEFINE_F(AudioReaderFixture, EntireAiff)(benchmark::State& state)
+{
+    for (auto _ : state) {
+        doEntireRead(fileAiff.path());
+    }
+}
+
+BENCHMARK_DEFINE_F(AudioReaderFixture, ForwardAiff)(benchmark::State& state)
+{
+    for (auto _ : state) {
+        doReaderBenchmark(fileAiff.path(), workBuffer, sfz::AudioReaderType::Forward);
+    }
+}
+
+BENCHMARK_DEFINE_F(AudioReaderFixture, ReverseAiff)(benchmark::State& state)
+{
+    for (auto _ : state) {
+        doReaderBenchmark(fileAiff.path(), workBuffer, sfz::AudioReaderType::Reverse);
+    }
+}
+
 BENCHMARK_DEFINE_F(AudioReaderFixture, EntireOgg)(benchmark::State& state)
 {
     for (auto _ : state) {
@@ -225,6 +248,9 @@ BENCHMARK_REGISTER_F(AudioReaderFixture, EntireWav)->Range(1, 1);
 BENCHMARK_REGISTER_F(AudioReaderFixture, ForwardFlac)->RangeMultiplier(2)->Range((1 << 6), (1 << 10));
 BENCHMARK_REGISTER_F(AudioReaderFixture, ReverseFlac)->RangeMultiplier(2)->Range((1 << 6), (1 << 10));
 BENCHMARK_REGISTER_F(AudioReaderFixture, EntireFlac)->Range(1, 1);
+BENCHMARK_REGISTER_F(AudioReaderFixture, ForwardAiff)->RangeMultiplier(2)->Range((1 << 6), (1 << 10));
+BENCHMARK_REGISTER_F(AudioReaderFixture, ReverseAiff)->RangeMultiplier(2)->Range((1 << 6), (1 << 10));
+BENCHMARK_REGISTER_F(AudioReaderFixture, EntireAiff)->Range(1, 1);
 BENCHMARK_REGISTER_F(AudioReaderFixture, ForwardOgg)->RangeMultiplier(2)->Range((1 << 6), (1 << 10));
 #if !defined(ST_AUDIO_FILE_USE_SNDFILE)
 BENCHMARK_REGISTER_F(AudioReaderFixture, ReverseOgg)->RangeMultiplier(2)->Range((1 << 6), (1 << 10));

--- a/common.mk
+++ b/common.mk
@@ -156,6 +156,17 @@ SFIZZ_CXX_FLAGS += $(SFIZZ_SNDFILE_CXX_FLAGS) -DST_AUDIO_FILE_USE_SNDFILE=1
 SFIZZ_LINK_FLAGS += $(SFIZZ_SNDFILE_LINK_FLAGS)
 endif
 
+# libaiff dependency
+
+ifneq ($(SFIZZ_USE_SNDFILE),1)
+SFIZZ_SOURCES += \
+	$(SFIZZ_DIR)/external/st_audiofile/thirdparty/libaiff/libaiff.all.c
+SFIZZ_C_FLAGS += \
+	-I$(SFIZZ_DIR)/external/st_audiofile/thirdparty/libaiff
+SFIZZ_CXX_FLAGS += \
+	-I$(SFIZZ_DIR)/external/st_audiofile/thirdparty/libaiff
+endif
+
 ### Abseil dependency
 
 SFIZZ_C_FLAGS += -I$(SFIZZ_DIR)/external/abseil-cpp

--- a/external/st_audiofile/CMakeLists.txt
+++ b/external/st_audiofile/CMakeLists.txt
@@ -19,7 +19,10 @@ add_executable(st_info
 target_link_libraries(st_info
     PRIVATE st_audiofile)
 
-if(ST_AUDIO_FILE_USE_SNDFILE)
+if(NOT ST_AUDIO_FILE_USE_SNDFILE)
+    add_subdirectory("thirdparty/libaiff" EXCLUDE_FROM_ALL)
+    target_link_libraries(st_audiofile PRIVATE aiff::aiff)
+else()
     target_compile_definitions(st_audiofile
         PUBLIC "ST_AUDIO_FILE_USE_SNDFILE=1")
     if(ST_AUDIO_FILE_EXTERNAL_SNDFILE)

--- a/external/st_audiofile/src/st_audiofile.h
+++ b/external/st_audiofile/src/st_audiofile.h
@@ -23,6 +23,7 @@ typedef struct st_audio_file st_audio_file;
 typedef enum st_audio_file_type {
     st_audio_file_wav,
     st_audio_file_flac,
+    st_audio_file_aiff,
     st_audio_file_ogg,
     st_audio_file_mp3,
     st_audio_file_other,

--- a/external/st_audiofile/src/st_audiofile_common.c
+++ b/external/st_audiofile/src/st_audiofile_common.c
@@ -23,6 +23,9 @@ const char* st_type_string(int type)
     case st_audio_file_flac:
         type_string = "FLAC";
         break;
+    case st_audio_file_aiff:
+        type_string = "AIFF";
+        break;
     case st_audio_file_ogg:
         type_string = "OGG";
         break;

--- a/external/st_audiofile/src/st_audiofile_libs.c
+++ b/external/st_audiofile/src/st_audiofile_libs.c
@@ -4,6 +4,7 @@
 // license. You should have receive a LICENSE.md file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
+#if !defined(ST_AUDIO_FILE_USE_SNDFILE)
 #define DR_WAV_IMPLEMENTATION
 #define DR_FLAC_IMPLEMENTATION
 #define DR_MP3_IMPLEMENTATION
@@ -27,3 +28,5 @@ stb_vorbis* stb_vorbis_open_filename_w(const wchar_t* filename, int* error, cons
    return NULL;
 }
 #endif
+
+#endif // !defined(ST_AUDIO_FILE_USE_SNDFILE)

--- a/external/st_audiofile/src/st_audiofile_libs.h
+++ b/external/st_audiofile/src/st_audiofile_libs.h
@@ -14,6 +14,7 @@
 #   undef STB_VORBIS_HEADER_ONLY
 #endif
 #include "stb_vorbis.c"
+#include "libaiff/libaiff.h"
 
 #if defined(_WIN32)
 #include <wchar.h>

--- a/external/st_audiofile/src/st_audiofile_sndfile.c
+++ b/external/st_audiofile/src/st_audiofile_sndfile.c
@@ -69,6 +69,9 @@ int st_get_type(st_audio_file* af)
     case SF_FORMAT_FLAC:
         type = st_audio_file_flac;
         break;
+    case SF_FORMAT_AIFF:
+        type = st_audio_file_aiff;
+        break;
     case SF_FORMAT_OGG:
         type = st_audio_file_ogg;
         break;

--- a/src/sfizz/FileMetadata.h
+++ b/src/sfizz/FileMetadata.h
@@ -113,9 +113,19 @@ public:
     size_t readRiffData(size_t index, void* buffer, size_t count);
 
     /**
+     * @brief Extract the instrument data and convert it to sndfile instrument
+     */
+    bool extractInstrument(InstrumentInfo& ins);
+
+    /**
      * @brief Extract the RIFF 'smpl' data and convert it to sndfile instrument
      */
     bool extractRiffInstrument(InstrumentInfo& ins);
+
+    /**
+     * @brief Extract the AIFF 'INST' data and convert it to sndfile instrument
+     */
+    bool extractAiffInstrument(InstrumentInfo& ins);
 
     /**
      * @brief Extract the wavetable information from various relevant RIFF chunks

--- a/src/sfizz/FilePool.cpp
+++ b/src/sfizz/FilePool.cpp
@@ -243,7 +243,7 @@ absl::optional<sfz::FileInformation> sfz::FilePool::getFileInformation(const Fil
     if (!haveInstrumentInfo) {
         // if no instrument, then try extracting from embedded RIFF chunks (flac)
         if (mdReaderOpened)
-            haveInstrumentInfo = mdReader.extractRiffInstrument(instrumentInfo);
+            haveInstrumentInfo = mdReader.extractInstrument(instrumentInfo);
     }
 
     if (mdReaderOpened) {

--- a/tests/FileInstrument.cpp
+++ b/tests/FileInstrument.cpp
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
             return 1;
         }
         sfz::InstrumentInfo ins {};
-        if (!reader.extractRiffInstrument(ins)) {
+        if (!reader.extractInstrument(ins)) {
             fprintf(stderr, "Cannot get instrument\n");
             return 1;
         }


### PR DESCRIPTION
This adds support of AIFF files using a library as submodule.
It enables coverage of SFZ required formats without the libsndfile requirement.

- [x] loops
- [x] compression
- [x] performance

While not a blocker, it's important noting that the library is several times slower than the wav decoder at this time.
EDIT improved 4-5x by PCM→float optimization in libaiff
