### PR TITLE
Process WAV chunk padding correctly

### DIFF
--- a/src/sfizz/FileMetadata.cpp
+++ b/src/sfizz/FileMetadata.cpp
@@ -231,7 +231,7 @@ bool FileMetadataReader::Impl::openRiff()
         info.length = riffChunkSize;
         riffChunks.push_back(info);
 
-        if (fseek(stream, riffChunkSize, SEEK_CUR) != 0)
+        if (fseek(stream, riffChunkSize + (riffChunkSize & 1), SEEK_CUR) != 0)
             return false;
     }
 


### PR DESCRIPTION
The chunks of WAV files have to be 2 byte-aligned, the same as AIFF.
Usually this case is not met because WAV standard chunks are even-sized, but custom chunks can be an exception.

https://github.com/mackron/dr_libs/blob/cac1785cee4abb455817b43d5dee33b49d61be2f/dr_wav.h#L1526