### PR TITLE
Add OSC and plugin-side communication

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -89,6 +89,7 @@ SFIZZ_SOURCES = \
 	src/sfizz/Logger.cpp \
 	src/sfizz/LFO.cpp \
 	src/sfizz/LFODescription.cpp \
+	src/sfizz/Messaging.cpp \
 	src/sfizz/MidiState.cpp \
 	src/sfizz/OpcodeCleanup.cpp \
 	src/sfizz/Opcode.cpp \
@@ -112,6 +113,7 @@ SFIZZ_SOURCES = \
 	src/sfizz/simd/HelpersAVX.cpp \
 	src/sfizz/Smoothers.cpp \
 	src/sfizz/Synth.cpp \
+	src/sfizz/SynthMessaging.cpp \
 	src/sfizz/Tuning.cpp \
 	src/sfizz/utility/SpinMutex.cpp \
 	src/sfizz/Voice.cpp \

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(sfizz_editor STATIC EXCLUDE_FROM_ALL
     src/editor/utility/vstgui_after.h
     src/editor/utility/vstgui_before.h)
 target_include_directories(sfizz_editor PUBLIC "src")
+target_link_libraries(sfizz_editor PUBLIC sfizz_messaging)
 target_link_libraries(sfizz_editor PRIVATE sfizz-vstgui)
 target_link_libraries(sfizz_editor PUBLIC absl::strings)
 if(APPLE)

--- a/editor/src/editor/Editor.cpp
+++ b/editor/src/editor/Editor.cpp
@@ -100,6 +100,7 @@ struct Editor::Impl : EditorController::Receiver, IControlListener {
     SPiano* piano_ = nullptr;
 
     void uiReceiveValue(EditId id, const EditValue& v) override;
+    void uiReceiveMessage(const char* path, const char* sig, const sfizz_arg_t* args) override;
 
     void createFrameContents();
 
@@ -316,6 +317,11 @@ void Editor::Impl::uiReceiveValue(EditId id, const EditValue& v)
         }
         break;
     }
+}
+
+void Editor::Impl::uiReceiveMessage(const char* path, const char* sig, const sfizz_arg_t* args)
+{
+    // TODO handle the message...
 }
 
 void Editor::Impl::createFrameContents()

--- a/editor/src/editor/EditorController.h
+++ b/editor/src/editor/EditorController.h
@@ -6,6 +6,7 @@
 
 #pragma once
 #include "EditValue.h"
+#include <sfizz_message.h>
 #include <absl/strings/string_view.h>
 #include <string>
 #include <cstdint>
@@ -20,6 +21,7 @@ public:
     virtual void uiBeginSend(EditId id) = 0;
     virtual void uiEndSend(EditId id) = 0;
     virtual void uiSendMIDI(const uint8_t* msg, uint32_t len) = 0;
+    virtual void uiSendMessage(const char* path, const char* sig, const sfizz_arg_t* args) = 0;
     class Receiver;
     void decorate(Receiver* r) { r_ = r; }
 
@@ -27,10 +29,12 @@ public:
     public:
         virtual ~Receiver() {}
         virtual void uiReceiveValue(EditId id, const EditValue& v) = 0;
+        virtual void uiReceiveMessage(const char* path, const char* sig, const sfizz_arg_t* args) = 0;
     };
 
     // called by DSP
     void uiReceiveValue(EditId id, const EditValue& v);
+    void uiReceiveMessage(const char* path, const char* sig, const sfizz_arg_t* args);
 
 private:
     Receiver* r_ = nullptr;
@@ -40,4 +44,10 @@ inline void EditorController::uiReceiveValue(EditId id, const EditValue& v)
 {
     if (r_)
         r_->uiReceiveValue(id, v);
+}
+
+inline void EditorController::uiReceiveMessage(const char* path, const char* sig, const sfizz_arg_t* args)
+{
+    if (r_)
+        r_->uiReceiveMessage(path, sig, args);
 }

--- a/lv2/sfizz.ttl.in
+++ b/lv2/sfizz.ttl.in
@@ -11,6 +11,7 @@
 @prefix pprop:   <http://lv2plug.in/ns/ext/port-props#> .
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsz:     <http://lv2plug.in/ns/ext/resize-port#> .
 @prefix state:   <http://lv2plug.in/ns/ext/state#> .
 @prefix time:    <http://lv2plug.in/ns/ext/time#> .
 @prefix ui:      <http://lv2plug.in/ns/extensions/ui#> .
@@ -92,21 +93,23 @@ midnam:update a lv2:Feature .
   lv2:port [
     a lv2:InputPort, atom:AtomPort ;
     atom:bufferType atom:Sequence ;
-    atom:supports patch:Message, midi:MidiEvent, time:Position ;
+    atom:supports patch:Message, midi:MidiEvent, time:Position, <@LV2PLUGIN_URI@:OSCBlob> ;
     lv2:designation lv2:control ;
     lv2:index 0 ;
     lv2:symbol "control" ;
     lv2:name "Control",
       "Contrôle"@fr ;
+    rsz:minimumSize 65536 ;
   ] , [
     a lv2:OutputPort, atom:AtomPort ;
     atom:bufferType atom:Sequence ;
-    atom:supports patch:Message ;
+    atom:supports patch:Message, <@LV2PLUGIN_URI@:OSCBlob> ;
     lv2:designation lv2:control ;
     lv2:index 1 ;
     lv2:symbol "notify" ;
     lv2:name "Notify",
       "Notification"@fr ;
+    rsz:minimumSize 65536 ;
   ] , [
     a lv2:AudioPort, lv2:OutputPort ;
     lv2:index 2 ;

--- a/lv2/sfizz_lv2.h
+++ b/lv2/sfizz_lv2.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #define MAX_PATH_SIZE 1024
+#define ATOM_TEMP_SIZE 8192
+#define OSC_TEMP_SIZE 8192
 
 #define SFIZZ_URI "http://sfztools.github.io/sfizz"
 #define SFIZZ_UI_URI "http://sfztools.github.io/sfizz#ui"
@@ -19,6 +21,8 @@
 // These ones are just for the worker
 #define SFIZZ__logStatus SFIZZ_URI ":" "log_status"
 #define SFIZZ__checkModification SFIZZ_URI ":" "check_modification"
+// OSC atoms
+#define SFIZZ__OSCBlob SFIZZ_URI ":" "OSCBlob"
 
 enum
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,6 +148,7 @@ set (SFIZZ_SOURCES
     sfizz/PowerFollower.cpp
     sfizz/FlexEGDescription.cpp
     sfizz/FlexEnvelope.cpp
+    sfizz/SynthMessaging.cpp
     sfizz/modulations/ModId.cpp
     sfizz/modulations/ModKey.cpp
     sfizz/modulations/ModKeyHash.cpp
@@ -206,12 +207,27 @@ set (SFIZZ_PARSER_SOURCES
 set (SFIZZ_PARSER_OTHER sfizz/OpcodeCleanup.re)
 source_group ("Other Files" FILES ${SFIZZ_PARSER_OTHER})
 
+# Sfizz parser library
 add_library (sfizz_parser STATIC)
 target_sources (sfizz_parser PRIVATE
     ${SFIZZ_PARSER_HEADERS} ${SFIZZ_PARSER_SOURCES} ${SFIZZ_PARSER_OTHER})
 target_include_directories (sfizz_parser PUBLIC sfizz)
 target_include_directories (sfizz_parser PUBLIC external)
 target_link_libraries (sfizz_parser PUBLIC absl::strings PRIVATE absl::flat_hash_map)
+
+# OSC messaging library
+set (SFIZZ_MESSAGING_HEADERS
+    sfizz/Messaging.h
+    sfizz_message.h)
+
+set (SFIZZ_MESSAGING_SOURCES
+    sfizz/Messaging.cpp)
+
+add_library (sfizz_messaging STATIC)
+target_sources (sfizz_messaging PRIVATE
+    ${SFIZZ_MESSAGING_HEADERS} ${SFIZZ_MESSAGING_SOURCES})
+target_include_directories (sfizz_messaging PUBLIC ".")
+target_link_libraries (sfizz_messaging PUBLIC absl::strings)
 
 # Sfizz static library
 add_library(sfizz_static STATIC)
@@ -220,8 +236,8 @@ target_sources(sfizz_static PRIVATE
 target_include_directories (sfizz_static PUBLIC .)
 target_include_directories (sfizz_static PUBLIC external)
 target_link_libraries (sfizz_static PUBLIC absl::strings absl::span)
-target_link_libraries (sfizz_static PRIVATE sfizz_parser absl::flat_hash_map Threads::Threads st_audiofile sfizz-pugixml sfizz-spline sfizz-tunings sfizz-kissfft sfizz-cpuid sfizz-jsl sfizz-atomic)
-set_target_properties (sfizz_static PROPERTIES OUTPUT_NAME sfizz PUBLIC_HEADER "sfizz.h;sfizz.hpp")
+target_link_libraries (sfizz_static PRIVATE sfizz_parser sfizz_messaging absl::flat_hash_map Threads::Threads st_audiofile sfizz-pugixml sfizz-spline sfizz-tunings sfizz-kissfft sfizz-cpuid sfizz-jsl sfizz-atomic)
+set_target_properties (sfizz_static PROPERTIES OUTPUT_NAME sfizz PUBLIC_HEADER "sfizz.h;sfizz.hpp;sfizz_message.h")
 if(SFIZZ_USE_SNDFILE)
     target_compile_definitions (sfizz_static PUBLIC SFIZZ_USE_SNDFILE=1)
     target_link_libraries (sfizz_static PUBLIC st_audiofile)
@@ -251,7 +267,7 @@ if (SFIZZ_SHARED)
         ${SFIZZ_HEADERS} ${SFIZZ_SOURCES} ${FAUST_FILES} sfizz/sfizz_wrapper.cpp sfizz/sfizz.cpp)
     target_include_directories (sfizz_shared PRIVATE .)
     target_include_directories (sfizz_shared PRIVATE external)
-    target_link_libraries (sfizz_shared PRIVATE absl::strings absl::span sfizz_parser absl::flat_hash_map Threads::Threads st_audiofile sfizz-pugixml sfizz-spline sfizz-tunings sfizz-kissfft sfizz-cpuid sfizz-jsl sfizz-atomic)
+    target_link_libraries (sfizz_shared PRIVATE absl::strings absl::span sfizz_parser sfizz_messaging absl::flat_hash_map Threads::Threads st_audiofile sfizz-pugixml sfizz-spline sfizz-tunings sfizz-kissfft sfizz-cpuid sfizz-jsl sfizz-atomic)
     if(SFIZZ_USE_SNDFILE)
         target_compile_definitions (sfizz_shared PUBLIC SFIZZ_USE_SNDFILE=1)
         target_link_libraries (sfizz_shared PUBLIC st_audiofile)
@@ -263,7 +279,7 @@ if (SFIZZ_SHARED)
         target_compile_definitions (sfizz_shared PRIVATE "SFIZZ_ENABLE_RELEASE_ASSERT=1")
     endif()
     target_compile_definitions(sfizz_shared PRIVATE SFIZZ_EXPORT_SYMBOLS)
-    set_target_properties (sfizz_shared PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR} OUTPUT_NAME sfizz PUBLIC_HEADER "sfizz.h;sfizz.hpp")
+    set_target_properties (sfizz_shared PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR} OUTPUT_NAME sfizz PUBLIC_HEADER "sfizz.h;sfizz.hpp;sfizz_message.h")
     sfizz_enable_lto_if_needed(sfizz_shared)
     sfizz_enable_fast_math(sfizz_shared)
 

--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -10,6 +10,7 @@
 */
 
 #pragma once
+#include "sfizz_message.h"
 #include <stddef.h>
 #include <stdbool.h>
 
@@ -730,6 +731,79 @@ SFIZZ_EXPORTED_API int sfizz_get_cc_label_number(sfizz_synth_t* synth, int label
  * @returns the label or @null if the index is out of bounds.
  */
 SFIZZ_EXPORTED_API const char * sfizz_get_cc_label_text(sfizz_synth_t* synth, int label_index);
+
+/**
+ * @addtogroup Messaging
+ * @{
+ */
+
+/**
+ * @brief Client for communicating with the synth engine in either direction
+ * @since 0.6.0
+ */
+typedef struct sfizz_client_t sfizz_client_t;
+
+/**
+ * @brief Create a new messaging client
+ * @since 0.6.0
+ *
+ * @param data         The opaque data pointer which is passed to the receiver.
+ * @return             The new client.
+ */
+SFIZZ_EXPORTED_API sfizz_client_t* sfizz_create_client(void* data);
+
+/**
+ * @brief Destroy a messaging client
+ * @since 0.6.0
+ *
+ * @param client       The client.
+ */
+SFIZZ_EXPORTED_API void sfizz_delete_client(sfizz_client_t* client);
+
+/**
+ * @brief Get the client data
+ * @since 0.6.0
+ *
+ * @param client       The client.
+ * @return             The client data.
+ */
+SFIZZ_EXPORTED_API void* sfizz_get_client_data(sfizz_client_t* client);
+
+/**
+ * @brief Set the function which receives reply messages from the synth engine.
+ * @since 0.6.0
+ *
+ * @param client       The client.
+ * @param receive      The pointer to the receiving function.
+ */
+SFIZZ_EXPORTED_API void sfizz_set_receive_callback(sfizz_client_t* client, sfizz_receive_t* receive);
+
+/**
+ * @brief Send a message to the synth engine
+ * @since 0.6.0
+ *
+ * @param synth        The synth.
+ * @param client       The client sending the message.
+ * @param delay        The delay of the message in the block, in samples.
+ * @param path         The OSC address pattern.
+ * @param sig          The OSC type tag string.
+ * @param args         The OSC arguments, whose number and format is determined the type tag string.
+ */
+SFIZZ_EXPORTED_API void sfizz_send_message(sfizz_synth_t* synth, sfizz_client_t* client, int delay, const char* path, const char* sig, const sfizz_arg_t* args);
+
+/**
+ * @brief Set the function which receives broadcast messages from the synth engine.
+ * @since 0.6.0
+ *
+ * @param synth        The synth.
+ * @param broadcast    The pointer to the receiving function.
+ * @param data         The opaque data pointer which is passed to the receiver.
+ */
+SFIZZ_EXPORTED_API void sfizz_set_broadcast_callback(sfizz_synth_t* synth, sfizz_receive_t* broadcast, void* data);
+
+/**
+ * @}
+ */
 
 #ifdef __cplusplus
 }

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -10,6 +10,7 @@
 */
 
 #pragma once
+#include "sfizz_message.h"
 #include <string>
 #include <utility>
 #include <vector>
@@ -28,6 +29,7 @@
 namespace sfz
 {
 class Synth;
+class Client;
 /**
  * @brief Main class.
  */
@@ -565,7 +567,75 @@ public:
      */
     const std::vector<std::pair<uint16_t, std::string>>& getCCLabels() const noexcept;
 
+    /**
+     * @addtogroup Messaging
+     * @{
+     */
+
+private:
+    struct ClientDeleter {
+        void operator()(Client *client) const noexcept;
+    };
+
+public:
+    using ClientPtr = std::unique_ptr<Client, ClientDeleter>;
+
+    /**
+     * @brief Create a new messaging client
+     * @since 0.6.0
+     *
+     * @param data         The opaque data pointer which is passed to the receiver.
+     * @return             The new client.
+     */
+    static ClientPtr createClient(void* data);
+
+    /**
+     * @brief Get the client data
+     * @since 0.6.0
+     *
+     * @param client       The client.
+     * @return             The client data.
+     */
+    static void* getClientData(Client& client);
+
+    /**
+     * @brief Set the function which receives reply messages from the synth engine.
+     * @since 0.6.0
+     *
+     * @param client       The client.
+     * @param receive      The pointer to the receiving function.
+     */
+    static void setReceiveCallback(Client& client, sfizz_receive_t* receive);
+
+    /**
+     * @brief Send a message to the synth engine
+     * @since 0.6.0
+     *
+     * @param client       The client sending the message.
+     * @param delay        The delay of the message in the block, in samples.
+     * @param path         The OSC address pattern.
+     * @param sig          The OSC type tag string.
+     * @param args         The OSC arguments, whose number and format is determined the type tag string.
+     */
+    void sendMessage(Client& client, int delay, const char* path, const char* sig, const sfizz_arg_t* args);
+
+    /**
+     * @brief Set the function which receives broadcast messages from the synth engine.
+     * @since 0.6.0
+     *
+     * @param broadcast    The pointer to the receiving function.
+     * @param data         The opaque data pointer which is passed to the receiver.
+     */
+    void setBroadcastCallback(sfizz_receive_t* broadcast, void* data);
+
+    /**
+     * @}
+     */
+
 private:
     std::unique_ptr<sfz::Synth> synth;
 };
+
+using ClientPtr = Sfizz::ClientPtr;
+
 }

--- a/src/sfizz/Messaging.cpp
+++ b/src/sfizz/Messaging.cpp
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "Messaging.h"
+#include <absl/strings/string_view.h>
+#include <algorithm>
+#include <type_traits>
+#include <cstring>
+
+#ifdef __cplusplus
+static_assert(
+    sizeof(sfizz_arg_t) == sizeof(int64_t) && alignof(sfizz_arg_t) == 8,
+    "The ABI stability check has failed.");
+#endif
+
+template <class T>
+static T paddingSize(T count, unsigned align) {
+    unsigned mask = align - 1;
+    return (align - (count & mask)) & mask;
+};
+
+///
+class OSCWriter {
+public:
+    void setOutputBuffer(void* buffer, uint32_t capacity);
+    uint32_t writeMessage(const char* path, const char* sig, const sfizz_arg_t* args);
+
+private:
+    uint32_t appendBytes(const void* src, uint32_t count);
+    uint32_t appendZeros(uint32_t count);
+    template <class T> uint32_t appendInteger(T integer);
+    uint32_t appendFloat(float f);
+    uint32_t appendDouble(float d);
+
+private:
+    uint8_t* dstBuffer_ = nullptr;
+    uint32_t dstCapacity_ = 0;
+};
+
+class OSCReader {
+public:
+    void setInputBuffer(const void* buffer, uint32_t capacity);
+    void setAllocationBuffer(void* buffer, uint32_t capacity);
+    int32_t extractMessage(const char** outPath, const char** outSig, const sfizz_arg_t** outArgs);
+
+private:
+    template <class T> T* allocate(uint32_t count);
+    bool extractString(const char*& outStr, uint32_t& outLen);
+    template <class T> bool extractInteger(T& outValue);
+    bool extractFloat(float& f);
+    bool extractDouble(double& d);
+
+private:
+    const uint8_t* srcBuffer_ = nullptr;
+    uint32_t srcCapacity_ = 0;
+    uint8_t* allocBuffer_ = nullptr;
+    uint32_t allocCapacity_ = 0;
+};
+
+///
+extern "C" uint32_t sfizz_prepare_message(
+    void* buffer, uint32_t capacity,
+    const char* path, const char* sig, const sfizz_arg_t* args)
+{
+    OSCWriter writer;
+    writer.setOutputBuffer(buffer, capacity);
+    return writer.writeMessage(path, sig, args);
+}
+
+extern "C" int32_t sfizz_extract_message(
+    const void* srcBuffer, uint32_t srcCapacity,
+    void* argsBuffer, uint32_t argsCapacity,
+    const char** outPath, const char** outSig, const sfizz_arg_t** outArgs)
+{
+    OSCReader reader;
+    reader.setInputBuffer(srcBuffer, srcCapacity);
+    reader.setAllocationBuffer(argsBuffer, argsCapacity);
+    return reader.extractMessage(outPath, outSig, outArgs);
+}
+
+///
+void OSCWriter::setOutputBuffer(void* buffer, uint32_t capacity)
+{
+    dstBuffer_ = reinterpret_cast<uint8_t*>(buffer);
+    dstCapacity_ = capacity;
+}
+
+uint32_t OSCWriter::writeMessage(const char* path, const char* sig, const sfizz_arg_t* args)
+{
+    uint32_t msglen = 0;
+
+    // write path, null byte, and 4byte padding
+    uint32_t pathlen = static_cast<uint32_t>(strlen(path));
+    msglen += appendBytes(path, pathlen + 1);
+    msglen += appendZeros(paddingSize(pathlen + 1, 4));
+
+    // write comma, signature, null byte, and 4byte padding
+    uint32_t siglen = static_cast<uint32_t>(strlen(sig));
+    msglen += appendBytes(",", 1);
+    msglen += appendBytes(sig, siglen + 1);
+    msglen += appendZeros(paddingSize(siglen + 2, 4));
+
+    // write arguments
+    for (uint32_t i = 0; i < siglen; ++i) {
+        switch (sig[i]) {
+        default:
+            return 0;
+        case 'i':
+        case 'c':
+        case 'r':
+            msglen += appendInteger(args[i].i);
+            break;
+        case 'm':
+            msglen += appendBytes(args[i].m, 4);
+            break;
+        case 'h':
+            msglen += appendInteger(args[i].h);
+            break;
+        case 'f':
+            msglen += appendFloat(args[i].f);
+            break;
+        case 'd':
+            msglen += appendDouble(args[i].d);
+            break;
+        case 's':
+        case 'S':
+            {
+                size_t len = strlen(args[i].s);
+                msglen += appendBytes(args[i].s, len + 1);
+                msglen += appendZeros(paddingSize(len + 1, 4));
+            }
+            break;
+        case 'b':
+            {
+                msglen += appendInteger(args[i].b->size);
+                msglen += appendBytes(args[i].b->data, args[i].b->size);
+                msglen += appendZeros(paddingSize(args[i].b->size, 4));
+            }
+            break;
+        case 'T':
+        case 'F':
+        case 'N':
+        case 'I':
+            break;
+        }
+    }
+
+    return msglen;
+}
+
+uint32_t OSCWriter::appendBytes(const void* src, uint32_t count)
+{
+    uint32_t written = std::min(dstCapacity_, count);
+    memcpy(dstBuffer_, src, written);
+    dstBuffer_ += written;
+    dstCapacity_ -= written;
+    return count;
+}
+
+uint32_t OSCWriter::appendZeros(uint32_t count)
+{
+    uint32_t written = std::min(dstCapacity_, count);
+    memset(dstBuffer_, '\0', written);
+    dstBuffer_ += written;
+    dstCapacity_ -= written;
+    return count;
+}
+
+template <class T> uint32_t OSCWriter::appendInteger(T integer)
+{
+    using U = typename std::make_unsigned<T>::type;
+    const U uinteger = static_cast<U>(integer);
+    uint8_t data[sizeof(U)];
+    for (unsigned i = 0; i < sizeof(U); ++i) {
+        unsigned sh = 8 * (sizeof(U) - 1 - i);
+        data[i] = (uint8_t)((uinteger >> sh) & 0xff);
+    }
+    return appendBytes(data, sizeof(U));
+}
+
+uint32_t OSCWriter::appendFloat(float f)
+{
+    union { float f; uint32_t i; } u;
+    u.f = f;
+    return appendInteger(u.i);
+}
+
+uint32_t OSCWriter::appendDouble(float d)
+{
+    union { double d; uint64_t i; } u;
+    u.d = d;
+    return appendInteger(u.i);
+}
+
+///
+void OSCReader::setInputBuffer(const void* buffer, uint32_t capacity)
+{
+    srcBuffer_ = reinterpret_cast<const uint8_t*>(buffer);
+    srcCapacity_ = capacity;
+}
+
+void OSCReader::setAllocationBuffer(void* buffer, uint32_t capacity)
+{
+    allocBuffer_ = reinterpret_cast<uint8_t*>(buffer);
+    allocCapacity_ = capacity;
+}
+
+int32_t OSCReader::extractMessage(const char** outPath, const char** outSig, const sfizz_arg_t** outArgs)
+{
+    const uint8_t* const srcStart = srcBuffer_;
+
+    // read path, null byte
+    const char* path;
+    uint32_t pathlen;
+    if (!extractString(path, pathlen))
+        return 0;
+    if (outPath)
+        *outPath = path;
+
+    // read signature, null byte
+    const char* sig;
+    uint32_t siglen;
+    if (!extractString(sig, siglen) || sig[0] != ',')
+        return 0;
+    ++sig;
+    --siglen;
+    if (outSig)
+        *outSig = sig;
+
+    // read arguments
+    sfizz_arg_t* args = allocate<sfizz_arg_t>(siglen);
+    if (!args)
+        return -1;
+    if (outArgs)
+        *outArgs = args;
+
+    for (uint32_t i = 0, n = siglen; i < n; ++i) {
+        switch (sig[i]) {
+        default:
+            return 0;
+        case 'i':
+        case 'c':
+        case 'r':
+            if (!extractInteger(args[i].i))
+                return 0;
+            break;
+        case 'm':
+            if (srcCapacity_ < 4)
+                return 0;
+            memcpy(args[i].m, srcBuffer_, 4);
+            srcBuffer_ += 4;
+            srcCapacity_ -= 4;
+            break;
+        case 'h':
+            if (!extractInteger(args[i].h))
+                return 0;
+            break;
+        case 'f':
+            if (!extractFloat(args[i].f))
+                return 0;
+            break;
+        case 'd':
+            if (!extractDouble(args[i].d))
+                return 0;
+            break;
+        case 's':
+        case 'S':
+            {
+                const char* str;
+                uint32_t len;
+                if (!extractString(str, len))
+                    return 0;
+                args[i].s = str;
+            }
+            break;
+        case 'b':
+            {
+                sfizz_blob_t* blob = allocate<sfizz_blob_t>(1);
+                if (!blob)
+                    return -1;
+                args[i].b = blob;
+                uint32_t len = blob->size;
+                if (!extractInteger(len))
+                    return 0;
+                uint32_t padlen = len + paddingSize(len, 4);
+                if (srcCapacity_ < padlen)
+                    return 0;
+                blob->data = srcBuffer_;
+                blob->size = len;
+                srcBuffer_ += padlen;
+                srcCapacity_ -= padlen;
+            }
+            break;
+        case 'T':
+        case 'F':
+        case 'N':
+        case 'I':
+            break;
+        }
+    }
+
+    return srcBuffer_ - srcStart;
+}
+
+template <class T> T* OSCReader::allocate(uint32_t count)
+{
+    uintptr_t pad = paddingSize(reinterpret_cast<uintptr_t>(allocBuffer_), alignof(T));
+    uint32_t size = count * sizeof(T);
+    if (allocCapacity_ < pad + size)
+        return nullptr;
+    void* ptr = allocBuffer_ + pad;
+    allocBuffer_ += pad + size;
+    allocCapacity_ -= pad + size;
+    return reinterpret_cast<T *>(ptr);
+}
+
+bool OSCReader::extractString(const char*& outStr, uint32_t& outLen)
+{
+    const char* str = reinterpret_cast<const char*>(srcBuffer_);
+    uint32_t len = static_cast<uint32_t>(strnlen(str, srcCapacity_));
+    if (len == srcCapacity_)
+        return false;
+    uint32_t padlen = len + 1 + paddingSize(len + 1, 4);
+    if (padlen > srcCapacity_)
+        return false;
+    srcBuffer_ += padlen;
+    srcCapacity_ -= padlen;
+    outStr = str;
+    outLen = len;
+    return true;
+}
+
+template <class T> bool OSCReader::extractInteger(T& outValue)
+{
+    if (srcCapacity_ < sizeof(T))
+        return false;
+    using U = typename std::make_unsigned<T>::type;
+    U value = 0;
+    const uint8_t* src = reinterpret_cast<const uint8_t*>(srcBuffer_);
+    for (unsigned i = 0; i < sizeof(T); ++i)
+        value = (value << 8) | src[i];
+    srcBuffer_ += sizeof(T);
+    srcCapacity_ -= sizeof(T);
+    outValue = static_cast<T>(value);
+    return true;
+};
+
+bool OSCReader::extractFloat(float& f)
+{
+    union { float f; uint32_t i; } u;
+    if (!extractInteger(u.i))
+        return false;
+    f = u.f;
+    return true;
+}
+
+bool OSCReader::extractDouble(double& d)
+{
+    union { double d; uint64_t i; } u;
+    if (!extractInteger(u.i))
+        return false;
+    d = u.d;
+    return true;
+}

--- a/src/sfizz/Messaging.h
+++ b/src/sfizz/Messaging.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include "sfizz_message.h"
+
+namespace sfz {
+
+class Client {
+public:
+    explicit Client(void* data) : data_(data) {}
+    void* getClientData() const { return data_; }
+    void setReceiveCallback(sfizz_receive_t* receive) { receive_ = receive; }
+    bool canReceive() const { return receive_ != nullptr; }
+    void receive(int delay, const char* path, const char* sig, const sfizz_arg_t* args);
+
+private:
+    void* data_ = nullptr;
+    sfizz_receive_t* receive_ = nullptr;
+};
+
+inline void Client::receive(int delay, const char* path, const char* sig, const sfizz_arg_t* args)
+{
+    if (receive_)
+        receive_(data_, delay, path, sig, args);
+}
+
+} // namespace sfz

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -298,6 +298,10 @@ struct Synth::Impl final: public Parser::Listener {
     fs::file_time_type modificationTime_ { };
 
     std::array<float, config::numCCs> defaultCCValues_;
+
+    // Messaging
+    sfizz_receive_t* broadcastReceiver = nullptr;
+    void* broadcastData = nullptr;
 };
 
 Synth::Synth()
@@ -1951,6 +1955,13 @@ std::bitset<config::numCCs> Synth::getUsedCCs() const noexcept
         impl.updateUsedCCsFromRegion(used, *region);
     impl.updateUsedCCsFromModulations(used, impl.resources_.modMatrix);
     return used;
+}
+
+void sfz::Synth::setBroadcastCallback(sfizz_receive_t* broadcast, void* data)
+{
+    Impl& impl = *impl_;
+    impl.broadcastReceiver = broadcast;
+    impl.broadcastData = data;
 }
 
 void Synth::Impl::updateUsedCCsFromRegion(std::bitset<config::numCCs>& usedCCs, const Region& region)

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -8,6 +8,7 @@
 #include "AudioSpan.h"
 #include "LeakDetector.h"
 #include "Resources.h"
+#include "Messaging.h"
 #include "utility/NumericId.h"
 #include "parser/Parser.h"
 #include <ghc/fs_std.hpp>
@@ -584,6 +585,27 @@ public:
      * @return const std::bitset<config::numCCs>&
      */
     std::bitset<config::numCCs> getUsedCCs() const noexcept;
+
+    /**
+     * @brief Dispatch the incoming message to the synth engine
+     * @since 0.6.0
+     *
+     * @param client       The client sending the message.
+     * @param delay        The delay of the message in the block, in samples.
+     * @param path         The OSC address pattern.
+     * @param sig          The OSC type tag string.
+     * @param args         The OSC arguments, whose number and format is determined the type tag string.
+     */
+    void dispatchMessage(Client& client, int delay, const char* path, const char* sig, const sfizz_arg_t* args);
+
+    /**
+     * @brief Set the function which receives broadcast messages from the synth engine.
+     * @since 0.6.0
+     *
+     * @param broadcast    The pointer to the receiving function.
+     * @param data         The opaque data pointer which is passed to the receiver.
+     */
+    void setBroadcastCallback(sfizz_receive_t* broadcast, void* data);
 
 private:
     struct Impl;

--- a/src/sfizz/SynthMessaging.cpp
+++ b/src/sfizz/SynthMessaging.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "Synth.h"
+#include "StringViewHelpers.h"
+#include <absl/strings/ascii.h>
+#include <cstring>
+
+namespace sfz {
+static constexpr unsigned maxIndices = 8;
+
+static bool extractMessage(const char* pattern, const char* path, unsigned* indices);
+static uint64_t hashMessagePath(const char* path, const char* sig);
+
+void sfz::Synth::dispatchMessage(Client& client, int delay, const char* path, const char* sig, const sfizz_arg_t* args)
+{
+    unsigned indices[maxIndices];
+
+    switch (hashMessagePath(path, sig)) {
+        #define MATCH(p, s) case hash(p "," s): \
+            if (extractMessage(p, path, indices) && !strcmp(sig, s))
+
+        MATCH("/hello", "") {
+            client.receive(delay, "/hello", "", nullptr);
+            break;
+        }
+
+        // TODO...
+    }
+}
+
+static bool extractMessage(const char* pattern, const char* path, unsigned* indices)
+{
+    unsigned nthIndex = 0;
+
+    while (const char *endp = strchr(pattern, '&')) {
+        if (nthIndex == maxIndices)
+            return false;
+
+        size_t length = endp - pattern;
+        if (strncmp(pattern, path, length))
+            return false;
+        pattern += length;
+        path += length;
+
+        length = 0;
+        while (absl::ascii_isdigit(path[length]))
+            ++length;
+
+        if (!absl::SimpleAtoi(absl::string_view(path, length), &indices[nthIndex++]))
+            return false;
+
+        pattern += 1;
+        path += length;
+    }
+
+    return !strcmp(path, pattern);
+}
+
+static uint64_t hashMessagePath(const char* path, const char* sig)
+{
+    uint64_t h = Fnv1aBasis;
+    while (unsigned char c = *path++) {
+        if (!absl::ascii_isdigit(c))
+            h = hashByte(c, h);
+        else {
+            h = hashByte('&', h);
+            while (absl::ascii_isdigit(*path))
+                ++path;
+        }
+    }
+    h = hashByte(',');
+    while (unsigned char c = *sig++)
+        h = hashByte(c, h);
+    return h;
+}
+
+} // namespace sfz

--- a/src/sfizz/SynthMessaging.cpp
+++ b/src/sfizz/SynthMessaging.cpp
@@ -72,7 +72,7 @@ static uint64_t hashMessagePath(const char* path, const char* sig)
                 ++path;
         }
     }
-    h = hashByte(',');
+    h = hashByte(',', h);
     while (unsigned char c = *sig++)
         h = hashByte(c, h);
     return h;

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -5,6 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #include "Synth.h"
+#include "Messaging.h"
 #include "sfizz.hpp"
 #include "absl/memory/memory.h"
 
@@ -304,4 +305,34 @@ const std::vector<std::pair<uint8_t, std::string>>& sfz::Sfizz::getKeyLabels() c
 const std::vector<std::pair<uint16_t, std::string>>& sfz::Sfizz::getCCLabels() const noexcept
 {
     return synth->getCCLabels();
+}
+
+void sfz::Sfizz::ClientDeleter::operator()(Client *client) const noexcept
+{
+    delete client;
+}
+
+auto sfz::Sfizz::createClient(void* data) -> ClientPtr
+{
+    return ClientPtr(new Client(data));
+}
+
+void* sfz::Sfizz::getClientData(Client& client)
+{
+    return client.getClientData();
+}
+
+void sfz::Sfizz::setReceiveCallback(Client& client, sfizz_receive_t* receive)
+{
+    client.setReceiveCallback(receive);
+}
+
+void sfz::Sfizz::sendMessage(Client& client, int delay, const char* path, const char* sig, const sfizz_arg_t* args)
+{
+    synth->dispatchMessage(client, delay, path, sig, args);
+}
+
+void sfz::Sfizz::setBroadcastCallback(sfizz_receive_t* broadcast, void* data)
+{
+    synth->setBroadcastCallback(broadcast, data);
 }

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -7,6 +7,7 @@
 #include "Config.h"
 #include "Macros.h"
 #include "Synth.h"
+#include "Messaging.h"
 #include "sfizz.h"
 #include <limits>
 
@@ -427,6 +428,38 @@ const char * sfizz_get_cc_label_text(sfizz_synth_t* synth, int label_index)
         return NULL;
 
     return ccLabels[label_index].second.c_str();
+}
+
+sfizz_client_t* sfizz_create_client(void* data)
+{
+    return reinterpret_cast<sfizz_client_t*>(new sfz::Client(data));
+}
+
+void sfizz_delete_client(sfizz_client_t* client)
+{
+    delete reinterpret_cast<sfz::Client*>(client);
+}
+
+void* sfizz_get_client_data(sfizz_client_t* client)
+{
+    return reinterpret_cast<sfz::Client*>(client)->getClientData();
+}
+
+void sfizz_set_receive_callback(sfizz_client_t* client, sfizz_receive_t* receive)
+{
+    reinterpret_cast<sfz::Client*>(client)->setReceiveCallback(receive);
+}
+
+void sfizz_send_message(sfizz_synth_t* synth, sfizz_client_t* client, int delay, const char* path, const char* sig, const sfizz_arg_t* args)
+{
+    auto* self = reinterpret_cast<sfz::Synth*>(synth);
+    self->dispatchMessage(*reinterpret_cast<sfz::Client*>(client), delay, path, sig, args);
+}
+
+void sfizz_set_broadcast_callback(sfizz_synth_t* synth, sfizz_receive_t* broadcast, void* data)
+{
+    auto* self = reinterpret_cast<sfz::Synth*>(synth);
+    self->setBroadcastCallback(broadcast, data);
 }
 
 #ifdef __cplusplus

--- a/src/sfizz_message.h
+++ b/src/sfizz_message.h
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @addtogroup Messaging
+ * @{
+ */
+
+/**
+ * @brief Representation of a binary blob in OSC format
+ * @since 0.6.0
+ */
+typedef struct {
+    const uint8_t* data;
+    uint32_t size;
+} sfizz_blob_t;
+
+/**
+ * @brief Representation of an argument of variant type in OSC format
+ * @since 0.6.0
+ */
+typedef union {
+    int32_t i;
+    int64_t h;
+    float f;
+    double d;
+    const char* s;
+    const sfizz_blob_t* b;
+    uint8_t m[4];
+} sfizz_arg_t;
+
+/**
+ * @brief Generic message receiving function
+ * @since 0.6.0
+ */
+typedef void (sfizz_receive_t)(void* data, int delay, const char* path, const char* sig, const sfizz_arg_t* args);
+
+/**
+ * @brief Convert the message to OSC using the provided output buffer
+ * @since 0.6.0
+ *
+ * @param buffer        The output buffer
+ * @param capacity      The capacity of the buffer
+ * @param path          The path
+ * @param sig           The signature
+ * @param args          The arguments
+ * @return              The size necessary to store the converted message in
+ *                      entirety, <= capacity if the written message is valid.
+ */
+uint32_t sfizz_prepare_message(
+    void* buffer, uint32_t capacity,
+    const char* path, const char* sig, const sfizz_arg_t* args);
+
+/**
+ * @brief Extract the contents of an OSC message
+ * @since 0.6.0
+ *
+ * @param srcBuffer     The data of the OSC message
+ * @param srcCapacity   The size of the OSC message
+ * @param argsBuffer    A buffer where the function can allocate the arguments
+ * @param argsCapacity  The capacity of the argument buffer
+ * @param outPath       A pointer to the variable which receives the path
+ * @param outSig        A pointer to the variable which receives the signature
+ * @param outArgs       A pointer to the variable which receives the arguments
+ * @return              On success, this is the number of bytes read.
+ *                      On failure, it is 0 if the OSC message is invalid,
+ *                      -1 if there was not enough buffer for the arguments.
+ */
+int32_t sfizz_extract_message(
+    const void* srcBuffer, uint32_t srcCapacity,
+    void* argsBuffer, uint32_t argsCapacity,
+    const char** outPath, const char** outSig, const sfizz_arg_t** outArgs);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SFIZZ_TEST_SOURCES
     ConcurrencyT.cpp
     ModulationsT.cpp
     LFOT.cpp
+    MessagingT.cpp
     DataHelpers.h
     DataHelpers.cpp
 )

--- a/tests/MessagingT.cpp
+++ b/tests/MessagingT.cpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "sfizz/Messaging.h"
+#include "catch2/catch.hpp"
+#include <absl/types/span.h>
+#include <cstring>
+
+TEST_CASE("[Messaging] OSC message creation")
+{
+    // http://opensoundcontrol.org/spec-1_0-examples
+
+    {
+        const char* path = "/oscillator/4/frequency";
+        const char* sig = "f";
+        sfizz_arg_t args[1];
+        args[0].f = 440.0f;
+
+        const uint8_t expected[] = {
+            0x2f, /* / */  0x6f, /* o */  0x73, /* s */  0x63, /* c */
+            0x69, /* i */  0x6c, /* l */  0x6c, /* l */  0x61, /* a */
+            0x74, /* t */  0x6f, /* o */  0x72, /* r */  0x2f, /* / */
+            0x34, /* 4 */  0x2f, /* / */  0x66, /* f */  0x72, /* r */
+            0x65, /* e */  0x71, /* q */  0x75, /* u */  0x65, /* e */
+            0x6e, /* n */  0x63, /* c */  0x79, /* y */  0x00,
+            0x2c, /* , */  0x66, /* f */  0x00,          0x00,
+            0x43,          0xdc,          0x00,          0x00,
+        };
+
+        uint32_t size = sfizz_prepare_message(nullptr, 0, path, sig, args);
+        REQUIRE(size == sizeof(expected));
+
+        uint8_t actual[sizeof(expected)];
+        size = sfizz_prepare_message(actual, sizeof(actual), path, sig, args);
+        REQUIRE(size == sizeof(expected));
+        REQUIRE(absl::MakeSpan(actual) == absl::MakeSpan(expected));
+
+        const char* path2;
+        const char* sig2;
+        const sfizz_arg_t* args2;
+        uint8_t buffer[256];
+        REQUIRE(sfizz_extract_message(actual, sizeof(actual), buffer, sizeof(buffer), &path2, &sig2, &args2) > 0);
+        REQUIRE(!strcmp(path, path2));
+        REQUIRE(!strcmp(sig, sig2));
+        REQUIRE(args[0].f == 440.0f);
+    }
+
+    {
+        const char* path = "/foo";
+        const char* sig = "iisff";
+        sfizz_arg_t args[5];
+        args[0].i = 1000;
+        args[1].i = -1;
+        args[2].s = "hello";
+        args[3].f = 1.234f;
+        args[4].f = 5.678f;
+
+        const uint8_t expected[] = {
+            0x2f, /* / */  0x66, /* f */  0x6f, /* o */  0x6f, /* o */
+            0x00,          0x00,          0x00,          0x00,
+            0x2c, /* , */  0x69, /* i */  0x69, /* i */  0x73, /* s */
+            0x66, /* f */  0x66, /* f */  0x00,          0x00,
+            0x00,          0x00,          0x03,          0xe8,
+            0xff,          0xff,          0xff,          0xff,
+            0x68,          0x65,          0x6c,          0x6c,
+            0x6f,          0x00,          0x00,          0x00,
+            0x3f,          0x9d,          0xf3,          0xb6,
+            0x40,          0xb5,          0xb2,          0x2d,
+        };
+
+        uint32_t size = sfizz_prepare_message(nullptr, 0, path, sig, args);
+        REQUIRE(size == sizeof(expected));
+
+        uint8_t actual[sizeof(expected)];
+        size = sfizz_prepare_message(actual, sizeof(actual), path, sig, args);
+        REQUIRE(size == sizeof(expected));
+        REQUIRE(absl::MakeSpan(actual) == absl::MakeSpan(expected));
+
+        const char* path2;
+        const char* sig2;
+        const sfizz_arg_t* args2;
+        uint8_t buffer[256];
+        REQUIRE(sfizz_extract_message(actual, sizeof(actual), buffer, sizeof(buffer), &path2, &sig2, &args2) > 0);
+        REQUIRE(!strcmp(path, path2));
+        REQUIRE(!strcmp(sig, sig2));
+        REQUIRE(args[0].i == 1000);
+        REQUIRE(args[1].i == -1);
+        REQUIRE(!strcmp(args[2].s, "hello"));
+        REQUIRE(args[3].f == 1.234f);
+        REQUIRE(args[4].f == 5.678f);
+    }
+}

--- a/tests/MessagingT.cpp
+++ b/tests/MessagingT.cpp
@@ -45,7 +45,7 @@ TEST_CASE("[Messaging] OSC message creation")
         REQUIRE(sfizz_extract_message(actual, sizeof(actual), buffer, sizeof(buffer), &path2, &sig2, &args2) > 0);
         REQUIRE(!strcmp(path, path2));
         REQUIRE(!strcmp(sig, sig2));
-        REQUIRE(args[0].f == 440.0f);
+        REQUIRE(args2[0].f == 440.0f);
     }
 
     {
@@ -86,10 +86,10 @@ TEST_CASE("[Messaging] OSC message creation")
         REQUIRE(sfizz_extract_message(actual, sizeof(actual), buffer, sizeof(buffer), &path2, &sig2, &args2) > 0);
         REQUIRE(!strcmp(path, path2));
         REQUIRE(!strcmp(sig, sig2));
-        REQUIRE(args[0].i == 1000);
-        REQUIRE(args[1].i == -1);
-        REQUIRE(!strcmp(args[2].s, "hello"));
-        REQUIRE(args[3].f == 1.234f);
-        REQUIRE(args[4].f == 5.678f);
+        REQUIRE(args2[0].i == 1000);
+        REQUIRE(args2[1].i == -1);
+        REQUIRE(!strcmp(args2[2].s, "hello"));
+        REQUIRE(args2[3].f == 1.234f);
+        REQUIRE(args2[4].f == 5.678f);
     }
 }

--- a/vst/SfizzVstController.h
+++ b/vst/SfizzVstController.h
@@ -9,6 +9,7 @@
 #include "public.sdk/source/vst/vsteditcontroller.h"
 #include "public.sdk/source/vst/vstparameters.h"
 #include "vstgui/plugin-bindings/vst3editor.h"
+#include <sfizz_message.h>
 class SfizzVstState;
 
 using namespace Steinberg;
@@ -49,6 +50,9 @@ public:
     struct StateListener {
         virtual void onStateChanged() = 0;
     };
+    struct MessageListener {
+        virtual void onMessageReceived(const char* path, const char* sig, const sfizz_arg_t* args) = 0;
+    };
 
     const SfizzVstState& getSfizzState() const { return _state; }
     SfizzVstState& getSfizzState() { return _state; }
@@ -62,6 +66,9 @@ public:
     void addSfizzStateListener(StateListener* listener);
     void removeSfizzStateListener(StateListener* listener);
 
+    void addSfizzMessageListener(MessageListener* listener);
+    void removeSfizzMessageListener(MessageListener* listener);
+
     ///
     static FUnknown* createInstance(void*);
 
@@ -72,4 +79,5 @@ private:
     SfizzUiState _uiState;
     SfizzPlayState _playState {};
     std::vector<StateListener*> _stateListeners;
+    std::vector<MessageListener*> _messageListeners;
 };

--- a/vst/SfizzVstEditor.h
+++ b/vst/SfizzVstEditor.h
@@ -16,7 +16,10 @@ namespace VSTGUI { class RunLoop; }
 using namespace Steinberg;
 using namespace VSTGUI;
 
-class SfizzVstEditor : public Vst::VSTGUIEditor, public SfizzVstController::StateListener, public EditorController {
+class SfizzVstEditor : public Vst::VSTGUIEditor,
+                       public SfizzVstController::StateListener,
+                       public SfizzVstController::MessageListener,
+                       public EditorController {
 public:
     explicit SfizzVstEditor(void *controller);
     ~SfizzVstEditor();
@@ -35,12 +38,16 @@ public:
     // SfizzVstController::StateListener
     void onStateChanged() override;
 
+    // SfizzVstController::MessageListener
+    void onMessageReceived(const char* path, const char* sig, const sfizz_arg_t* args) override;
+
 protected:
     // EditorController
     void uiSendValue(EditId id, const EditValue& v) override;
     void uiBeginSend(EditId id) override;
     void uiEndSend(EditId id) override;
     void uiSendMIDI(const uint8_t* data, uint32_t len) override;
+    void uiSendMessage(const char* path, const char* sig, const sfizz_arg_t* args) override;
 
 private:
     void loadSfzFile(const std::string& filePath);
@@ -55,4 +62,7 @@ private:
 #if !defined(__APPLE__) && !defined(_WIN32)
     SharedPointer<RunLoop> _runLoop;
 #endif
+
+    // messaging
+    std::unique_ptr<uint8[]> oscTemp_;
 };

--- a/vst/SfizzVstProcessor.h
+++ b/vst/SfizzVstProcessor.h
@@ -35,7 +35,7 @@ public:
     void processParameterChanges(Vst::IParameterChanges& pc);
     void processControllerChanges(Vst::IParameterChanges& pc);
     void processEvents(Vst::IEventList& events);
-    void processMidiFromUi();
+    void processMessagesFromUi();
     static int convertVelocityFromFloat(float x);
 
     tresult PLUGIN_API notify(Vst::IMessage* message) override;
@@ -51,6 +51,11 @@ private:
     SfizzVstState _state;
     float _currentStretchedTuning = 0;
 
+    // client
+    sfz::ClientPtr _client;
+    std::unique_ptr<uint8_t[]> _oscTemp;
+    void receiveMessage(int delay, const char* path, const char* sig, const sfizz_arg_t* args);
+
     // misc
     static void loadSfzFileOrDefault(sfz::Sfizz& synth, const std::string& filePath);
 
@@ -59,7 +64,7 @@ private:
     volatile bool _workRunning = false;
     Ring_Buffer _fifoToWorker;
     RTSemaphore _semaToWorker;
-    Ring_Buffer _fifoMidiFromUi;
+    Ring_Buffer _fifoMessageFromUi;
     std::mutex _processMutex;
 
     // file modification periodic checker
@@ -95,6 +100,9 @@ private:
     // reader
     RTMessagePtr readWorkerMessage();
     bool discardWorkerMessage();
+
+    // generic
+    static bool writeMessage(Ring_Buffer& fifo, const char* type, const void* data, uintptr_t size);
 };
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This implements the OSC message protocol.
- serialization routines in `sfizz_message.h` + tests
- sfizz client API for sending to synth and receiving
- a skeleton of a message matcher by hashing
- a VST implementation over FIFO buffer
- a LV2 implementation over custom binary atoms (not osc.lv2 extension, that's for another time)
- communicating the messages with UI in both directions

not implemented:
- actual messages that will interest us (cf. `SynthMessaging.cpp`)