### PR TITLE
Cache the value of usedCCs

### DIFF
--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -683,7 +683,7 @@ void Synth::Impl::finalizeSfzLoad()
     std::bitset<config::numCCs> usedCCs;
     for (const RegionPtr& regionPtr : regions_) {
         const Region& region = *regionPtr;
-        updateUsedCCsFromRegion(usedCCs, region);
+        collectUsedCCsFromRegion(usedCCs, region);
         for (const Region::Connection& connection : region.connections) {
             if (connection.source.id() == ModId::Controller)
                 usedCCs.set(connection.source.parameters().cc);
@@ -1682,8 +1682,8 @@ std::bitset<config::numCCs> Synth::getUsedCCs() const noexcept
     Impl& impl = *impl_;
     std::bitset<config::numCCs> used;
     for (const Impl::RegionPtr& region : impl.regions_)
-        impl.updateUsedCCsFromRegion(used, *region);
-    impl.updateUsedCCsFromModulations(used, impl.resources_.modMatrix);
+        impl.collectUsedCCsFromRegion(used, *region);
+    impl.collectUsedCCsFromModulations(used, impl.resources_.modMatrix);
     return used;
 }
 
@@ -1694,41 +1694,41 @@ void sfz::Synth::setBroadcastCallback(sfizz_receive_t* broadcast, void* data)
     impl.broadcastData = data;
 }
 
-void Synth::Impl::updateUsedCCsFromRegion(std::bitset<config::numCCs>& usedCCs, const Region& region)
+void Synth::Impl::collectUsedCCsFromRegion(std::bitset<config::numCCs>& usedCCs, const Region& region)
 {
-    updateUsedCCsFromCCMap(usedCCs, region.offsetCC);
-    updateUsedCCsFromCCMap(usedCCs, region.amplitudeEG.ccAttack);
-    updateUsedCCsFromCCMap(usedCCs, region.amplitudeEG.ccRelease);
-    updateUsedCCsFromCCMap(usedCCs, region.amplitudeEG.ccDecay);
-    updateUsedCCsFromCCMap(usedCCs, region.amplitudeEG.ccDelay);
-    updateUsedCCsFromCCMap(usedCCs, region.amplitudeEG.ccHold);
-    updateUsedCCsFromCCMap(usedCCs, region.amplitudeEG.ccStart);
-    updateUsedCCsFromCCMap(usedCCs, region.amplitudeEG.ccSustain);
+    collectUsedCCsFromCCMap(usedCCs, region.offsetCC);
+    collectUsedCCsFromCCMap(usedCCs, region.amplitudeEG.ccAttack);
+    collectUsedCCsFromCCMap(usedCCs, region.amplitudeEG.ccRelease);
+    collectUsedCCsFromCCMap(usedCCs, region.amplitudeEG.ccDecay);
+    collectUsedCCsFromCCMap(usedCCs, region.amplitudeEG.ccDelay);
+    collectUsedCCsFromCCMap(usedCCs, region.amplitudeEG.ccHold);
+    collectUsedCCsFromCCMap(usedCCs, region.amplitudeEG.ccStart);
+    collectUsedCCsFromCCMap(usedCCs, region.amplitudeEG.ccSustain);
     if (region.pitchEG) {
-        updateUsedCCsFromCCMap(usedCCs, region.pitchEG->ccAttack);
-        updateUsedCCsFromCCMap(usedCCs, region.pitchEG->ccRelease);
-        updateUsedCCsFromCCMap(usedCCs, region.pitchEG->ccDecay);
-        updateUsedCCsFromCCMap(usedCCs, region.pitchEG->ccDelay);
-        updateUsedCCsFromCCMap(usedCCs, region.pitchEG->ccHold);
-        updateUsedCCsFromCCMap(usedCCs, region.pitchEG->ccStart);
-        updateUsedCCsFromCCMap(usedCCs, region.pitchEG->ccSustain);
+        collectUsedCCsFromCCMap(usedCCs, region.pitchEG->ccAttack);
+        collectUsedCCsFromCCMap(usedCCs, region.pitchEG->ccRelease);
+        collectUsedCCsFromCCMap(usedCCs, region.pitchEG->ccDecay);
+        collectUsedCCsFromCCMap(usedCCs, region.pitchEG->ccDelay);
+        collectUsedCCsFromCCMap(usedCCs, region.pitchEG->ccHold);
+        collectUsedCCsFromCCMap(usedCCs, region.pitchEG->ccStart);
+        collectUsedCCsFromCCMap(usedCCs, region.pitchEG->ccSustain);
     }
     if (region.filterEG) {
-        updateUsedCCsFromCCMap(usedCCs, region.filterEG->ccAttack);
-        updateUsedCCsFromCCMap(usedCCs, region.filterEG->ccRelease);
-        updateUsedCCsFromCCMap(usedCCs, region.filterEG->ccDecay);
-        updateUsedCCsFromCCMap(usedCCs, region.filterEG->ccDelay);
-        updateUsedCCsFromCCMap(usedCCs, region.filterEG->ccHold);
-        updateUsedCCsFromCCMap(usedCCs, region.filterEG->ccStart);
-        updateUsedCCsFromCCMap(usedCCs, region.filterEG->ccSustain);
+        collectUsedCCsFromCCMap(usedCCs, region.filterEG->ccAttack);
+        collectUsedCCsFromCCMap(usedCCs, region.filterEG->ccRelease);
+        collectUsedCCsFromCCMap(usedCCs, region.filterEG->ccDecay);
+        collectUsedCCsFromCCMap(usedCCs, region.filterEG->ccDelay);
+        collectUsedCCsFromCCMap(usedCCs, region.filterEG->ccHold);
+        collectUsedCCsFromCCMap(usedCCs, region.filterEG->ccStart);
+        collectUsedCCsFromCCMap(usedCCs, region.filterEG->ccSustain);
     }
-    updateUsedCCsFromCCMap(usedCCs, region.ccConditions);
-    updateUsedCCsFromCCMap(usedCCs, region.ccTriggers);
-    updateUsedCCsFromCCMap(usedCCs, region.crossfadeCCInRange);
-    updateUsedCCsFromCCMap(usedCCs, region.crossfadeCCOutRange);
+    collectUsedCCsFromCCMap(usedCCs, region.ccConditions);
+    collectUsedCCsFromCCMap(usedCCs, region.ccTriggers);
+    collectUsedCCsFromCCMap(usedCCs, region.crossfadeCCInRange);
+    collectUsedCCsFromCCMap(usedCCs, region.crossfadeCCOutRange);
 }
 
-void Synth::Impl::updateUsedCCsFromModulations(std::bitset<config::numCCs>& usedCCs, const ModMatrix& mm)
+void Synth::Impl::collectUsedCCsFromModulations(std::bitset<config::numCCs>& usedCCs, const ModMatrix& mm)
 {
     class CCSourceCollector : public ModMatrix::KeyVisitor {
     public:

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -584,7 +584,7 @@ public:
      *
      * @return const std::bitset<config::numCCs>&
      */
-    std::bitset<config::numCCs> getUsedCCs() const noexcept;
+    const std::bitset<config::numCCs>& getUsedCCs() const noexcept;
 
     /**
      * @brief Dispatch the incoming message to the synth engine

--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -177,6 +177,8 @@ struct Synth::Impl final: public Parser::Listener {
     static void collectUsedCCsFromRegion(std::bitset<config::numCCs>& usedCCs, const Region& region);
     static void collectUsedCCsFromModulations(std::bitset<config::numCCs>& usedCCs, const ModMatrix& mm);
 
+    std::bitset<config::numCCs> collectAllUsedCCs();
+
     /**
      * @brief Set the default value for a CC
      *
@@ -268,6 +270,7 @@ struct Synth::Impl final: public Parser::Listener {
     fs::file_time_type modificationTime_ { };
 
     std::array<float, config::numCCs> defaultCCValues_;
+    std::bitset<config::numCCs> currentUsedCCs_;
 
     // Messaging
     sfizz_receive_t* broadcastReceiver = nullptr;

--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -168,14 +168,14 @@ struct Synth::Impl final: public Parser::Listener {
     void finalizeSfzLoad();
 
     template<class T>
-    static void updateUsedCCsFromCCMap(std::bitset<config::numCCs>& usedCCs, const CCMap<T> map) noexcept
+    static void collectUsedCCsFromCCMap(std::bitset<config::numCCs>& usedCCs, const CCMap<T> map) noexcept
     {
         for (auto& mod : map)
             usedCCs[mod.cc] = true;
     }
 
-    static void updateUsedCCsFromRegion(std::bitset<config::numCCs>& usedCCs, const Region& region);
-    static void updateUsedCCsFromModulations(std::bitset<config::numCCs>& usedCCs, const ModMatrix& mm);
+    static void collectUsedCCsFromRegion(std::bitset<config::numCCs>& usedCCs, const Region& region);
+    static void collectUsedCCsFromModulations(std::bitset<config::numCCs>& usedCCs, const ModMatrix& mm);
 
     /**
      * @brief Set the default value for a CC


### PR DESCRIPTION
This permits to query the used CC more efficiently on receiving a request from the UI.
It will be computed once and cached after loading.