### PR TITLE
Add API to process CC events received by automation

### DIFF
--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -322,6 +322,23 @@ SFIZZ_EXPORTED_API void sfizz_send_cc(sfizz_synth_t* synth, int delay, int cc_nu
 SFIZZ_EXPORTED_API void sfizz_send_hdcc(sfizz_synth_t* synth, int delay, int cc_number, float norm_value);
 
 /**
+ * @brief Send a high precision CC automation to the synth.
+ *
+ * This updates the CC value known to the synth, but without performing
+ * additional MIDI-specific interpretations. (eg. the CC 120 and up)
+ *
+ * As with all MIDI events, this needs to happen before the call to
+ * sfizz_render_block() in each block and should appear in order of the delays.
+ * @since 0.6.0
+ *
+ * @param synth       The synth.
+ * @param delay       The delay of the event in the block, in samples.
+ * @param cc_number   The MIDI CC number.
+ * @param norm_value  The normalized CC value, in domain 0 to 1.
+ */
+SFIZZ_EXPORTED_API void sfizz_automate_hdcc(sfizz_synth_t* synth, int delay, int cc_number, float norm_value);
+
+/**
  * @brief Send a pitch wheel event.
  *
  * As with all MIDI events, this needs to happen before the call to

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -297,6 +297,21 @@ public:
     void hdcc(int delay, int ccNumber, float normValue) noexcept;
 
     /**
+     * @brief Send a high precision CC automation to the synth
+     *
+     * This updates the CC value known to the synth, but without performing
+     * additional MIDI-specific interpretations. (eg. the CC 120 and up)
+     *
+     * @since 0.6.0
+     *
+     * @param delay the delay at which the event occurs; this should be lower
+     *              than the size of the block in the next call to renderBlock().
+     * @param ccNumber the cc number.
+     * @param normValue the normalized cc value, in domain 0 to 1.
+     */
+    void automateHdcc(int delay, int ccNumber, float normValue) noexcept;
+
+    /**
      * @brief Send a pitch bend event to the synth
      * @since 0.2.0
      *

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -343,6 +343,15 @@ public:
      */
     void hdcc(int delay, int ccNumber, float normValue) noexcept;
     /**
+     * @brief Send a high precision CC automation to the synth
+     *
+     * @param delay the delay at which the event occurs; this should be lower
+     *              than the size of the block in the next call to renderBlock().
+     * @param ccNumber the cc number.
+     * @param normValue the normalized cc value, in domain 0 to 1.
+     */
+    void automateHdcc(int delay, int ccNumber, float normValue) noexcept;
+    /**
      * @brief Get the current value of a controller under the current instrument
      *
      * @param ccNumber the cc number

--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -180,6 +180,16 @@ struct Synth::Impl final: public Parser::Listener {
     std::bitset<config::numCCs> collectAllUsedCCs();
 
     /**
+     * @brief Perform a CC event
+     *
+     * @param delay      The delay
+     * @param ccNumber   The CC number
+     * @param normValue  The normalized value
+     * @param asMidi     Whether to process as a MIDI event
+     */
+    void performHdcc(int delay, int ccNumber, float normValue, bool asMidi) noexcept;
+
+    /**
      * @brief Set the default value for a CC
      *
      * @param ccNumber

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -144,6 +144,11 @@ void sfz::Sfizz::hdcc(int delay, int ccNumber, float normValue) noexcept
     synth->hdcc(delay, ccNumber, normValue);
 }
 
+void sfz::Sfizz::automateHdcc(int delay, int ccNumber, float normValue) noexcept
+{
+    synth->automateHdcc(delay, ccNumber, normValue);
+}
+
 void sfz::Sfizz::pitchWheel(int delay, int pitch) noexcept
 {
     synth->pitchWheel(delay, pitch);

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -146,6 +146,11 @@ void sfizz_send_hdcc(sfizz_synth_t* synth, int delay, int cc_number, float norm_
     auto* self = reinterpret_cast<sfz::Synth*>(synth);
     self->hdcc(delay, cc_number, norm_value);
 }
+void sfizz_automate_hdcc(sfizz_synth_t* synth, int delay, int cc_number, float norm_value)
+{
+    auto* self = reinterpret_cast<sfz::Synth*>(synth);
+    self->automateHdcc(delay, cc_number, norm_value);
+}
 void sfizz_send_pitch_wheel(sfizz_synth_t* synth, int delay, int pitch)
 {
     auto* self = reinterpret_cast<sfz::Synth*>(synth);

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -1394,3 +1394,32 @@ TEST_CASE("[Synth] Default ampeg_release")
 
     REQUIRE(synth.getRegionView(0)->amplitudeEG.release > 0.0005f);
 }
+
+TEST_CASE("[Synth] Send CC vs. Automate CC")
+{
+    {
+        sfz::Synth synth;
+
+        synth.loadSfzString(fs::current_path() / "send_cc.sfz", R"(
+            <region> sample=*sine
+        )");
+
+        synth.noteOn(0, 60, 100);
+        synth.hdcc(1, 120, 0.0f);
+
+        REQUIRE(synth.getNumActiveVoices() == 0);
+   }
+
+    {
+        sfz::Synth synth;
+
+        synth.loadSfzString(fs::current_path() / "automate_cc.sfz", R"(
+            <region> sample=*sine
+        )");
+
+        synth.noteOn(0, 60, 100);
+        synth.automateHdcc(1, 120, 0.0f);
+
+        REQUIRE(synth.getNumActiveVoices() == 1);
+   }
+}


### PR DESCRIPTION
This API allows to receive CC values without having them interpreted as MIDI events.
For instance, this API would permit to turn a UI knob attached to the CC 121, without triggering an avalanche of reset events.