### PR TITLE
Prerequisites for automated macOS code signing

### DIFF
--- a/cmake/BundleDylibs.cmake
+++ b/cmake/BundleDylibs.cmake
@@ -13,7 +13,7 @@ function(bundle_dylibs NAME PATH)
         return()
     endif()
 
-    set(_relative_libdir "../libs")
+    set(_relative_libdir "../Frameworks")
 
     get_filename_component(_dir "${PATH}" DIRECTORY)
     set(_dir "${_dir}/${_relative_libdir}")

--- a/vst/CMakeLists.txt
+++ b/vst/CMakeLists.txt
@@ -123,8 +123,15 @@ else()
         LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/${VST3_PACKAGE_ARCHITECTURE}-linux/$<0:>")
 endif()
 
-file(COPY "gpl-3.0.txt"
-    DESTINATION "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}")
+# Copy the license
+if(APPLE)
+    # on macOS, files are not permitted at the bundle root, during code signing
+    file(COPY "gpl-3.0.txt"
+        DESTINATION "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/SharedSupport/License")
+else()
+    file(COPY "gpl-3.0.txt"
+        DESTINATION "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}")
+endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(${VSTPLUGIN_PRJ_NAME} PRIVATE
@@ -280,7 +287,7 @@ elseif(SFIZZ_AU)
         DESTINATION "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources")
 
     file(COPY "gpl-3.0.txt"
-        DESTINATION "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}")
+        DESTINATION "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/SharedSupport/License")
 
     # Add the resource fork
     if (FALSE)


### PR DESCRIPTION
- have the dylibs in bundle folder `Frameworks` where `codesign` can find them
- do not store custom files at the root of the bundles (note: LV2 are not a macOS bundle)
