### PR TITLE
Add lfoN_beats

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -48,6 +48,7 @@ SFIZZ_CXX_FLAGS = $(SFIZZ_C_FLAGS)
 SFIZZ_SOURCES = \
 	src/sfizz/ADSREnvelope.cpp \
 	src/sfizz/AudioReader.cpp \
+	src/sfizz/BeatClock.cpp \
 	src/sfizz/Curve.cpp \
 	src/sfizz/effects/Apan.cpp \
 	src/sfizz/Effects.cpp \
@@ -90,6 +91,7 @@ SFIZZ_SOURCES = \
 	src/sfizz/LFO.cpp \
 	src/sfizz/LFODescription.cpp \
 	src/sfizz/Messaging.cpp \
+	src/sfizz/Metronome.cpp \
 	src/sfizz/MidiState.cpp \
 	src/sfizz/OpcodeCleanup.cpp \
 	src/sfizz/Opcode.cpp \

--- a/demos/PlotLFO.cpp
+++ b/demos/PlotLFO.cpp
@@ -114,7 +114,8 @@ int main(int argc, char* argv[])
     std::vector<std::unique_ptr<sfz::LFO>> lfos(numLfos);
 
     for (size_t l = 0; l < numLfos; ++l) {
-        sfz::LFO* lfo = new sfz::LFO(bufferPool);
+        const NumericId<sfz::LFO> id { static_cast<int>(l) };
+        sfz::LFO* lfo = new sfz::LFO(id, bufferPool);
         lfos[l].reset(lfo);
         lfo->setSampleRate(sampleRate);
         lfo->configure(&desc[l]);

--- a/demos/PlotLFO.cpp
+++ b/demos/PlotLFO.cpp
@@ -108,25 +108,29 @@ int main(int argc, char* argv[])
         return 1;
     }
 
+    sfz::BufferPool bufferPool;
+
     size_t numLfos = desc.size();
-    std::vector<sfz::LFO> lfos(numLfos);
+    std::vector<std::unique_ptr<sfz::LFO>> lfos(numLfos);
 
     for (size_t l = 0; l < numLfos; ++l) {
-        lfos[l].setSampleRate(sampleRate);
-        lfos[l].configure(&desc[l]);
+        sfz::LFO* lfo = new sfz::LFO(bufferPool);
+        lfos[l].reset(lfo);
+        lfo->setSampleRate(sampleRate);
+        lfo->configure(&desc[l]);
     }
 
     size_t numFrames = (size_t)std::ceil(sampleRate * duration);
     std::vector<float> outputMemory(numLfos * numFrames);
 
     for (size_t l = 0; l < numLfos; ++l) {
-        lfos[l].start(0);
+        lfos[l]->start(0);
     }
 
     std::vector<absl::Span<float>> lfoOutputs(numLfos);
     for (size_t l = 0; l < numLfos; ++l) {
         lfoOutputs[l] = absl::MakeSpan(&outputMemory[l * numFrames], numFrames);
-        lfos[l].process(lfoOutputs[l]);
+        lfos[l]->process(lfoOutputs[l]);
     }
 
     if (saveFlac) {

--- a/lv2/sfizz.c
+++ b/lv2/sfizz.c
@@ -175,11 +175,11 @@ typedef struct
 
     // Timing data
     int bar;
-    float bar_beat;
+    double bar_beat;
     int beats_per_bar;
     int beat_unit;
-    float bpm_tempo;
-    float speed;
+    double bpm_tempo;
+    double speed;
 
     // Paths
     char bundle_path[MAX_BUNDLE_PATH_SIZE];

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ set (SFIZZ_HEADERS
     sfizz/AudioBuffer.h
     sfizz/AudioReader.h
     sfizz/AudioSpan.h
+    sfizz/BeatClock.h
     sfizz/Buffer.h
     sfizz/BufferPool.h
     sfizz/CCMap.h
@@ -79,6 +80,7 @@ set (SFIZZ_HEADERS
     sfizz/LFO.h
     sfizz/LFODescription.h
     sfizz/MathHelpers.h
+    sfizz/Metronome.h
     sfizz/MidiState.h
     sfizz/ModifierHelpers.h
     sfizz/OnePoleFilter.h
@@ -149,6 +151,8 @@ set (SFIZZ_SOURCES
     sfizz/PowerFollower.cpp
     sfizz/FlexEGDescription.cpp
     sfizz/FlexEnvelope.cpp
+    sfizz/BeatClock.cpp
+    sfizz/Metronome.cpp
     sfizz/SynthMessaging.cpp
     sfizz/modulations/ModId.cpp
     sfizz/modulations/ModKey.cpp

--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -375,7 +375,7 @@ SFIZZ_EXPORTED_API void sfizz_send_time_signature(sfizz_synth_t* synth, int dela
  * @param bar       The current bar.
  * @param bar_beat  The fractional position of the current beat within the bar.
  */
-SFIZZ_EXPORTED_API void sfizz_send_time_position(sfizz_synth_t* synth, int delay, int bar, float bar_beat);
+SFIZZ_EXPORTED_API void sfizz_send_time_position(sfizz_synth_t* synth, int delay, int bar, double bar_beat);
 
 /**
  * @brief Send the playback state.

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -344,7 +344,7 @@ public:
      * @param bar     The current bar.
      * @param barBeat The fractional position of the current beat within the bar.
      */
-    void timePosition(int delay, int bar, float barBeat);
+    void timePosition(int delay, int bar, double barBeat);
 
     /**
      * @brief Send the playback state.

--- a/src/sfizz/BeatClock.cpp
+++ b/src/sfizz/BeatClock.cpp
@@ -210,7 +210,7 @@ void BeatClock::calculatePhase(float beatPeriod, float* phaseOut)
 {
     const unsigned numFrames = currentCycleFrames_;
 
-    if (beatPeriod == 0.0f) {
+    if (beatPeriod <= 0.0f) {
         fill(absl::MakeSpan(phaseOut, numFrames), 0.0f);
         return;
     }
@@ -236,7 +236,7 @@ void BeatClock::calculatePhaseModulated(const float* beatPeriodData, float* phas
         float beatPosition = std::max(0.0f, beatPositionData[i]);
         float phase = beatPosition / beatPeriod;
         phase -= static_cast<int>(phase);
-        phaseOut[i] = (beatPeriod != 0.0f) ? phase : 0.0f;
+        phaseOut[i] = (beatPeriod > 0.0f) ? phase : 0.0f;
     }
 }
 

--- a/src/sfizz/BeatClock.cpp
+++ b/src/sfizz/BeatClock.cpp
@@ -191,25 +191,6 @@ void BeatClock::fillBufferUpTo(unsigned delay)
 
         // quantization to nearest for prevention of rounding errors
         beatData[fill] = dequantize<int>(quantize(clientPos.toBeats(sig)));
-
-#if 0
-        BBT oldClientPos = clientPos;
-
-        // quantization to nearest for prevention of rounding errors
-        qbeats_t oldQbeats = quantize(oldClientPos.toBeats(sig));
-        qbeats_t qbeats = quantize(clientPos.toBeats(sig));
-
-        int oldBeatNumber = dequantize<int>(oldQbeats);
-        int beatNumber = dequantize<int>(qbeats);
-
-        int beatIncrement = std::max(0, beatNumber - oldBeatNumber);
-        int beatDistanceToNextBar = sig.beatsPerBar - (oldBeatNumber % sig.beatsPerBar);
-        int barIncrement = (beatIncrement < beatDistanceToNextBar) ? 0 :
-            (1 + (beatIncrement - beatDistanceToNextBar) / sig.beatsPerBar);
-
-        beatData[fill] = beatIncrement;
-        barData[fill] = barIncrement;
-#endif
     }
 
     currentCycleFill_ = fill;

--- a/src/sfizz/BeatClock.cpp
+++ b/src/sfizz/BeatClock.cpp
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "BeatClock.h"
+#include "Config.h"
+#include "Debug.h"
+#include <iostream>
+#include <cmath>
+
+namespace sfz {
+
+bool TimeSignature::operator==(const TimeSignature& other) const
+{
+    return beatsPerBar == other.beatsPerBar && beatUnit == other.beatUnit;
+}
+
+bool TimeSignature::operator!=(const TimeSignature& other) const
+{
+    return !operator==(other);
+}
+
+///
+BBT BBT::toSignature(TimeSignature oldSig, TimeSignature newSig) const
+{
+    double beatsInOldSig = toBeats(oldSig);
+    double beatsInNewSig = beatsInOldSig * newSig.beatUnit / oldSig.beatUnit;
+    return BBT::fromBeats(newSig, beatsInNewSig);
+}
+
+double BBT::toBeats(TimeSignature sig) const
+{
+    return beat + bar * sig.beatsPerBar;
+}
+
+BBT BBT::fromBeats(TimeSignature sig, double beats)
+{
+    int newBar = static_cast<int>(beats / sig.beatsPerBar);
+    double newBeat = beats - newBar * sig.beatsPerBar;
+    return BBT(newBar, newBeat);
+}
+
+double BBT::toBars(TimeSignature sig) const
+{
+    return bar + beat / sig.beatsPerBar;
+}
+
+///
+constexpr int BeatClock::resolution;
+
+auto BeatClock::quantize(double beats) -> qbeats_t
+{
+    double d = beats * (1 << resolution);
+    d = std::copysign(0.5 + std::fabs(d), d);
+    return static_cast<qbeats_t>(d);
+}
+
+template <class T>
+T BeatClock::dequantize(qbeats_t qbeats)
+{
+    return qbeats / static_cast<T>(1 << resolution);
+}
+
+///
+BeatClock::BeatClock()
+{
+    setSampleRate(config::defaultSampleRate);
+    setSamplesPerBlock(config::defaultSamplesPerBlock);
+}
+
+void BeatClock::clear()
+{
+    beatsPerSecond_ = 2.0;
+    timeSig_ =  { 4, 4 };
+    isPlaying_ = false;
+
+    lastHostPos_ = { 0, 0 };
+    lastClientPos_ = { 0, 0 };
+}
+
+void BeatClock::beginCycle(unsigned numFrames)
+{
+    currentCycleFrames_ = numFrames;
+    currentCycleFill_ = 0;
+    currentCycleStartPos_ = lastClientPos_;
+}
+
+void BeatClock::endCycle()
+{
+    fillBufferUpTo(currentCycleFrames_);
+}
+
+void BeatClock::setSampleRate(double sampleRate)
+{
+    samplePeriod_ = 1.0 / sampleRate;
+}
+
+void BeatClock::setSamplesPerBlock(unsigned samplesPerBlock)
+{
+    runningBeat_.resize(samplesPerBlock);
+    runningBeatsPerBar_.resize(samplesPerBlock);
+}
+
+void BeatClock::setTempo(unsigned delay, double secondsPerBeat)
+{
+    fillBufferUpTo(delay);
+
+    beatsPerSecond_ = 1.0 / secondsPerBeat;
+}
+
+void BeatClock::setTimeSignature(unsigned delay, TimeSignature newSig)
+{
+    fillBufferUpTo(delay);
+
+    if (!newSig.valid()) {
+        CHECKFALSE;
+        return;
+    }
+
+    TimeSignature oldSig = timeSig_;
+    if (oldSig == newSig)
+        return;
+
+    timeSig_ = newSig;
+
+    // convert time to new signature
+    lastHostPos_ = lastHostPos_.toSignature(oldSig, newSig);
+    lastClientPos_ = lastClientPos_.toSignature(oldSig, newSig);
+}
+
+void BeatClock::setTimePosition(unsigned delay, BBT newPos)
+{
+    fillBufferUpTo(delay);
+
+    lastHostPos_ = newPos;
+
+    // apply host position in the next frame
+    mustApplyHostPos_ = true;
+}
+
+void BeatClock::setPlaying(unsigned delay, bool playing)
+{
+    fillBufferUpTo(delay);
+
+    isPlaying_ = playing;
+}
+
+absl::Span<const int> BeatClock::getRunningBeat()
+{
+    fillBufferUpTo(currentCycleFrames_);
+
+    return absl::MakeConstSpan(runningBeat_.data(), currentCycleFrames_);
+}
+
+absl::Span<const int> BeatClock::getRunningBeatsPerBar()
+{
+    fillBufferUpTo(currentCycleFrames_);
+
+    return absl::MakeConstSpan(runningBeatsPerBar_.data(), currentCycleFrames_);
+}
+
+void BeatClock::fillBufferUpTo(unsigned delay)
+{
+    int *beatData = runningBeat_.data();
+    int *beatsPerBarData = runningBeatsPerBar_.data();
+    unsigned fill = currentCycleFill_;
+
+    const TimeSignature sig = timeSig_;
+    for (unsigned i = fill; i < delay; ++i)
+        beatsPerBarData[i] = sig.beatsPerBar;
+
+    if (!isPlaying_) {
+        for (; fill < delay; ++fill)
+            beatData[fill] = 0;
+        currentCycleFill_ = fill;
+        return;
+    }
+
+    BBT clientPos = lastClientPos_;
+    const double beatsPerFrame = beatsPerSecond_ * samplePeriod_;
+
+    const BBT hostPos = lastHostPos_;
+    bool mustApplyHostPos = mustApplyHostPos_;
+
+    for (; fill < delay; ++fill) {
+        clientPos = BBT::fromBeats(sig, clientPos.toBeats(sig) + beatsPerFrame);
+        clientPos = mustApplyHostPos ? hostPos : clientPos;
+        mustApplyHostPos = false;
+
+        // quantization to nearest for prevention of rounding errors
+        beatData[fill] = dequantize<int>(quantize(clientPos.toBeats(sig)));
+
+#if 0
+        BBT oldClientPos = clientPos;
+
+        // quantization to nearest for prevention of rounding errors
+        qbeats_t oldQbeats = quantize(oldClientPos.toBeats(sig));
+        qbeats_t qbeats = quantize(clientPos.toBeats(sig));
+
+        int oldBeatNumber = dequantize<int>(oldQbeats);
+        int beatNumber = dequantize<int>(qbeats);
+
+        int beatIncrement = std::max(0, beatNumber - oldBeatNumber);
+        int beatDistanceToNextBar = sig.beatsPerBar - (oldBeatNumber % sig.beatsPerBar);
+        int barIncrement = (beatIncrement < beatDistanceToNextBar) ? 0 :
+            (1 + (beatIncrement - beatDistanceToNextBar) / sig.beatsPerBar);
+
+        beatData[fill] = beatIncrement;
+        barData[fill] = barIncrement;
+#endif
+    }
+
+    currentCycleFill_ = fill;
+    lastClientPos_ = clientPos;
+    mustApplyHostPos_ = mustApplyHostPos;
+}
+
+} // namespace sfz
+
+std::ostream& operator<<(std::ostream& os, const sfz::BBT& pos)
+{
+    return os << pos.bar << ':' << std::fixed << pos.beat;
+}
+
+std::ostream& operator<<(std::ostream& os, const sfz::TimeSignature& sig)
+{
+    return os << sig.beatsPerBar << '/' << sig.beatUnit;
+}

--- a/src/sfizz/BeatClock.cpp
+++ b/src/sfizz/BeatClock.cpp
@@ -150,6 +150,13 @@ absl::Span<const int> BeatClock::getRunningBeatNumber()
     return absl::MakeConstSpan(runningBeatNumber_.data(), currentCycleFrames_);
 }
 
+absl::Span<const float> BeatClock::getRunningBeatPosition()
+{
+    fillBufferUpTo(currentCycleFrames_);
+
+    return absl::MakeConstSpan(runningBeatPosition_.data(), currentCycleFrames_);
+}
+
 absl::Span<const int> BeatClock::getRunningBeatsPerBar()
 {
     fillBufferUpTo(currentCycleFrames_);

--- a/src/sfizz/BeatClock.h
+++ b/src/sfizz/BeatClock.h
@@ -130,6 +130,16 @@ public:
      * @brief Get the time signature numerator for each frame of the current cycle.
      */
     absl::Span<const int> getRunningBeatsPerBar();
+    /**
+     * @brief Create a normalized phase signal for LFO which completes a
+     *        period every N-th beat.
+     */
+    void calculatePhase(float beatPeriod, float* phaseOut);
+    /**
+     * @brief Create a normalized phase signal for LFO which completes a
+     *        period every N-th beat, where N can vary over time.
+     */
+    void calculatePhaseModulated(const float* beatPeriodData, float* phaseOut);
 
 private:
     void fillBufferUpTo(unsigned delay);

--- a/src/sfizz/BeatClock.h
+++ b/src/sfizz/BeatClock.h
@@ -111,6 +111,10 @@ public:
      */
     void setPlaying(unsigned delay, bool playing);
     /**
+     * Check whether the clock is currently ticking.
+     */
+    bool isPlaying() const noexcept { return isPlaying_; }
+    /**
      * @brief Get the beat number for each frame of the current cycle.
      *
      * This signal is quantized to a fixed resolution, such that it never

--- a/src/sfizz/BeatClock.h
+++ b/src/sfizz/BeatClock.h
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include <absl/types/span.h>
+#include <vector>
+#include <iosfwd>
+
+namespace sfz {
+
+/**
+ * @brief Musical time signature
+ */
+struct TimeSignature {
+    TimeSignature() {}
+    TimeSignature(int beatsPerBar, int beatUnit) : beatsPerBar(beatsPerBar), beatUnit(beatUnit) {}
+
+    /**
+     * @brief Check the signature validity.
+     * Valid signatures have a strictly positive numerator and denominator.
+     */
+    bool valid() const { return beatsPerBar > 0 && beatUnit > 0; }
+
+    bool operator==(const TimeSignature& other) const;
+    bool operator!=(const TimeSignature& other) const;
+
+    /**
+     * @brief Time signature numerator, indicating the number of beats in a bar
+     */
+    int beatsPerBar = 0;
+    /**
+     * @brief Time signature denominator, indicating the type of note (4=quarter)
+     */
+    int beatUnit = 0;
+};
+
+/**
+ * @brief Musical time in BBT form
+ */
+struct BBT {
+    BBT() {}
+    BBT(int bar, double beat) : bar(bar), beat(beat) {}
+
+    /**
+     * @brief Convert the time to a different signature.
+     */
+    BBT toSignature(TimeSignature oldSig, TimeSignature newSig) const;
+    /**
+     * @brief Convert the time to a fractional quantity in beats.
+     */
+    double toBeats(TimeSignature sig) const;
+    /**
+     * @brief Convert the time to a fractional quantity in bars.
+     */
+    double toBars(TimeSignature sig) const;
+    /**
+     * @brief Convert the fractional quantity in beats to musical time.
+     */
+    static BBT fromBeats(TimeSignature sig, double beats);
+
+    /**
+     * @brief Bar number
+     */
+    int bar = 0;
+    /**
+     * @brief Beat and tick, stored in the integral and fractional parts
+     */
+    double beat = 0;
+};
+
+class BeatClock {
+public:
+    BeatClock();
+
+    /**
+     * @brief Set the sample rate.
+     */
+    void setSampleRate(double sampleRate);
+    /**
+     * @brief Set the block size.
+     */
+    void setSamplesPerBlock(unsigned samplesPerBlock);
+    /**
+     * @brief Reinitialize the current state.
+     */
+    void clear();
+    /**
+     * @brief Start a new cycle of clock processing.
+     */
+    void beginCycle(unsigned numFrames);
+    /**
+     * @brief End the current cycle of clock processing.
+     */
+    void endCycle();
+    /**
+     * @brief Set the tempo.
+     */
+    void setTempo(unsigned delay, double secondsPerBeat);
+    /**
+     * @brief Set the time signature.
+     */
+    void setTimeSignature(unsigned delay, TimeSignature newSig);
+    /**
+     * @brief Set the time position.
+     */
+    void setTimePosition(unsigned delay, BBT newPos);
+    /**
+     * @brief Set whether the clock is ticking or stopped.
+     */
+    void setPlaying(unsigned delay, bool playing);
+    /**
+     * @brief Get the beat number for each frame of the current cycle.
+     */
+    absl::Span<const int> getRunningBeat();
+    /**
+     * @brief Get the time signature numerator for each frame of the current cycle.
+     */
+    absl::Span<const int> getRunningBeatsPerBar();
+
+private:
+    void fillBufferUpTo(unsigned delay);
+
+private:
+    double samplePeriod_ = 0;
+
+    // quantization
+    typedef int64_t qbeats_t;
+    static constexpr int resolution = 16; // bits
+    static qbeats_t quantize(int beats) { return beats * (1 << resolution); }
+    static qbeats_t quantize(double beats);
+    template <class T> static T dequantize(qbeats_t qbeats);
+
+    // status of current cycle
+    unsigned currentCycleFrames_ = 0;
+    unsigned currentCycleFill_ = 0;
+    BBT currentCycleStartPos_;
+
+    // musical time information from host
+    double beatsPerSecond_ = 2.0;
+    TimeSignature timeSig_ { 4, 4 };
+    bool isPlaying_ = false;
+
+    // last time position received from host
+    BBT lastHostPos_;
+    bool mustApplyHostPos_ = false;
+
+    // plugin-side counter
+    BBT lastClientPos_;
+
+    std::vector<int> runningBeat_;
+    std::vector<int> runningBeatsPerBar_;
+};
+
+} // namespace sfz
+
+std::ostream& operator<<(std::ostream& os, const sfz::BBT& pos);
+std::ostream& operator<<(std::ostream& os, const sfz::TimeSignature& sig);

--- a/src/sfizz/BufferPool.h
+++ b/src/sfizz/BufferPool.h
@@ -9,6 +9,7 @@
 #include "Debug.h"
 #include "Buffer.h"
 #include "AudioBuffer.h"
+#include "AudioSpan.h"
 #include <array>
 #include <memory>
 #include <functional>

--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -222,7 +222,9 @@ namespace Default
     constexpr int numLFOSubs { 2 };
     constexpr int numLFOSteps { 8 };
     constexpr Range<float> lfoFreqRange { 0.0, 100.0 };
+    constexpr Range<float> lfoFreqModRange { -100.0, 100.0 };
     constexpr Range<float> lfoBeatsRange { 0.0, 1000.0 };
+    constexpr Range<float> lfoBeatsModRange { -1000.0, 1000.0 };
     constexpr Range<float> lfoPhaseRange { 0.0, 1.0 };
     constexpr Range<float> lfoDelayRange { 0.0, 30.0 };
     constexpr Range<float> lfoFadeRange { 0.0, 30.0 };

--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -222,6 +222,7 @@ namespace Default
     constexpr int numLFOSubs { 2 };
     constexpr int numLFOSteps { 8 };
     constexpr Range<float> lfoFreqRange { 0.0, 100.0 };
+    constexpr Range<float> lfoBeatsRange { 0.0, 1000.0 };
     constexpr Range<float> lfoPhaseRange { 0.0, 1.0 };
     constexpr Range<float> lfoDelayRange { 0.0, 30.0 };
     constexpr Range<float> lfoFadeRange { 0.0, 30.0 };

--- a/src/sfizz/LFO.cpp
+++ b/src/sfizz/LFO.cpp
@@ -18,14 +18,16 @@
 namespace sfz {
 
 struct LFO::Impl {
-    explicit Impl(BufferPool& bufferPool, BeatClock* beatClock)
-        : bufferPool_(bufferPool),
+    explicit Impl(NumericId<LFO> id, BufferPool& bufferPool, BeatClock* beatClock)
+        : id_(id),
+          bufferPool_(bufferPool),
           beatClock_(beatClock),
           sampleRate_(config::defaultSampleRate),
           desc_(&LFODescription::getDefault())
     {
     }
 
+    NumericId<LFO> id_;
     BufferPool& bufferPool_;
     BeatClock* beatClock_ = nullptr;
     float sampleRate_ = 0;
@@ -41,13 +43,18 @@ struct LFO::Impl {
     std::array<int, config::maxLFOSubs> sampleHoldState_ {{}};
 };
 
-LFO::LFO(BufferPool& bufferPool, BeatClock* beatClock)
-    : impl_(new Impl(bufferPool, beatClock))
+LFO::LFO(NumericId<LFO> id, BufferPool& bufferPool, BeatClock* beatClock)
+    : impl_(new Impl(id, bufferPool, beatClock))
 {
 }
 
 LFO::~LFO()
 {
+}
+
+NumericId<LFO> LFO::getId() const noexcept
+{
+    return impl_->id_;
 }
 
 void LFO::setSampleRate(double sampleRate)

--- a/src/sfizz/LFO.h
+++ b/src/sfizz/LFO.h
@@ -10,6 +10,7 @@
 
 namespace sfz {
 class BufferPool;
+class BeatClock;
 
 enum class LFOWave : int;
 struct LFODescription;
@@ -50,7 +51,9 @@ struct LFODescription;
 
 class LFO {
 public:
-    explicit LFO(BufferPool& bufferPool);
+    explicit LFO(
+        BufferPool& bufferPool,
+        BeatClock* beatClock = nullptr);
     ~LFO();
 
     /**

--- a/src/sfizz/LFO.h
+++ b/src/sfizz/LFO.h
@@ -5,6 +5,7 @@
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
 #pragma once
+#include "utility/NumericId.h"
 #include <absl/types/span.h>
 #include <memory>
 
@@ -52,9 +53,12 @@ struct LFODescription;
 class LFO {
 public:
     explicit LFO(
+        NumericId<LFO> id,
         BufferPool& bufferPool,
         BeatClock* beatClock = nullptr);
     ~LFO();
+
+    NumericId<LFO> getId() const noexcept;
 
     /**
        Sets the sample rate.

--- a/src/sfizz/LFO.h
+++ b/src/sfizz/LFO.h
@@ -9,6 +9,7 @@
 #include <memory>
 
 namespace sfz {
+class BufferPool;
 
 enum class LFOWave : int;
 struct LFODescription;
@@ -49,7 +50,7 @@ struct LFODescription;
 
 class LFO {
 public:
-    LFO();
+    explicit LFO(BufferPool& bufferPool);
     ~LFO();
 
     /**
@@ -91,23 +92,28 @@ private:
        on wave type inside the frame loop.
      */
     template <LFOWave W>
-    void processWave(unsigned nth, absl::Span<float> out);
+    void processWave(unsigned nth, absl::Span<float> out, const float* phaseIn);
 
     /**
        Process a sample-and-hold subwaveform, adding to the buffer.
      */
     template <LFOWave W>
-    void processSH(unsigned nth, absl::Span<float> out);
+    void processSH(unsigned nth, absl::Span<float> out, const float* phaseIn);
 
     /**
        Process the step sequencer, adding to the buffer.
      */
-    void processSteps(absl::Span<float> out);
+    void processSteps(absl::Span<float> out, const float* phaseIn);
 
     /**
        Process the fade in gain, and apply it to the buffer.
      */
     void processFadeIn(absl::Span<float> out);
+
+    /**
+       Generate the phase of the N-th generator
+     */
+    void generatePhase(unsigned nth, absl::Span<float> phases);
 
 private:
     struct Impl;

--- a/src/sfizz/LFO.h
+++ b/src/sfizz/LFO.h
@@ -12,6 +12,8 @@
 namespace sfz {
 class BufferPool;
 class BeatClock;
+class ModMatrix;
+struct Region;
 
 enum class LFOWave : int;
 struct LFODescription;
@@ -55,7 +57,8 @@ public:
     explicit LFO(
         NumericId<LFO> id,
         BufferPool& bufferPool,
-        BeatClock* beatClock = nullptr);
+        BeatClock* beatClock = nullptr,
+        ModMatrix* modMatrix = nullptr);
     ~LFO();
 
     NumericId<LFO> getId() const noexcept;
@@ -82,7 +85,7 @@ public:
 
        TODO(jpc) frequency modulations
      */
-    void process(absl::Span<float> out);
+    void process(absl::Span<float> out, NumericId<Region> regionId = {});
 
 private:
     /**
@@ -120,7 +123,7 @@ private:
     /**
        Generate the phase of the N-th generator
      */
-    void generatePhase(unsigned nth, absl::Span<float> phases);
+    void generatePhase(unsigned nth, absl::Span<float> phases, NumericId<Region> regionId);
 
 private:
     struct Impl;

--- a/src/sfizz/LFODescription.h
+++ b/src/sfizz/LFODescription.h
@@ -28,6 +28,7 @@ struct LFODescription {
     ~LFODescription();
     static const LFODescription& getDefault();
     float freq = 0; // lfoN_freq
+    float beats = 0; // lfoN_beats
     float phase0 = 0; // lfoN_phase
     float delay = 0; // lfoN_delay
     float fade = 0; // lfoN_fade

--- a/src/sfizz/Metronome.cpp
+++ b/src/sfizz/Metronome.cpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "Metronome.h"
+#include "Config.h"
+
+namespace sfz {
+
+Metronome::Metronome()
+{
+    fGain = 0.5f;
+    init(config::defaultSampleRate);
+}
+
+void Metronome::init(float sampleRate)
+{
+    fConst0 = std::min<float>(192000.0f, std::max<float>(1.0f, float(sampleRate)));
+    fConst1 = std::cos((2764.60156f / fConst0));
+    fConst2 = std::sqrt(std::max<float>(0.0f, ((fConst1 + 1.0f) / (1.0f - fConst1))));
+    fConst3 = (1.0f / fConst2);
+    fConst4 = std::cos((5529.20312f / fConst0));
+    fConst5 = std::sqrt(std::max<float>(0.0f, ((fConst4 + 1.0f) / (1.0f - fConst4))));
+    fConst6 = (1.0f / fConst5);
+    fConst7 = std::max<float>(1.0f, (0.00499999989f * fConst0));
+    fConst8 = (1.0f / fConst7);
+    fConst9 = (1.0f / std::max<float>(1.0f, (0.100000001f * fConst0)));
+    clear();
+}
+
+void Metronome::clear()
+{
+    for (int l0 = 0; (l0 < 2); l0 = (l0 + 1)) {
+        iVec0[l0] = 0;
+    }
+    for (int l1 = 0; (l1 < 2); l1 = (l1 + 1)) {
+        iVec1[l1] = 0;
+    }
+    for (int l2 = 0; (l2 < 2); l2 = (l2 + 1)) {
+        iVec2[l2] = 0;
+    }
+    for (int l3 = 0; (l3 < 2); l3 = (l3 + 1)) {
+        iRec0[l3] = 0;
+    }
+    for (int l4 = 0; (l4 < 2); l4 = (l4 + 1)) {
+        fVec3[l4] = 0.0f;
+    }
+    for (int l5 = 0; (l5 < 2); l5 = (l5 + 1)) {
+        fRec1[l5] = 0.0f;
+    }
+    for (int l6 = 0; (l6 < 2); l6 = (l6 + 1)) {
+        fRec2[l6] = 0.0f;
+    }
+    for (int l7 = 0; (l7 < 2); l7 = (l7 + 1)) {
+        fVec4[l7] = 0.0f;
+    }
+    for (int l8 = 0; (l8 < 2); l8 = (l8 + 1)) {
+        fRec3[l8] = 0.0f;
+    }
+    for (int l9 = 0; (l9 < 2); l9 = (l9 + 1)) {
+        fRec4[l9] = 0.0f;
+    }
+    for (int l10 = 0; (l10 < 2); l10 = (l10 + 1)) {
+        iRec5[l10] = 0;
+    }
+}
+
+void Metronome::processAdding(const int* beats, const int* beatsPerBar, float* outputL, float* outputR, int numFrames)
+{
+    float fSlow0 = float(fGain);
+    for (int i = 0; (i < numFrames); i = (i + 1)) {
+        int iTemp0 = int(beats[i]);
+        iVec0[0] = iTemp0;
+        iVec1[0] = 1;
+        int iTemp1 = ((iTemp0 - iVec0[1]) > 0);
+        iVec2[0] = iTemp1;
+        iRec0[0] = (iTemp1 ? ((iTemp0 % int(beatsPerBar[i])) == 0) : iRec0[1]);
+        fVec3[0] = fConst2;
+        float fTemp2 = float((1 - iVec1[1]));
+        float fTemp3 = (fConst3 * (fRec2[1] * (fTemp2 + fVec3[1])));
+        float fTemp4 = (fConst1 * (fTemp3 + fRec1[1]));
+        fRec1[0] = (fTemp4 + (fTemp2 + fTemp3));
+        fRec2[0] = (fTemp4 - fRec1[1]);
+        fVec4[0] = fConst5;
+        float fTemp5 = (fConst6 * (fRec4[1] * (fTemp2 + fVec4[1])));
+        float fTemp6 = (fConst4 * (fTemp5 + fRec3[1]));
+        fRec3[0] = (fTemp6 + (fTemp2 + fTemp5));
+        fRec4[0] = (fTemp6 - fRec3[1]);
+        iRec5[0] = (((iRec5[1] + (iRec5[1] > 0)) * (iTemp1 <= iVec2[1])) + (iTemp1 > iVec2[1]));
+        float fTemp7 = float(iRec5[0]);
+        float fTemp8 = (fSlow0 * ((iRec0[0] ? (0.0f - (fConst5 * fRec4[0])) : (0.0f - (fConst2 * fRec2[0]))) * std::max<float>(0.0f, std::min<float>((fConst8 * fTemp7), ((fConst9 * (fConst7 - fTemp7)) + 1.0f)))));
+        outputL[i] += float(fTemp8);
+        outputR[i] += float(fTemp8);
+        iVec0[1] = iVec0[0];
+        iVec1[1] = iVec1[0];
+        iVec2[1] = iVec2[0];
+        iRec0[1] = iRec0[0];
+        fVec3[1] = fVec3[0];
+        fRec1[1] = fRec1[0];
+        fRec2[1] = fRec2[0];
+        fVec4[1] = fVec4[0];
+        fRec3[1] = fRec3[0];
+        fRec4[1] = fRec4[0];
+        iRec5[1] = iRec5[0];
+    }
+}
+
+} // namespace sfz

--- a/src/sfizz/Metronome.h
+++ b/src/sfizz/Metronome.h
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include <algorithm>
+#include <cmath>
+
+namespace sfz {
+
+class Metronome {
+public:
+    Metronome();
+    void init(float sampleRate);
+    void clear();
+    void processAdding(const int* beats, const int* beatsPerBar, float* outputL, float* outputR, int numFrames);
+    void setGain(float gain) { fGain = gain; }
+
+private:
+    float fGain;
+    int iVec0[2];
+    int iVec1[2];
+    int iVec2[2];
+    int iRec0[2];
+    float fConst0;
+    float fConst1;
+    float fConst2;
+    float fVec3[2];
+    float fConst3;
+    float fRec1[2];
+    float fRec2[2];
+    float fConst4;
+    float fConst5;
+    float fVec4[2];
+    float fConst6;
+    float fRec3[2];
+    float fRec4[2];
+    float fConst7;
+    float fConst8;
+    int iRec5[2];
+    float fConst9;
+
+    /*
+         import("stdfaust.lib");
+
+         process(beats, beatsPerBar) = tone : *(envelope) <: (_, _) with {
+           gain = hslider("[1] Gain", 0.5, 0.0, 1.0, 0.001);
+           beatNumber = int(beats);
+           beatIncrement = beatNumber-beatNumber';
+           tone = (os.oscws(440.0), os.oscws(880.0)) : select2(toneSelect);
+           toneSelect = x letrec { 'x = ba.if(beatIncrement>0, (beatNumber%int(beatsPerBar))==0, x); };
+           envelope = (beatIncrement>0) : en.ar(5e-3, 100e-3) : *(gain);
+         };
+    */
+};
+
+} // namespace sfz

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -866,6 +866,16 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
             setValueFromOpcode(opcode, lfos[lfoNumber - 1].freq, Default::lfoFreqRange);
         }
         break;
+    case hash("lfo&_beats"):
+        {
+            const auto lfoNumber = opcode.parameters.front();
+            if (lfoNumber == 0)
+                return false;
+            if (!extendIfNecessary(lfos, lfoNumber, Default::numLFOs))
+                return false;
+            setValueFromOpcode(opcode, lfos[lfoNumber - 1].beats, Default::lfoBeatsRange);
+        }
+        break;
     case hash("lfo&_phase"):
         {
             const auto lfoNumber = opcode.parameters.front();

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -866,6 +866,16 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
             setValueFromOpcode(opcode, lfos[lfoNumber - 1].freq, Default::lfoFreqRange);
         }
         break;
+    case_any_ccN("lfo&_freq"):
+        {
+            const auto lfoNumber = opcode.parameters.front();
+            if (lfoNumber == 0)
+                return false;
+            if (!extendIfNecessary(lfos, lfoNumber, Default::numLFOs))
+                return false;
+            processGenericCc(opcode, Default::lfoFreqModRange, ModKey::createNXYZ(ModId::LFOFrequency, id, lfoNumber - 1));
+        }
+        break;
     case hash("lfo&_beats"):
         {
             const auto lfoNumber = opcode.parameters.front();
@@ -874,6 +884,16 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode)
             if (!extendIfNecessary(lfos, lfoNumber, Default::numLFOs))
                 return false;
             setValueFromOpcode(opcode, lfos[lfoNumber - 1].beats, Default::lfoBeatsRange);
+        }
+        break;
+    case_any_ccN("lfo&_beats"):
+        {
+            const auto lfoNumber = opcode.parameters.front();
+            if (lfoNumber == 0)
+                return false;
+            if (!extendIfNecessary(lfos, lfoNumber, Default::numLFOs))
+                return false;
+            processGenericCc(opcode, Default::lfoBeatsModRange, ModKey::createNXYZ(ModId::LFOBeats, id, lfoNumber - 1));
         }
         break;
     case hash("lfo&_phase"):

--- a/src/sfizz/Resources.h
+++ b/src/sfizz/Resources.h
@@ -13,6 +13,8 @@
 #include "Wavetables.h"
 #include "Curve.h"
 #include "Tuning.h"
+#include "BeatClock.h"
+#include "Metronome.h"
 #include "modulations/ModMatrix.h"
 #include "absl/types/optional.h"
 
@@ -32,11 +34,15 @@ struct Resources
     Tuning tuning;
     absl::optional<StretchTuning> stretch;
     ModMatrix modMatrix;
+    BeatClock beatClock;
+    Metronome metronome;
 
     void setSampleRate(float samplerate)
     {
         midiState.setSampleRate(samplerate);
         modMatrix.setSampleRate(samplerate);
+        beatClock.setSampleRate(samplerate);
+        metronome.init(samplerate);
     }
 
     void setSamplesPerBlock(int samplesPerBlock)
@@ -44,6 +50,7 @@ struct Resources
         bufferPool.setBufferSize(samplesPerBlock);
         midiState.setSamplesPerBlock(samplesPerBlock);
         modMatrix.setSamplesPerBlock(samplesPerBlock);
+        beatClock.setSamplesPerBlock(samplesPerBlock);
     }
 
     void clear()
@@ -54,6 +61,8 @@ struct Resources
         logger.clear();
         midiState.reset();
         modMatrix.clear();
+        beatClock.clear();
+        metronome.clear();
     }
 };
 }

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -925,7 +925,7 @@ void Synth::renderBlock(AudioSpan<float> buffer) noexcept
     constexpr bool metronomeEnabled = false;
     if (metronomeEnabled) {
         impl.resources_.metronome.processAdding(
-            bc.getRunningBeat().data(), bc.getRunningBeatsPerBar().data(),
+            bc.getRunningBeatNumber().data(), bc.getRunningBeatsPerBar().data(),
             buffer.getChannel(0), buffer.getChannel(1), numFrames);
     }
 

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -396,7 +396,7 @@ public:
      * @param      bar                  The current bar.
      * @param      bar_beat             The fractional position of the current beat within the bar.
      */
-    void timePosition(int delay, int bar, float barBeat);
+    void timePosition(int delay, int bar, double barBeat);
     /**
      * @brief      Send the playback state.
      *

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -1478,7 +1478,7 @@ void Voice::setMaxLFOsPerVoice(size_t numLFOs)
     impl.lfos_.resize(numLFOs);
 
     for (size_t i = 0; i < numLFOs; ++i) {
-        auto lfo = absl::make_unique<LFO>();
+        auto lfo = absl::make_unique<LFO>(impl.resources_.bufferPool);
         lfo->setSampleRate(impl.sampleRate_);
         impl.lfos_[i] = std::move(lfo);
     }

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -1475,10 +1475,12 @@ void Voice::setMaxEQsPerVoice(size_t numFilters)
 void Voice::setMaxLFOsPerVoice(size_t numLFOs)
 {
     Impl& impl = *impl_;
+    Resources& resources = impl.resources_;
+
     impl.lfos_.resize(numLFOs);
 
     for (size_t i = 0; i < numLFOs; ++i) {
-        auto lfo = absl::make_unique<LFO>(impl.resources_.bufferPool);
+        auto lfo = absl::make_unique<LFO>(resources.bufferPool, &resources.beatClock);
         lfo->setSampleRate(impl.sampleRate_);
         impl.lfos_[i] = std::move(lfo);
     }

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -1481,7 +1481,7 @@ void Voice::setMaxLFOsPerVoice(size_t numLFOs)
 
     for (size_t i = 0; i < numLFOs; ++i) {
         const NumericId<LFO> id { static_cast<int>(i) };
-        auto lfo = absl::make_unique<LFO>(id, resources.bufferPool, &resources.beatClock);
+        auto lfo = absl::make_unique<LFO>(id, resources.bufferPool, &resources.beatClock, &resources.modMatrix);
         lfo->setSampleRate(impl.sampleRate_);
         impl.lfos_[i] = std::move(lfo);
     }

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -1480,7 +1480,8 @@ void Voice::setMaxLFOsPerVoice(size_t numLFOs)
     impl.lfos_.resize(numLFOs);
 
     for (size_t i = 0; i < numLFOs; ++i) {
-        auto lfo = absl::make_unique<LFO>(resources.bufferPool, &resources.beatClock);
+        const NumericId<LFO> id { static_cast<int>(i) };
+        auto lfo = absl::make_unique<LFO>(id, resources.bufferPool, &resources.beatClock);
         lfo->setSampleRate(impl.sampleRate_);
         impl.lfos_[i] = std::move(lfo);
     }

--- a/src/sfizz/modulations/ModId.cpp
+++ b/src/sfizz/modulations/ModId.cpp
@@ -68,6 +68,10 @@ int ModIds::flags(ModId id) noexcept
         return kModIsPerVoice|kModIsAdditive;
     case ModId::OscillatorModDepth:
         return kModIsPerVoice|kModIsPercentMultiplicative;
+    case ModId::LFOFrequency:
+        return kModIsPerVoice|kModIsAdditive;
+    case ModId::LFOBeats:
+        return kModIsPerVoice|kModIsAdditive;
 
         // unknown
     default:

--- a/src/sfizz/modulations/ModId.h
+++ b/src/sfizz/modulations/ModId.h
@@ -49,6 +49,8 @@ enum class ModId : int {
     EqBandwidth,
     OscillatorDetune,
     OscillatorModDepth,
+    LFOFrequency,
+    LFOBeats,
 
     _TargetsEnd,
     // [/targets] --------------------------------------------------------------

--- a/src/sfizz/modulations/ModKey.cpp
+++ b/src/sfizz/modulations/ModKey.cpp
@@ -118,6 +118,10 @@ std::string ModKey::toString() const
         return absl::StrCat("OscillatorDetune {", region_.number(), ", N=", 1 + params_.N, "}");
    case ModId::OscillatorModDepth:
         return absl::StrCat("OscillatorModDepth {", region_.number(), ", N=", 1 + params_.N, "}");
+    case ModId::LFOFrequency:
+        return absl::StrCat("LFOFrequency {", region_.number(), ", N=", 1 + params_.N, "}");
+    case ModId::LFOBeats:
+        return absl::StrCat("LFOBeats {", region_.number(), ", N=", 1 + params_.N, "}");
 
     default:
         return {};

--- a/src/sfizz/modulations/sources/LFO.cpp
+++ b/src/sfizz/modulations/sources/LFO.cpp
@@ -59,7 +59,7 @@ void LFOSource::generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl
     }
 
     LFO* lfo = voice->getLFO(lfoIndex);
-    lfo->process(buffer);
+    lfo->process(buffer, region->getId());
 }
 
 } // namespace sfz

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -164,7 +164,7 @@ void sfz::Sfizz::timeSignature(int delay, int beatsPerBar, int beatUnit)
     synth->timeSignature(delay, beatsPerBar, beatUnit);
 }
 
-void sfz::Sfizz::timePosition(int delay, int bar, float barBeat)
+void sfz::Sfizz::timePosition(int delay, int bar, double barBeat)
 {
     synth->timePosition(delay, bar, barBeat);
 }

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -166,7 +166,7 @@ void sfizz_send_time_signature(sfizz_synth_t* synth, int delay, int beats_per_ba
     auto* self = reinterpret_cast<sfz::Synth*>(synth);
     self->timeSignature(delay, beats_per_bar, beat_unit);
 }
-void sfizz_send_time_position(sfizz_synth_t* synth, int delay, int bar, float bar_beat)
+void sfizz_send_time_position(sfizz_synth_t* synth, int delay, int bar, double bar_beat)
 {
     auto* self = reinterpret_cast<sfz::Synth*>(synth);
     self->timePosition(delay, bar, bar_beat);

--- a/tests/LFOT.cpp
+++ b/tests/LFOT.cpp
@@ -26,7 +26,8 @@ static bool computeLFO(DataPoints& dp, const fs::path& sfzPath, double sampleRat
     std::vector<std::unique_ptr<sfz::LFO>> lfos(numLfos);
 
     for (size_t l = 0; l < numLfos; ++l) {
-        sfz::LFO* lfo = new sfz::LFO(resources.bufferPool);
+        const NumericId<sfz::LFO> id { static_cast<int>(l) };
+        sfz::LFO* lfo = new sfz::LFO(id, resources.bufferPool);
         lfos[l].reset(lfo);
         lfo->setSampleRate(sampleRate);
         lfo->configure(&desc[l]);

--- a/vst/SfizzVstProcessor.cpp
+++ b/vst/SfizzVstProcessor.cpp
@@ -286,7 +286,7 @@ void SfizzVstProcessor::updateTimeInfo(const Vst::ProcessContext& context)
         double beats = context.projectTimeMusic * 0.25 * _timeSigDenominator;
         double bars = beats / _timeSigNumerator;
         beats -= int(bars) * _timeSigNumerator;
-        synth.timePosition(0, int(bars), float(beats));
+        synth.timePosition(0, int(bars), beats);
     }
 
     synth.playbackState(0, (context.state & context.kPlaying) != 0);


### PR DESCRIPTION
Based on #364
This permits the phase of LFO to be driven by the musical clock.
It implements the opcode `lfoN_beats`.

Depending whether the opcode is used or not, and whether the hosts provides the musical clock, the code will select 1 of 2 paths for phase generation.
The value is taken to be the number of beats that span a period of the LFO.

Decoupling phase and waveform generation opens new possibilities for improvement.
- vectorize the wave generation
- implement `lfoN_count`, at the phase generator level