### PR TITLE
Make sure to null the editor frame after closing

### DIFF
--- a/vst/SfizzVstEditor.cpp
+++ b/vst/SfizzVstEditor.cpp
@@ -79,6 +79,7 @@ void PLUGIN_API SfizzVstEditor::close()
             frame->forget();
         else
             frame->close();
+        this->frame = nullptr;
     }
 }
 


### PR DESCRIPTION
This hardens the plugin in case host would call `close` multiple times.
Also this will possibly be required for a workaround to how Reaper processes the messages.