### PR TITLE
Delayed UI updates with locking

### DIFF
--- a/vst/SfizzVstController.h
+++ b/vst/SfizzVstController.h
@@ -11,6 +11,7 @@
 #include "vstgui/plugin-bindings/vst3editor.h"
 #include <sfizz_message.h>
 class SfizzVstState;
+class SfizzVstEditor;
 
 using namespace Steinberg;
 using namespace VSTGUI;
@@ -47,28 +48,6 @@ public:
     tresult PLUGIN_API setComponentState(IBStream* state) override;
     tresult PLUGIN_API notify(Vst::IMessage* message) override;
 
-    struct StateListener {
-        virtual void onStateChanged() = 0;
-    };
-    struct MessageListener {
-        virtual void onMessageReceived(const char* path, const char* sig, const sfizz_arg_t* args) = 0;
-    };
-
-    const SfizzVstState& getSfizzState() const { return _state; }
-    SfizzVstState& getSfizzState() { return _state; }
-
-    const SfizzUiState& getSfizzUiState() const { return _uiState; }
-    SfizzUiState& getSfizzUiState() { return _uiState; }
-
-    const SfizzPlayState& getSfizzPlayState() const { return _playState; }
-    SfizzPlayState& getSfizzPlayState() { return _playState; }
-
-    void addSfizzStateListener(StateListener* listener);
-    void removeSfizzStateListener(StateListener* listener);
-
-    void addSfizzMessageListener(MessageListener* listener);
-    void removeSfizzMessageListener(MessageListener* listener);
-
     ///
     static FUnknown* createInstance(void*);
 
@@ -78,6 +57,5 @@ private:
     SfizzVstState _state;
     SfizzUiState _uiState;
     SfizzPlayState _playState {};
-    std::vector<StateListener*> _stateListeners;
-    std::vector<MessageListener*> _messageListeners;
+    Steinberg::IPtr<SfizzVstEditor> _editor;
 };

--- a/vst/SfizzVstEditor.cpp
+++ b/vst/SfizzVstEditor.cpp
@@ -53,6 +53,10 @@ bool PLUGIN_API SfizzVstEditor::open(void* parent, const VSTGUI::PlatformType& p
         editor = new Editor(*this);
         editor_.reset(editor);
     }
+
+    mustRedisplayState_ = true;
+    mustRedisplayUiState_ = true;
+    mustRedisplayPlayState_ = true;
     updateStateDisplay();
 
     if (!frame->open(parent, platformType, config)) {

--- a/vst/SfizzVstEditor.h
+++ b/vst/SfizzVstEditor.h
@@ -41,6 +41,10 @@ public:
     SfizzUiState getCurrentUiState() const;
     void receiveMessage(const void* data, uint32_t size);
 
+private:
+    void processOscQueue();
+    void flushOscQueue();
+
 protected:
     // EditorController
     void uiSendValue(EditId id, const EditValue& v) override;
@@ -75,4 +79,5 @@ private:
     volatile bool mustRedisplayState_ = false;
     volatile bool mustRedisplayUiState_ = false;
     volatile bool mustRedisplayPlayState_ = false;
+    std::vector<uint8_t> oscQueue_;
 };

--- a/vst/SfizzVstProcessor.cpp
+++ b/vst/SfizzVstProcessor.cpp
@@ -558,8 +558,10 @@ void SfizzVstProcessor::receiveMessage(int delay, const char* path, const char* 
 {
     uint8_t* oscTemp = _oscTemp.get();
     uint32_t oscSize = sfizz_prepare_message(oscTemp, kOscTempSize, path, sig, args);
-    if (oscSize <= kOscTempSize)
-        writeWorkerMessage("ReceiveMessage", oscTemp, oscSize);
+    if (oscSize <= kOscTempSize) {
+        if (writeWorkerMessage("ReceiveMessage", oscTemp, oscSize))
+            _semaToWorker.post();
+    }
 }
 
 void SfizzVstProcessor::loadSfzFileOrDefault(sfz::Sfizz& synth, const std::string& filePath)


### PR DESCRIPTION
Reaper apparently suffers a defect of VST3 implementation, which causes notifications to the UI controller to not arrive on the UI thread but they should.

When the strings which are part of the state are accessed concurrently, there would be a memory corruption. (sfz file, scala file)

To work around, this adopts a different strategy.
The controller sends its whole copy of the state to the editor, with mutex protection.
It sets a flag to the editor that indicates some redisplays must happen.
The editor processes the updates in the notification of the idle timer.