### PR TITLE
Static link strategy for AudioUnit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,6 @@
 [submodule "external/st_audiofile/thirdparty/libaiff"]
 	path = external/st_audiofile/thirdparty/libaiff
 	url = https://github.com/sfztools/libaiff.git
+[submodule "vst/external/sfzt_auwrapper"]
+	path = vst/external/sfzt_auwrapper
+	url = https://github.com/sfztools/sfzt_auwrapper.git

--- a/scripts/appveyor/after_build.sh
+++ b/scripts/appveyor/after_build.sh
@@ -15,8 +15,6 @@ else
   # code-sign AudioUnit and dylibs
   codesign --sign "${CODESIGN_IDENTITY}" --deep --keychain build.keychain --force --verbose \
            "${INSTALL_DIR}"/Library/Audio/Plug-Ins/Components/sfizz.component
-  codesign --sign "${CODESIGN_IDENTITY}" --deep --keychain build.keychain --force --verbose \
-           "${INSTALL_DIR}"/Library/Audio/Plug-Ins/Components/sfizz.component/Contents/Resources/plugin.vst3
   # code-sign LV2 and dylibs (note: manual, LV2 are not real bundles)
   codesign --sign "${CODESIGN_IDENTITY}" --keychain build.keychain --force --verbose \
            "${INSTALL_DIR}"/Library/Audio/Plug-Ins/LV2/sfizz.lv2/Contents/Binary/*.so

--- a/vst/CMakeLists.txt
+++ b/vst/CMakeLists.txt
@@ -2,6 +2,8 @@ set (VSTPLUGIN_PRJ_NAME "${PROJECT_NAME}_vst3")
 set (VSTPLUGIN_BUNDLE_NAME "${PROJECT_NAME}.vst3")
 
 set (VST3SDK_BASEDIR "${CMAKE_CURRENT_SOURCE_DIR}/external/VST_SDK/VST3_SDK")
+#set (AUWRAPPER_BASEDIR "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper")
+set (AUWRAPPER_BASEDIR "${CMAKE_CURRENT_SOURCE_DIR}/external/sfzt_auwrapper")
 
 # VST plugin specific settings
 include (VSTConfig)
@@ -71,11 +73,13 @@ plugin_add_vstgui(${VSTPLUGIN_PRJ_NAME})
 set (RINGBUFFER_HEADERS
     "external/ring_buffer/ring_buffer/ring_buffer.h"
     "external/ring_buffer/ring_buffer/ring_buffer.tcc")
-source_group ("Header Files" FILES ${RINGBUFFER_HEADERS})
-target_include_directories(${VSTPLUGIN_PRJ_NAME} PRIVATE "external/ring_buffer")
-target_sources(${VSTPLUGIN_PRJ_NAME} PRIVATE
+add_library(sfizz_ring_buffer STATIC
     "external/ring_buffer/ring_buffer/ring_buffer.cpp"
     ${RINGBUFFER_HEADERS})
+source_group ("Header Files" FILES ${RINGBUFFER_HEADERS})
+target_include_directories(sfizz_ring_buffer INTERFACE "external/ring_buffer")
+
+target_link_libraries(${VSTPLUGIN_PRJ_NAME} PRIVATE sfizz_ring_buffer)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     target_link_libraries(${VSTPLUGIN_PRJ_NAME} PRIVATE
@@ -174,11 +178,13 @@ elseif(SFIZZ_AU)
     set(AUPLUGIN_BUNDLE_NAME "${PROJECT_NAME}.component")
 
     add_library(${AUPLUGIN_PRJ_NAME} MODULE
-        "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper/aucarbonview.mm"
-        "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper/aucocoaview.mm"
-        "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper/ausdk.mm"
-        "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper/auwrapper.mm"
-        "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper/NSDataIBStream.mm")
+        "${AUWRAPPER_BASEDIR}/aucarbonview.mm"
+        "${AUWRAPPER_BASEDIR}/aucocoaview.mm"
+        "${AUWRAPPER_BASEDIR}/ausdk.mm"
+        "${AUWRAPPER_BASEDIR}/auwrapper.mm"
+        "${AUWRAPPER_BASEDIR}/NSDataIBStream.mm"
+        ${VSTPLUGIN_HEADERS}
+        ${VSTPLUGIN_SOURCES})
     target_include_directories(${AUPLUGIN_PRJ_NAME} PRIVATE
         "${VST3SDK_BASEDIR}")
     target_link_libraries(${AUPLUGIN_PRJ_NAME} PRIVATE
@@ -190,9 +196,18 @@ elseif(SFIZZ_AU)
         "${APPLE_COREAUDIO_LIBRARY}"
         "${APPLE_COREMIDI_LIBRARY}")
 
+    target_link_libraries(${AUPLUGIN_PRJ_NAME}
+        PRIVATE ${PROJECT_NAME}::${PROJECT_NAME}
+        PRIVATE sfizz_editor
+        PRIVATE sfizz-pugixml)
+    target_include_directories(${AUPLUGIN_PRJ_NAME}
+        PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
     set_target_properties(${AUPLUGIN_PRJ_NAME} PROPERTIES
         OUTPUT_NAME "${PROJECT_NAME}"
         PREFIX "")
+
+    plugin_add_vst3sdk(${AUPLUGIN_PRJ_NAME})
+    plugin_add_vstgui(${AUPLUGIN_PRJ_NAME})
 
     # Get Core Audio utility classes if missing
     set(CA_UTILITY_BASEDIR
@@ -229,26 +244,6 @@ elseif(SFIZZ_AU)
         "${CA_UTILITY_BASEDIR}/CoreAudio/AudioUnits/AUPublic/Utility"
         "${CA_UTILITY_BASEDIR}/CoreAudio/PublicUtility")
 
-    # Add VST base classes
-    target_sources(${AUPLUGIN_PRJ_NAME} PRIVATE
-        "${VST3SDK_BASEDIR}/base/source/baseiids.cpp"
-        "${VST3SDK_BASEDIR}/base/source/fbuffer.cpp"
-        "${VST3SDK_BASEDIR}/base/source/fdebug.cpp"
-        "${VST3SDK_BASEDIR}/base/source/fdynlib.cpp"
-        "${VST3SDK_BASEDIR}/base/source/fobject.cpp"
-        "${VST3SDK_BASEDIR}/base/source/fstreamer.cpp"
-        "${VST3SDK_BASEDIR}/base/source/fstring.cpp"
-        "${VST3SDK_BASEDIR}/base/source/timer.cpp"
-        "${VST3SDK_BASEDIR}/base/source/updatehandler.cpp"
-        "${VST3SDK_BASEDIR}/base/thread/source/fcondition.cpp"
-        "${VST3SDK_BASEDIR}/base/thread/source/flock.cpp"
-        "${VST3SDK_BASEDIR}/pluginterfaces/base/conststringtable.cpp"
-        "${VST3SDK_BASEDIR}/pluginterfaces/base/coreiids.cpp"
-        "${VST3SDK_BASEDIR}/pluginterfaces/base/funknown.cpp"
-        "${VST3SDK_BASEDIR}/pluginterfaces/base/ustring.cpp"
-        "${VST3SDK_BASEDIR}/public.sdk/source/common/commoniids.cpp"
-        "${VST3SDK_BASEDIR}/public.sdk/source/vst/vstinitiids.cpp")
-
     # Add VST hosting classes
     target_sources(${AUPLUGIN_PRJ_NAME} PRIVATE
         "${VST3SDK_BASEDIR}/public.sdk/source/vst/hosting/eventlist.cpp"
@@ -256,6 +251,9 @@ elseif(SFIZZ_AU)
         "${VST3SDK_BASEDIR}/public.sdk/source/vst/hosting/parameterchanges.cpp"
         "${VST3SDK_BASEDIR}/public.sdk/source/vst/hosting/pluginterfacesupport.cpp"
         "${VST3SDK_BASEDIR}/public.sdk/source/vst/hosting/processdata.cpp")
+
+    # Add the ring buffer
+    target_link_libraries(${AUPLUGIN_PRJ_NAME} PRIVATE sfizz_ring_buffer)
 
     # Add generated source
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
@@ -269,6 +267,9 @@ elseif(SFIZZ_AU)
     # Create the bundle
     execute_process(
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources")
+    copy_editor_resources(
+        "${CMAKE_CURRENT_SOURCE_DIR}/../editor/resources"
+        "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources")
     set_target_properties(${AUPLUGIN_PRJ_NAME} PROPERTIES
         SUFFIX ""
         LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/MacOS/$<0:>")
@@ -315,7 +316,7 @@ elseif(SFIZZ_AU)
             "-I" "${CMAKE_CURRENT_BINARY_DIR}/include" # generated audiounitconfig.h
             "-o" "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources/${PROJECT_NAME}.rsrc"
             "-useDF"
-            "${VST3SDK_BASEDIR}/public.sdk/source/vst/auwrapper/auresource.r")
+            "${AUWRAPPER_BASEDIR}/auresource.r")
     endif()
 
     if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
@@ -336,14 +337,8 @@ elseif(SFIZZ_AU)
         install(DIRECTORY "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}"
             DESTINATION "${AUPLUGIN_INSTALL_DIR}"
             COMPONENT "au")
-        install(DIRECTORY "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/"
-            DESTINATION "${AUPLUGIN_INSTALL_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources/plugin.vst3"
-            COMPONENT "au")
         bundle_dylibs(au
             "${AUPLUGIN_INSTALL_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/MacOS/sfizz"
-            COMPONENT "au")
-        bundle_dylibs(au-vst
-            "${AUPLUGIN_INSTALL_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources/plugin.vst3/Contents/MacOS/sfizz"
             COMPONENT "au")
     endif()
 endif()

--- a/vst/cmake/Vst3.cmake
+++ b/vst/cmake/Vst3.cmake
@@ -10,7 +10,7 @@ function(plugin_add_vst3sdk NAME)
         "${VST3SDK_BASEDIR}/base/source/fobject.cpp"
         "${VST3SDK_BASEDIR}/base/source/fstreamer.cpp"
         "${VST3SDK_BASEDIR}/base/source/fstring.cpp"
-        # "${VST3SDK_BASEDIR}/base/source/timer.cpp"
+        "${VST3SDK_BASEDIR}/base/source/timer.cpp"
         "${VST3SDK_BASEDIR}/base/source/updatehandler.cpp"
         "${VST3SDK_BASEDIR}/base/thread/source/fcondition.cpp"
         "${VST3SDK_BASEDIR}/base/thread/source/flock.cpp"


### PR DESCRIPTION
This uses a different implementation strategy for Audio Unit.
The VST3 will be linked statically instead of loaded at runtime.
This resolves instability problems.
The modified `auwrapper` is provided as a submodule.
