### PR TITLE
Search the SFZ folders defined by variable SFZ_PATH

### DIFF
--- a/vst/SfizzFileScan.h
+++ b/vst/SfizzFileScan.h
@@ -40,4 +40,5 @@ std::vector<fs::path> getSfzSearchPaths();
 absl::optional<fs::path> getSfzConfigDefaultPath();
 void setSfzConfigDefaultPath(const fs::path& path);
 fs::path getSfzFallbackDefaultPath();
+std::vector<fs::path> getEnvironmentSfzPaths();
 } // namespace SfizzPaths


### PR DESCRIPTION
This permits to use an other SFZ files path, defined in the environment.