### PR TITLE
Possible corrections to CheckIPO.cmake script

### DIFF
--- a/cmake/CheckIPO.cmake
+++ b/cmake/CheckIPO.cmake
@@ -1,36 +1,34 @@
-# Added in CMake 3.9
-
 if(CMAKE_VERSION VERSION_LESS 3.9)
     message(WARNING "\nIPO checks are only available on CMake 3.9 and later.")
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l)
+    message(WARNING "\nLTO not enabled for armv7l.")
+else()
+    set(LTO_CHECK_OK ON)
+endif()
 
+if(NOT LTO_CHECK_OK)
     set(ENABLE_LTO OFF CACHE BOOL "" FORCE)
-
-    function(SFIZZ_ENABLE_LTO_IF_NEEDED TARGET)
+    function(sfizz_enable_lto_if_needed TARGET)
     endfunction()
-
     return()
 endif()
 
 include(CheckIPOSupported)
 check_ipo_supported(RESULT result OUTPUT output)
 
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l)
-    set(ENABLE_LTO OFF CACHE BOOL "" FORCE)
-endif()
-
 if(result AND ENABLE_LTO AND CMAKE_BUILD_TYPE STREQUAL "Release")
     message(STATUS "\nLTO enabled.")
 else()
-    if(${output})
-        message(WARNING "\nIPO disabled: ${output}")
+    if("${output}" STREQUAL "")
+        message(WARNING "\nLTO was disabled or not in a Release build.")
     else()
-        message(WARNING "\nIPO was disabled or not in a Release build.")
+        message(WARNING "\nLTO disabled: ${output}")
     endif()
     set(ENABLE_LTO OFF CACHE BOOL "" FORCE)
 endif()
 
-function(SFIZZ_ENABLE_LTO_IF_NEEDED TARGET)
-    if(${ENABLE_LTO})
+function(sfizz_enable_lto_if_needed TARGET)
+    if(ENABLE_LTO)
         message(STATUS "Enabling LTO on ${TARGET}")
         set_property(TARGET ${TARGET} PROPERTY INTERPROCEDURAL_OPTIMIZATION True)
     endif()


### PR DESCRIPTION
- add a warning when building for armv7 instead disable silently
- better condition expression syntax

I wonder if it could be useful also to rename `ENABLE_LTO` with a `SFIZZ_` prefix as all other options.