### PR TITLE
Hermite interpolator as default; has less HF attenuation

### DIFF
--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -1162,11 +1162,11 @@ void Voice::Impl::fillInterpolatedWithQuality(
         break;
     case 2: high:
         {
-#if 1
+#if 0
             // B-spline response has faster decay of aliasing, but not zero-crossings at integer positions
             constexpr auto itp = kInterpolatorBspline3;
 #else
-            // Hermite polynomial
+            // Hermite polynomial, has less pass-band attenuation
             constexpr auto itp = kInterpolatorHermite3;
 #endif
             fillInterpolated<itp, Adding>(source, dest, indices, coeffs, addingGains);


### PR DESCRIPTION
This should help with preserving more of the pass-band, as reported #594
the Hermite version is better in this regard, although the alias suppression is not as efficient