### PR TITLE
Make tuning frequency editable by wheel

### DIFF
--- a/editor/src/editor/EditIds.h
+++ b/editor/src/editor/EditIds.h
@@ -35,5 +35,6 @@ struct EditRange {
     constexpr EditRange() = default;
     constexpr EditRange(float def, float min, float max)
         : def(def), min(min), max(max) {}
+    float extent() const noexcept { return max - min; }
     static EditRange get(EditId id);
 };

--- a/editor/src/editor/Editor.cpp
+++ b/editor/src/editor/Editor.cpp
@@ -636,6 +636,7 @@ void Editor::Impl::createFrameContents()
             static_cast<int>(EditRange::get(EditId::ScalaRootKey).def) / 12);
     }
     adjustMinMaxToEditRange(tuningFrequencySlider_, EditId::TuningFrequency);
+    tuningFrequencySlider_->setWheelInc(0.1f / EditRange::get(EditId::TuningFrequency).extent());
     adjustMinMaxToEditRange(stretchedTuningSlider_, EditId::StretchTuning);
 
     for (int value : {1, 2, 4, 8, 16, 32, 64, 96, 128, 160, 192, 224, 256})

--- a/editor/src/editor/GUIComponents.cpp
+++ b/editor/src/editor/GUIComponents.cpp
@@ -160,6 +160,7 @@ SValueMenu::SValueMenu(const CRect& bounds, IControlListener* listener, int32_t 
 {
     setListener(listener);
     setTag(tag);
+    setWheelInc(0.0f);
 }
 
 CMenuItem* SValueMenu::addEntry(CMenuItem* item, float value, int32_t index)
@@ -224,6 +225,24 @@ CMouseEventResult SValueMenu::onMouseDown(CPoint& where, const CButtonState& but
     }
 
     return kMouseEventNotHandled;
+}
+
+bool SValueMenu::onWheel(const CPoint& where, const CMouseWheelAxis& axis, const float& distance, const CButtonState& buttons)
+{
+    (void)where;
+    (void)buttons;
+
+    if (axis != kMouseWheelAxisY)
+        return false;
+
+    float wheelInc = getWheelInc();
+    if (wheelInc != 0) {
+        float oldValue = getValue();
+        setValueNormalized(getValueNormalized() + distance * wheelInc);
+        if (getValue() != oldValue)
+            valueChanged();
+    }
+    return true;
 }
 
 void SValueMenu::onItemClicked(int32_t index)

--- a/editor/src/editor/GUIComponents.h
+++ b/editor/src/editor/GUIComponents.h
@@ -94,6 +94,7 @@ public:
 
 protected:
     CMouseEventResult onMouseDown(CPoint& where, const CButtonState& buttons) override;
+    bool onWheel(const CPoint& where, const CMouseWheelAxis& axis, const float& distance, const CButtonState& buttons) override;
 
 private:
     class MenuListener;


### PR DESCRIPTION
This allows the `SValueMenu` to be edited by wheel.
Tuning frequency can be adjusted by increments of `0.1`.