### PR TITLE
Avoid reloading invalid files in a loop

### DIFF
--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -110,9 +110,9 @@ struct Synth::Impl final: public Parser::Listener {
     /**
      * @brief Get the modification time of all included sfz files
      *
-     * @return fs::file_time_type
+     * @return absl::optional<fs::file_time_type>
      */
-    fs::file_time_type checkModificationTime();
+    absl::optional<fs::file_time_type> checkModificationTime() const;
 
     /**
      * @brief Check all regions and start voices for note on events
@@ -277,7 +277,7 @@ struct Synth::Impl final: public Parser::Listener {
     std::chrono::time_point<std::chrono::high_resolution_clock> lastGarbageCollection_;
 
     Parser parser_;
-    fs::file_time_type modificationTime_ { };
+    absl::optional<fs::file_time_type> modificationTime_ { };
 
     std::array<float, config::numCCs> defaultCCValues_;
     std::bitset<config::numCCs> currentUsedCCs_;

--- a/src/sfizz/parser/Parser.cpp
+++ b/src/sfizz/parser/Parser.cpp
@@ -19,7 +19,7 @@ Parser::~Parser()
 {
 }
 
-void Parser::reset()
+void Parser::clear()
 {
     _pathsIncluded.clear();
     _currentDefinitions = _externalDefinitions;
@@ -51,7 +51,7 @@ void Parser::parseString(const fs::path& path, absl::string_view sfzView)
 
 void Parser::parseVirtualFile(const fs::path& path, std::unique_ptr<Reader> reader)
 {
-    reset();
+    clear();
 
     if (_listener)
         _listener->onParseBegin();

--- a/src/sfizz/parser/Parser.h
+++ b/src/sfizz/parser/Parser.h
@@ -27,6 +27,8 @@ public:
     Parser();
     ~Parser();
 
+    void clear();
+
     void addExternalDefinition(absl::string_view id, absl::string_view value);
     void clearExternalDefinitions();
 
@@ -71,7 +73,6 @@ private:
     void processDirective();
     void processHeader();
     void processOpcode();
-    void reset();
 
     // errors and warnings
     void emitError(const SourceRange& range, const std::string& message);


### PR DESCRIPTION
This prevents incorrect or missing files from reloading in a loop.

Currently, when one creates a file without regions, loading will fail, and it is in "should reload" state until editing it into a valid file.

Note: In the update, in case a file can't load the first time, sfizz will not attempt to auto-reload this path.

An additional change of this PR: the parser gets cleared in the case where loading failed.
