### PR TITLE
Allow the build to pass in some Linux x86

### DIFF
--- a/src/sfizz/Messaging.cpp
+++ b/src/sfizz/Messaging.cpp
@@ -10,11 +10,11 @@
 #include <type_traits>
 #include <cstring>
 
-#ifdef __cplusplus
+// ensure that `sfizz_arg_t` has the same storage characteristics as `int64_t`
 static_assert(
-    sizeof(sfizz_arg_t) == sizeof(int64_t) && alignof(sfizz_arg_t) == 8,
+    sizeof(sfizz_arg_t) == sizeof(int64_t) &&
+    alignof(sfizz_arg_t) == alignof(int64_t),
     "The ABI stability check has failed.");
-#endif
 
 template <class T>
 static T paddingSize(T count, unsigned align) {


### PR DESCRIPTION
Fix the compile-time check. Under some x86 configurations, int64 aligns to 4.