### PR TITLE
Respect region end opcode

### DIFF
--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -950,9 +950,11 @@ void Voice::Impl::fillWithData(AudioSpan<float> buffer) noexcept
     else {
         // cut short the voice at the instant of reaching end of sample
         const auto sampleEnd = min(
-            static_cast<int>(currentPromise_->information.end),
-            static_cast<int>(source.getNumFrames())
-        ) - 1;
+            int(region_->trueSampleEnd(resources_.filePool.getOversamplingFactor())),
+            int(currentPromise_->information.end),
+            int(source.getNumFrames()))
+            - 1;
+
         for (unsigned i = 0; i < numSamples; ++i) {
             if ((*indices)[i] >= sampleEnd) {
 #ifndef NDEBUG


### PR DESCRIPTION
Limit sample playback according to "end" opcode in non-looping modes. Currently, it is ignored.
Fixes #616.
Unsure if the opcode needs also special hangling when looping?