### PR TITLE
Fix voice groups destroyed after polyphony changed

### DIFF
--- a/src/sfizz/PolyphonyGroup.cpp
+++ b/src/sfizz/PolyphonyGroup.cpp
@@ -17,6 +17,11 @@ void sfz::PolyphonyGroup::removeVoice(const Voice* voice) noexcept
     swapAndPopFirst(voices, [voice](const Voice* v) { return v == voice; });
 }
 
+void sfz::PolyphonyGroup::removeAllVoices() noexcept
+{
+    voices.clear();
+}
+
 unsigned sfz::PolyphonyGroup::numPlayingVoices() const noexcept
 {
     return absl::c_count_if(voices, [](const Voice* v) {

--- a/src/sfizz/PolyphonyGroup.h
+++ b/src/sfizz/PolyphonyGroup.h
@@ -36,6 +36,10 @@ public:
      */
     void removeVoice(const Voice* voice) noexcept;
     /**
+     * @brief Remove all the voices from this polyphony group.
+     */
+    void removeAllVoices() noexcept;
+    /**
      * @brief Get the polyphony limit for this group
      *
      * @return unsigned


### PR DESCRIPTION
Stability fix for voice manager, which can do out-of-bounds access with polyphony groups.
This also should help to fix the recent crashes.