### PR TITLE
Fix a variety of xrun situations

### DIFF
--- a/src/sfizz/Config.h
+++ b/src/sfizz/Config.h
@@ -139,6 +139,17 @@ namespace config {
      */
     static constexpr float overflowVoiceMultiplier { 1.5f };
     static_assert(overflowVoiceMultiplier >= 1.0f, "This needs to add voices");
+
+    /**
+     * @brief Calculate the effective voice number for the polyphony setting,
+     * accounting for the overflow factor.
+     */
+    inline constexpr int calculateActualVoices(int polyphony)
+    {
+        return
+            (int(polyphony * config::overflowVoiceMultiplier) < int(config::maxVoices)) ?
+            int(polyphony * config::overflowVoiceMultiplier) : int(config::maxVoices);
+    }
 } // namespace config
 
 } // namespace sfz

--- a/src/sfizz/PolyphonyGroup.cpp
+++ b/src/sfizz/PolyphonyGroup.cpp
@@ -1,9 +1,13 @@
 #include "PolyphonyGroup.h"
 
+sfz::PolyphonyGroup::PolyphonyGroup()
+{
+    voices.reserve(config::maxVoices);
+}
+
 void sfz::PolyphonyGroup::setPolyphonyLimit(unsigned limit) noexcept
 {
     polyphonyLimit = limit;
-    voices.reserve(limit);
 }
 
 void sfz::PolyphonyGroup::registerVoice(Voice* voice) noexcept

--- a/src/sfizz/PolyphonyGroup.h
+++ b/src/sfizz/PolyphonyGroup.h
@@ -16,6 +16,8 @@ namespace sfz
 {
 class PolyphonyGroup {
 public:
+    PolyphonyGroup();
+
     /**
      * @brief Set the polyphony limit for this polyphony group.
      *

--- a/src/sfizz/RegionSet.cpp
+++ b/src/sfizz/RegionSet.cpp
@@ -1,9 +1,16 @@
 #include "RegionSet.h"
 
+sfz::RegionSet::RegionSet(RegionSet* parentSet, OpcodeScope level)
+    : parent(parentSet), level(level)
+{
+    voices.reserve(config::maxVoices);
+    if (parentSet != nullptr)
+        parentSet->addSubset(this);
+}
+
 void sfz::RegionSet::setPolyphonyLimit(unsigned limit) noexcept
 {
     polyphonyLimit = limit;
-    voices.reserve(limit);
 }
 
 void sfz::RegionSet::addRegion(Region* region) noexcept

--- a/src/sfizz/RegionSet.h
+++ b/src/sfizz/RegionSet.h
@@ -18,12 +18,7 @@ namespace sfz
 class RegionSet {
 public:
     RegionSet() = delete;
-    RegionSet(RegionSet* parentSet, OpcodeScope level)
-    : parent(parentSet), level(level)
-    {
-        if (parentSet != nullptr)
-            parentSet->addSubset(this);
-    }
+    RegionSet(RegionSet* parentSet, OpcodeScope level);
     /**
      * @brief Set the polyphony limit for the set
      *

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -1645,7 +1645,7 @@ void Voice::Impl::pitchEnvelope(absl::Span<float> pitchSpan) noexcept
     if (!bends)
         return;
 
-    const auto events = resources_.midiState.getPitchEvents();
+    const EventVector& events = resources_.midiState.getPitchEvents();
     const auto bendLambda = [this](float bend) {
         return centsFactor(region_->getBendInCents(bend));
     };

--- a/src/sfizz/VoiceManager.cpp
+++ b/src/sfizz/VoiceManager.cpp
@@ -159,15 +159,14 @@ Voice* VoiceManager::findFreeVoice() noexcept
 
 void VoiceManager::requireNumVoices(int numVoices, Resources& resources)
 {
-    numActualVoices_ =
-        static_cast<int>(config::overflowVoiceMultiplier * numVoices);
     numRequiredVoices_ = numVoices;
+    const int numEffectiveVoices = getNumEffectiveVoices();
 
     clear();
-    list_.reserve(numActualVoices_);
-    activeVoices_.reserve(numActualVoices_);
+    list_.reserve(numEffectiveVoices);
+    activeVoices_.reserve(numEffectiveVoices);
 
-    for (int i = 0; i < numActualVoices_; ++i) {
+    for (int i = 0; i < numEffectiveVoices; ++i) {
         list_.emplace_back(i, resources);
         Voice& lastVoice = list_.back();
         lastVoice.setStateListener(this);

--- a/src/sfizz/VoiceManager.h
+++ b/src/sfizz/VoiceManager.h
@@ -133,7 +133,7 @@ struct VoiceManager final : public Voice::StateListener
 
 private:
     int numRequiredVoices_ { config::numVoices };
-    int numActualVoices_ { static_cast<int>(config::numVoices * config::overflowVoiceMultiplier) };
+    int getNumEffectiveVoices() const noexcept { return config::calculateActualVoices(numRequiredVoices_); }
     std::vector<Voice> list_;
     std::vector<Voice*> activeVoices_;
     // These are the `group=` groups where you can off voices


### PR DESCRIPTION
This fixes some situations where allocs happen under the RT thread.
There exist some more which are yet to identify.

Voices are upper-bounded to `config::maxVoice`, and buffers are made over-allocated to that amount. (it's simpler)