### PR TITLE
Update to CC controls panel

### DIFF
--- a/editor/src/editor/GUIComponents.cpp
+++ b/editor/src/editor/GUIComponents.cpp
@@ -570,6 +570,8 @@ void SControlsPanel::setControlUsed(uint32_t index, bool used)
             label->setStyle(CTextLabel::kRoundRectStyle);
             label->setRoundRectRadius(5.0);
             label->setBackColor(CColor(0x2e, 0x34, 0x36));
+            label->setTextTruncateMode(CTextLabel::kTruncateTail);
+            label->setTextInset({4.0, 0.0});
             label->setText(getDefaultLabelText(index));
             knob->setActiveTrackColor(CColor(0x00, 0xb6, 0x2a));
             knob->setInactiveTrackColor(CColor(0x30, 0x30, 0x30));
@@ -630,11 +632,12 @@ void SControlsPanel::setControlLabelText(uint32_t index, UTF8StringPtr text)
     if (!slot)
         return;
 
+    CTextLabel* label = slot->label;
     if (text && text[0] != '\0')
-        slot->label->setText(text);
+        label->setText(text);
     else
-        slot->label->setText(getDefaultLabelText(index).c_str());
-    slot->label->invalid();
+        label->setText(getDefaultLabelText(index).c_str());
+    label->invalid();
 }
 
 void SControlsPanel::recalculateSubViews()

--- a/vst/SfizzVstProcessor.cpp
+++ b/vst/SfizzVstProcessor.cpp
@@ -625,6 +625,11 @@ void SfizzVstProcessor::doBackgroundWork()
                 fprintf(stderr, "[Sfizz] sfz file has changed, reloading\n");
                 std::lock_guard<SpinMutex> lock(_processMutex);
                 loadSfzFileOrDefault(*_synth, _state.sfzFile);
+
+                Steinberg::OPtr<Vst::IMessage> reply { allocateMessage() };
+                reply->setMessageID("LoadedSfz");
+                reply->getAttributes()->setBinary("File", _state.sfzFile.data(), _state.sfzFile.size());
+                sendMessage(reply);
             }
             else if (_synth->shouldReloadScala()) {
                 fprintf(stderr, "[Sfizz] scala file has changed, reloading\n");


### PR DESCRIPTION
- VST: update CC panel when SFZ reloaded
- truncate CC labels

note: LV2 also has the update problem on reload, needs a fix as well