### PR TITLE
Corrected a compile error on gcc 9.3

### DIFF
--- a/src/sfizz/Logger.cpp
+++ b/src/sfizz/Logger.cpp
@@ -102,7 +102,11 @@ void sfz::Logger::logCallbackTime(const CallbackBreakdown& breakdown, int numVoi
     if (!loggingEnabled)
         return;
 
-    callbackTimeQueue.try_push<CallbackTime>({ breakdown, numVoices, numSamples });
+    CallbackTime callbackTime;
+    callbackTime.breakdown = breakdown;
+    callbackTime.numVoices = numVoices;
+    callbackTime.numSamples = numSamples;
+    callbackTimeQueue.try_push(callbackTime);
 }
 
 void sfz::Logger::logFileTime(std::chrono::duration<double> waitDuration, std::chrono::duration<double> loadDuration, uint32_t fileSize, absl::string_view filename)
@@ -110,7 +114,12 @@ void sfz::Logger::logFileTime(std::chrono::duration<double> waitDuration, std::c
     if (!loggingEnabled)
         return;
 
-    fileTimeQueue.try_push<FileTime>({ waitDuration, loadDuration, fileSize, filename });
+    FileTime fileTime;
+    fileTime.waitDuration = waitDuration;
+    fileTime.loadDuration = loadDuration;
+    fileTime.fileSize = fileSize;
+    fileTime.filename = filename;
+    fileTimeQueue.try_push(fileTime);
 }
 
 void sfz::Logger::setPrefix(absl::string_view prefix)

--- a/src/sfizz/Logger.h
+++ b/src/sfizz/Logger.h
@@ -48,18 +48,10 @@ struct ScopedTiming
 
 struct FileTime
 {
-    FileTime() = default;
-    FileTime(Duration waitDuration, Duration loadDuration, uint32_t fileSize, absl::string_view filename)
-    : waitDuration(waitDuration), loadDuration(loadDuration), fileSize(fileSize), filename(filename) { }
-    FileTime(const FileTime&) = default;
-    FileTime& operator=(const FileTime&) = default;
-    FileTime(FileTime&&) = default;
-    FileTime& operator=(FileTime&&) = default;
     Duration waitDuration { 0 };
     Duration loadDuration { 0 };
     uint32_t fileSize { 0 };
     absl::string_view filename {};
-    LEAK_DETECTOR(FileTime);
 };
 
 struct CallbackBreakdown
@@ -71,22 +63,13 @@ struct CallbackBreakdown
     Duration filters { 0 };
     Duration panning { 0 };
     Duration effects { 0 };
-    LEAK_DETECTOR(CallbackBreakdown);
 };
 
 struct CallbackTime
 {
-    CallbackTime() = default;
-    CallbackTime(const CallbackBreakdown& breakdown, int numVoices, size_t numSamples)
-    : breakdown(breakdown), numVoices(numVoices), numSamples(numSamples) { }
-    CallbackTime(const CallbackTime&) = default;
-    CallbackTime& operator=(const CallbackTime&) = default;
-    CallbackTime(CallbackTime&&) = default;
-    CallbackTime& operator=(CallbackTime&&) = default;
     CallbackBreakdown breakdown {};
     int numVoices { 0 };
     size_t numSamples { 0 };
-    LEAK_DETECTOR(CallbackTime);
 };
 
 class Logger

--- a/src/sfizz/Logger.h
+++ b/src/sfizz/Logger.h
@@ -52,6 +52,7 @@ struct FileTime
     Duration loadDuration { 0 };
     uint32_t fileSize { 0 };
     absl::string_view filename {};
+    LEAK_DETECTOR(FileTime);
 };
 
 struct CallbackBreakdown
@@ -63,6 +64,7 @@ struct CallbackBreakdown
     Duration filters { 0 };
     Duration panning { 0 };
     Duration effects { 0 };
+    LEAK_DETECTOR(CallbackBreakdown);
 };
 
 struct CallbackTime
@@ -70,6 +72,7 @@ struct CallbackTime
     CallbackBreakdown breakdown {};
     int numVoices { 0 };
     size_t numSamples { 0 };
+    LEAK_DETECTOR(CallbackTime);
 };
 
 class Logger

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -515,10 +515,10 @@ TEST_CASE("[Synth] veltrack")
     };
 
     const VeltrackData veltrackdata[] = {
-        { 25, veldata25 },
-        { 50, veldata50 },
-        { 75, veldata75 },
-        { 100, veldata100 },
+        { 25, absl::MakeConstSpan(veldata25) },
+        { 50, absl::MakeConstSpan(veldata50) },
+        { 75, absl::MakeConstSpan(veldata75) },
+        { 100, absl::MakeConstSpan(veldata100) },
     };
 
     for (const VeltrackData& vt : veltrackdata) {


### PR DESCRIPTION
Removed the leak detector, which allows for POD data structures with no default functions. This way the `noexcept` specifier on the `atomic_queue` is actually valid, since the `FileTime` and `CallbackTime` objects can be built without throwing.

Note: this apparently changed recently in the standard [http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1286r2.html](url).

No clue why gcc started complaining now, maybe it got updated on my machine?