### PR TITLE
Rename Opcode member "opcode" to "name"

### DIFF
--- a/devtools/Preprocessor.cpp
+++ b/devtools/Preprocessor.cpp
@@ -39,13 +39,13 @@ protected:
             std::cout << '\n';
             std::cout << '<' << header << '>' << '\n';
             for (const sfz::Opcode& opc : opcodes)
-                std::cout << opc.opcode << '=' << opc.value << '\n';
+                std::cout << opc.name << '=' << opc.value << '\n';
         }
         else if (g_mode == OutputXML) {
             pugi::xml_node block_node = g_xml_doc.append_child(header.c_str());
             for (const sfz::Opcode& opc : opcodes) {
                 pugi::xml_node opcode_node = block_node.append_child("opcode");
-                opcode_node.append_attribute("name").set_value(opc.opcode.c_str());
+                opcode_node.append_attribute("name").set_value(opc.name.c_str());
                 opcode_node.append_attribute("value").set_value(opc.value.c_str());
             }
         }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -219,6 +219,9 @@ target_include_directories(sfizz_parser PUBLIC sfizz)
 target_link_libraries(sfizz_parser
     PUBLIC sfizz::filesystem sfizz::simde absl::strings
     PRIVATE absl::flat_hash_map)
+if(SFIZZ_RELEASE_ASSERTS)
+    target_compile_definitions(sfizz_parser PUBLIC "SFIZZ_ENABLE_RELEASE_ASSERT=1")
+endif()
 
 # OSC messaging library
 set(SFIZZ_MESSAGING_HEADERS
@@ -235,6 +238,9 @@ target_sources(sfizz_messaging PRIVATE
     ${SFIZZ_MESSAGING_HEADERS} ${SFIZZ_MESSAGING_SOURCES})
 target_include_directories(sfizz_messaging PUBLIC ".")
 target_link_libraries(sfizz_messaging PUBLIC absl::strings)
+if(SFIZZ_RELEASE_ASSERTS)
+    target_compile_definitions(sfizz_messaging PUBLIC "SFIZZ_ENABLE_RELEASE_ASSERT=1")
+endif()
 
 # Sfizz spinlock mutex
 add_library(sfizz_spin_mutex STATIC

--- a/src/sfizz/Opcode.cpp
+++ b/src/sfizz/Opcode.cpp
@@ -7,6 +7,7 @@
 #include "Opcode.h"
 #include "LFODescription.h"
 #include "StringViewHelpers.h"
+#include "Debug.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
@@ -17,31 +18,31 @@
 namespace sfz {
 
 Opcode::Opcode(absl::string_view inputOpcode, absl::string_view inputValue)
-    : opcode(trim(inputOpcode))
+    : name(trim(inputOpcode))
     , value(trim(inputValue))
     , category(identifyCategory(inputOpcode))
 {
     size_t nextCharIndex { 0 };
     int parameterPosition { 0 };
-    auto nextNumIndex = opcode.find_first_of("1234567890");
-    while (nextNumIndex != opcode.npos) {
+    auto nextNumIndex = name.find_first_of("1234567890");
+    while (nextNumIndex != name.npos) {
         const auto numLetters = nextNumIndex - nextCharIndex;
         parameterPosition += numLetters;
-        lettersOnlyHash = hashNoAmpersand(opcode.substr(nextCharIndex, numLetters), lettersOnlyHash);
-        nextCharIndex = opcode.find_first_not_of("1234567890", nextNumIndex);
+        lettersOnlyHash = hashNoAmpersand(name.substr(nextCharIndex, numLetters), lettersOnlyHash);
+        nextCharIndex = name.find_first_not_of("1234567890", nextNumIndex);
 
         uint32_t returnedValue;
-        const auto numDigits = (nextCharIndex == opcode.npos) ? opcode.npos : nextCharIndex - nextNumIndex;
-        if (absl::SimpleAtoi(opcode.substr(nextNumIndex, numDigits), &returnedValue)) {
+        const auto numDigits = (nextCharIndex == name.npos) ? name.npos : nextCharIndex - nextNumIndex;
+        if (absl::SimpleAtoi(name.substr(nextNumIndex, numDigits), &returnedValue)) {
             lettersOnlyHash = hash("&", lettersOnlyHash);
             parameters.push_back(returnedValue);
         }
 
-        nextNumIndex = opcode.find_first_of("1234567890", nextCharIndex);
+        nextNumIndex = name.find_first_of("1234567890", nextCharIndex);
     }
 
-    if (nextCharIndex != opcode.npos)
-        lettersOnlyHash = hashNoAmpersand(opcode.substr(nextCharIndex), lettersOnlyHash);
+    if (nextCharIndex != name.npos)
+        lettersOnlyHash = hashNoAmpersand(name.substr(nextCharIndex), lettersOnlyHash);
 }
 
 static absl::string_view extractBackInteger(absl::string_view opcodeName)
@@ -54,7 +55,7 @@ static absl::string_view extractBackInteger(absl::string_view opcodeName)
 
 std::string Opcode::getDerivedName(OpcodeCategory newCategory, unsigned number) const
 {
-    std::string derivedName(opcode);
+    std::string derivedName(name);
 
     switch (category) {
     case kOpcodeNormal:
@@ -65,8 +66,8 @@ std::string Opcode::getDerivedName(OpcodeCategory newCategory, unsigned number) 
     case kOpcodeSmoothCcN:
         {
             // when the input is cc, first delete the suffix `_*cc`
-            size_t pos = opcode.rfind('_');
-            assert(pos != opcode.npos);
+            size_t pos = name.rfind('_');
+            ASSERT(pos != name.npos);
             derivedName.resize(pos);
         }
         break;
@@ -75,7 +76,7 @@ std::string Opcode::getDerivedName(OpcodeCategory newCategory, unsigned number) 
     // helper to extract the cc number optionally if the next part needs it
     auto ccNumberSuffix = [this, number]() -> std::string {
         return (number != ~0u) ? std::to_string(number) :
-            std::string(extractBackInteger(opcode));
+            std::string(extractBackInteger(name));
     };
 
     switch (newCategory) {
@@ -448,5 +449,5 @@ absl::optional<LFOWave> Opcode::readOptional(OpcodeSpec<LFOWave> spec) const
 
 std::ostream &operator<<(std::ostream &os, const sfz::Opcode &opcode)
 {
-    return os << opcode.opcode << '=' << '"' << opcode.value << '"';
+    return os << opcode.name << '=' << '"' << opcode.value << '"';
 }

--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -66,7 +66,7 @@ enum OpcodeScope {
 struct Opcode {
     Opcode() = delete;
     Opcode(absl::string_view inputOpcode, absl::string_view inputValue);
-    std::string opcode {};
+    std::string name {};
     std::string value {};
     uint64_t lettersOnlyHash { Fnv1aBasis };
     // This is to handle the integer parameters of some opcodes

--- a/src/sfizz/OpcodeCleanup.cpp
+++ b/src/sfizz/OpcodeCleanup.cpp
@@ -2643,7 +2643,7 @@ end_control:
 
 Opcode Opcode::cleanUp(OpcodeScope scope) const
 {
-    return Opcode(cleanUpOpcodeName(opcode, scope), value);
+    return Opcode(cleanUpOpcodeName(name, scope), value);
 }
 
 } // namespace sfz

--- a/src/sfizz/OpcodeCleanup.re
+++ b/src/sfizz/OpcodeCleanup.re
@@ -237,7 +237,7 @@ end_control:
 
 Opcode Opcode::cleanUp(OpcodeScope scope) const
 {
-    return Opcode(cleanUpOpcodeName(opcode, scope), value);
+    return Opcode(cleanUpOpcodeName(name, scope), value);
 }
 
 } // namespace sfz

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -142,13 +142,13 @@ void Synth::Impl::buildRegion(const std::vector<Opcode>& regionOpcodes)
     //
     auto parseOpcodes = [&](const std::vector<Opcode>& opcodes) {
         for (auto& opcode : opcodes) {
-            const auto unknown = absl::c_find_if(unknownOpcodes_, [&](absl::string_view sv) { return sv.compare(opcode.opcode) == 0; });
+            const auto unknown = absl::c_find_if(unknownOpcodes_, [&](absl::string_view sv) { return sv.compare(opcode.name) == 0; });
             if (unknown != unknownOpcodes_.end()) {
                 continue;
             }
 
             if (!lastRegion->parseOpcode(opcode))
-                unknownOpcodes_.emplace_back(opcode.opcode);
+                unknownOpcodes_.emplace_back(opcode.name);
         }
     };
 
@@ -405,7 +405,7 @@ void Synth::Impl::handleControlOpcodes(const std::vector<Opcode>& members)
             break;
         default:
             // Unsupported control opcode
-            DBG("Unsupported control opcode: " << member.opcode);
+            DBG("Unsupported control opcode: " << member.name);
         }
     }
 }

--- a/tests/OpcodeT.cpp
+++ b/tests/OpcodeT.cpp
@@ -14,7 +14,7 @@ TEST_CASE("[Opcode] Construction")
     SECTION("Normal construction")
     {
         Opcode opcode { "sample", "dummy" };
-        REQUIRE(opcode.opcode == "sample");
+        REQUIRE(opcode.name == "sample");
         REQUIRE(opcode.lettersOnlyHash == hash("sample"));
         REQUIRE(opcode.parameters.empty());
         REQUIRE(opcode.value == "dummy");
@@ -23,7 +23,7 @@ TEST_CASE("[Opcode] Construction")
     SECTION("Normal construction with underscore")
     {
         Opcode opcode { "sample_underscore", "dummy" };
-        REQUIRE(opcode.opcode == "sample_underscore");
+        REQUIRE(opcode.name == "sample_underscore");
         REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore"));
         REQUIRE(opcode.parameters.empty());
         REQUIRE(opcode.value == "dummy");
@@ -32,7 +32,7 @@ TEST_CASE("[Opcode] Construction")
     SECTION("Normal construction with ampersand")
     {
         Opcode opcode { "sample&_ampersand", "dummy" };
-        REQUIRE(opcode.opcode == "sample&_ampersand");
+        REQUIRE(opcode.name == "sample&_ampersand");
         REQUIRE(opcode.lettersOnlyHash == hash("sample_ampersand"));
         REQUIRE(opcode.parameters.empty());
         REQUIRE(opcode.value == "dummy");
@@ -41,7 +41,7 @@ TEST_CASE("[Opcode] Construction")
     SECTION("Normal construction with multiple ampersands")
     {
         Opcode opcode { "&sample&_ampersand&", "dummy" };
-        REQUIRE(opcode.opcode == "&sample&_ampersand&");
+        REQUIRE(opcode.name == "&sample&_ampersand&");
         REQUIRE(opcode.lettersOnlyHash == hash("sample_ampersand"));
         REQUIRE(opcode.parameters.empty());
         REQUIRE(opcode.value == "dummy");
@@ -50,7 +50,7 @@ TEST_CASE("[Opcode] Construction")
     SECTION("Parameterized opcode")
     {
         Opcode opcode { "sample123", "dummy" };
-        REQUIRE(opcode.opcode == "sample123");
+        REQUIRE(opcode.name == "sample123");
         REQUIRE(opcode.lettersOnlyHash == hash("sample&"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters.size() == 1);
@@ -60,7 +60,7 @@ TEST_CASE("[Opcode] Construction")
     SECTION("Parameterized opcode with ampersand")
     {
         Opcode opcode { "sample&123", "dummy" };
-        REQUIRE(opcode.opcode == "sample&123");
+        REQUIRE(opcode.name == "sample&123");
         REQUIRE(opcode.lettersOnlyHash == hash("sample&"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters.size() == 1);
@@ -70,7 +70,7 @@ TEST_CASE("[Opcode] Construction")
     SECTION("Parameterized opcode with underscore")
     {
         Opcode opcode { "sample_underscore123", "dummy" };
-        REQUIRE(opcode.opcode == "sample_underscore123");
+        REQUIRE(opcode.name == "sample_underscore123");
         REQUIRE(opcode.lettersOnlyHash == hash("sample_underscore&"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters == std::vector<uint16_t>({ 123 }));
@@ -79,7 +79,7 @@ TEST_CASE("[Opcode] Construction")
     SECTION("Parameterized opcode within the opcode")
     {
         Opcode opcode { "sample1_underscore", "dummy" };
-        REQUIRE(opcode.opcode == "sample1_underscore");
+        REQUIRE(opcode.name == "sample1_underscore");
         REQUIRE(opcode.lettersOnlyHash == hash("sample&_underscore"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters == std::vector<uint16_t>({ 1 }));
@@ -88,7 +88,7 @@ TEST_CASE("[Opcode] Construction")
     SECTION("Parameterized opcode within the opcode")
     {
         Opcode opcode { "sample123_underscore", "dummy" };
-        REQUIRE(opcode.opcode == "sample123_underscore");
+        REQUIRE(opcode.name == "sample123_underscore");
         REQUIRE(opcode.lettersOnlyHash == hash("sample&_underscore"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters.size() == 1);
@@ -98,7 +98,7 @@ TEST_CASE("[Opcode] Construction")
     SECTION("Parameterized opcode within the opcode twice")
     {
         Opcode opcode { "sample123_double44_underscore", "dummy" };
-        REQUIRE(opcode.opcode == "sample123_double44_underscore");
+        REQUIRE(opcode.name == "sample123_double44_underscore");
         REQUIRE(opcode.lettersOnlyHash == hash("sample&_double&_underscore"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters.size() == 2);
@@ -110,7 +110,7 @@ TEST_CASE("[Opcode] Construction")
     SECTION("Parameterized opcode within the opcode twice, with a back parameter")
     {
         Opcode opcode { "sample123_double44_underscore23", "dummy" };
-        REQUIRE(opcode.opcode == "sample123_double44_underscore23");
+        REQUIRE(opcode.name == "sample123_double44_underscore23");
         REQUIRE(opcode.lettersOnlyHash == hash("sample&_double&_underscore&"));
         REQUIRE(opcode.value == "dummy");
         REQUIRE(opcode.parameters.size() == 3);
@@ -198,8 +198,8 @@ TEST_CASE("[Opcode] Normalization")
 {
     // *_ccN
 
-    REQUIRE(Opcode("foo_cc7", "").cleanUp(kOpcodeScopeRegion).opcode == "foo_oncc7");
-    REQUIRE(Opcode("foo_cc7", "").cleanUp(kOpcodeScopeControl).opcode == "foo_cc7");
+    REQUIRE(Opcode("foo_cc7", "").cleanUp(kOpcodeScopeRegion).name == "foo_oncc7");
+    REQUIRE(Opcode("foo_cc7", "").cleanUp(kOpcodeScopeControl).name == "foo_cc7");
 
     // <region>
 
@@ -275,8 +275,8 @@ TEST_CASE("[Opcode] Normalization")
     for (auto pair : regionSpecific) {
         absl::string_view input = pair.first;
         absl::string_view expected = pair.second;
-        REQUIRE(Opcode(input, "").cleanUp(kOpcodeScopeRegion).opcode == expected);
-        REQUIRE(Opcode(input, "").cleanUp(kOpcodeScopeGeneric).opcode == input);
+        REQUIRE(Opcode(input, "").cleanUp(kOpcodeScopeRegion).name == expected);
+        REQUIRE(Opcode(input, "").cleanUp(kOpcodeScopeGeneric).name == input);
     }
 
     // <control>
@@ -289,13 +289,13 @@ TEST_CASE("[Opcode] Normalization")
     for (auto pair : controlSpecific) {
         absl::string_view input = pair.first;
         absl::string_view expected = pair.second;
-        REQUIRE(Opcode(input, "").cleanUp(kOpcodeScopeControl).opcode == expected);
-        REQUIRE(Opcode(input, "").cleanUp(kOpcodeScopeGeneric).opcode == input);
+        REQUIRE(Opcode(input, "").cleanUp(kOpcodeScopeControl).name == expected);
+        REQUIRE(Opcode(input, "").cleanUp(kOpcodeScopeGeneric).name == input);
     }
 
     // case
 
-    REQUIRE(Opcode("SaMpLe", "").cleanUp(kOpcodeScopeRegion).opcode == "sample");
+    REQUIRE(Opcode("SaMpLe", "").cleanUp(kOpcodeScopeRegion).name == "sample");
 }
 
 TEST_CASE("[Opcode] opcode read (uint8_t)")

--- a/tests/ParsingT.cpp
+++ b/tests/ParsingT.cpp
@@ -95,7 +95,7 @@ TEST_CASE("[Parsing] Empty2")
 namespace sfz{
 bool operator==(const Opcode& lhs, const Opcode& rhs)
 {
-    return (lhs.opcode == rhs.opcode) && (lhs.value == rhs.value);
+    return (lhs.name == rhs.name) && (lhs.value == rhs.value);
 }
 }
 
@@ -142,10 +142,10 @@ void memberTestNew(absl::string_view member, absl::string_view opcode, absl::str
     REQUIRE(mock.fullBlockHeaders.size() == 1);
     REQUIRE(mock.fullBlockMembers.size() == 1);
     REQUIRE(mock.headers[0] == "region");
-    REQUIRE(mock.opcodes[0].opcode == opcode);
+    REQUIRE(mock.opcodes[0].name == opcode);
     REQUIRE(mock.opcodes[0].value == value);
     REQUIRE(mock.fullBlockHeaders[0] == "region");
-    REQUIRE(mock.fullBlockMembers[0][0].opcode == opcode);
+    REQUIRE(mock.fullBlockMembers[0][0].name == opcode);
     REQUIRE(mock.fullBlockMembers[0][0].value == value);
 }
 


### PR DESCRIPTION
It's a little renaming which avoids absurd notations such as `opcode.opcode`.
At the same time, it's observed that release asserts don't activate in parser and messaging, the cmake edits fix this problem.