### PR TITLE
Add option SFIZZ_USE_SYSTEM_SIMDE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ option_ex (SFIZZ_SHARED            "Enable shared library build" ON)
 option_ex (SFIZZ_USE_SNDFILE       "Enable use of the sndfile library" ON)
 option_ex (SFIZZ_USE_VCPKG         "Assume that sfizz is build using vcpkg" OFF)
 option_ex (SFIZZ_USE_SYSTEM_ABSEIL "Use Abseil libraries preinstalled on system" OFF)
+option_ex (SFIZZ_USE_SYSTEM_SIMDE  "Use SIMDe libraries preinstalled on system" OFF)
 option_ex (SFIZZ_STATIC_DEPENDENCIES "Link dependencies statically" OFF)
 option_ex (SFIZZ_RELEASE_ASSERTS   "Forced assertions in release builds" OFF)
 

--- a/cmake/SfizzDeps.cmake
+++ b/cmake/SfizzDeps.cmake
@@ -87,7 +87,19 @@ add_subdirectory("external/st_audiofile" EXCLUDE_FROM_ALL)
 # The simde library
 add_library(sfizz_simde INTERFACE)
 add_library(sfizz::simde ALIAS sfizz_simde)
-target_include_directories(sfizz_simde INTERFACE "external/simde")
+if(SFIZZ_USE_SYSTEM_SIMDE)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(SIMDE "simde" REQUIRED)
+    target_include_directories(sfizz_simde INTERFACE "${SIMDE_INCLUDE_DIRS}")
+    if(NOT SIMDE_VERSION OR SIMDE_VERSION VERSION_LESS_EQUAL "0.7.2")
+        message(WARNING "The version of SIMDe on this system has known issues. \
+It is recommended to either update if a newer version is available, or use the \
+version bundled with this package. Refer to following issues: \
+simd-everywhere/simde#704, simd-everywhere/simde#706")
+    endif()
+else()
+    target_include_directories(sfizz_simde INTERFACE "external/simde")
+endif()
 if(TARGET sfizz::openmp)
     target_link_libraries(sfizz_simde INTERFACE sfizz::openmp)
 endif()


### PR DESCRIPTION
Allows to use system SIMDe headers.
Warns if the version is known to have problems.