### PR TITLE
Display key events on VK, with VST

### DIFF
--- a/plugins/editor/src/editor/EditIds.h
+++ b/plugins/editor/src/editor/EditIds.h
@@ -22,6 +22,9 @@ enum class EditId : int {
     UserFilesDir,
     FallbackFilesDir,
     //
+    Key0,
+    KeyLast = Key0 + 128 - 1,
+    //
     Controller0,
     ControllerLast = Controller0 + sfz::config::numCCs - 1,
     //
@@ -57,4 +60,17 @@ inline bool editIdIsCC(EditId id)
 {
     return int(id) >= int(EditId::Controller0) &&
         int(id) <= int(EditId::ControllerLast);
+}
+
+inline EditId editIdForKey(int key)
+{
+    return EditId(int(EditId::Key0) + key);
+}
+inline int keyForEditId(EditId id)
+{
+    return int(id) - int(EditId::Key0);
+}
+inline bool editIdIsKey(EditId id)
+{
+    return int(id) >= int(EditId::Key0) && int(id) <= int(EditId::KeyLast);
 }

--- a/plugins/editor/src/editor/Editor.cpp
+++ b/plugins/editor/src/editor/Editor.cpp
@@ -387,6 +387,14 @@ void Editor::Impl::uiReceiveValue(EditId id, const EditValue& v)
             setActivePanel(value);
         }
         break;
+    default:
+        if (editIdIsKey(id)) {
+            const int key = keyForEditId(id);
+            const float value = v.to_float();
+            if (SPiano* piano = piano_)
+                piano->setKeyValue(key, value);
+        }
+        break;
     }
 }
 

--- a/plugins/editor/src/editor/GUIPiano.cpp
+++ b/plugins/editor/src/editor/GUIPiano.cpp
@@ -50,6 +50,20 @@ void SPiano::setKeyUsed(unsigned key, bool used)
     invalid();
 }
 
+void SPiano::setKeyValue(unsigned key, float value)
+{
+    if (key >= 128)
+        return;
+
+    value = std::max(0.0f, std::min(1.0f, value));
+
+    if (keyval_[key] == value)
+        return;
+
+    keyval_[key] = value;
+    invalid();
+}
+
 void SPiano::draw(CDrawContext* dc)
 {
     const Dimensions dim = getDimensions(false);

--- a/plugins/editor/src/editor/GUIPiano.h
+++ b/plugins/editor/src/editor/GUIPiano.h
@@ -26,6 +26,7 @@ public:
     void setNumOctaves(unsigned octs);
 
     void setKeyUsed(unsigned key, bool used);
+    void setKeyValue(unsigned key, float value);
 
     std::function<void(unsigned, float)> onKeyPressed;
     std::function<void(unsigned, float)> onKeyReleased;
@@ -54,7 +55,7 @@ private:
 
 private:
     unsigned octs_ {};
-    std::vector<unsigned> keyval_;
+    std::vector<float> keyval_;
     std::bitset<128> keyUsed_;
     unsigned mousePressedKey_ = ~0u;
 

--- a/plugins/vst/SfizzVstController.h
+++ b/plugins/vst/SfizzVstController.h
@@ -46,6 +46,7 @@ public:
 
 protected:
     Steinberg::IPtr<OSCUpdate> oscUpdate_;
+    Steinberg::IPtr<NoteUpdate> noteUpdate_;
     Steinberg::IPtr<FilePathUpdate> sfzPathUpdate_;
     Steinberg::IPtr<FilePathUpdate> scalaPathUpdate_;
     Steinberg::IPtr<ProcessorStateUpdate> processorStateUpdate_;

--- a/plugins/vst/SfizzVstEditor.h
+++ b/plugins/vst/SfizzVstEditor.h
@@ -48,6 +48,7 @@ public:
 
 private:
     void processOscQueue();
+    void processNoteEventQueue();
 
 protected:
     // EditorController
@@ -77,6 +78,9 @@ private:
     typedef std::vector<uint8_t> OscByteVec;
     std::unique_ptr<OscByteVec> oscQueue_;
     std::mutex oscQueueMutex_;
+    typedef std::vector<std::pair<uint32, float>> NoteEventsVec;
+    std::unique_ptr<NoteEventsVec> noteEventQueue_;
+    std::mutex noteEventQueueMutex_;
 
     // subscribed updates
     std::vector<IPtr<FObject>> continuousUpdates_;

--- a/plugins/vst/SfizzVstProcessor.h
+++ b/plugins/vst/SfizzVstProcessor.h
@@ -11,6 +11,7 @@
 #include "public.sdk/source/vst/vstaudioeffect.h"
 #include <sfizz.hpp>
 #include <SpinMutex.h>
+#include <array>
 #include <thread>
 #include <memory>
 #include <cstdlib>
@@ -59,6 +60,9 @@ private:
 
     // misc
     static void loadSfzFileOrDefault(sfz::Sfizz& synth, const std::string& filePath);
+
+    // note event tracking
+    std::array<float, 128> _noteEventsCurrentCycle; // 0: off, >0: on, <0: no change
 
     // worker and thread sync
     std::thread _worker;

--- a/plugins/vst/SfizzVstUpdates.cpp
+++ b/plugins/vst/SfizzVstUpdates.cpp
@@ -35,3 +35,33 @@ void OSCUpdate::setMessage(const void* data, uint32_t size, bool copy)
     size_ = size;
     allocated_ = copy;
 }
+
+///
+NoteUpdate::~NoteUpdate()
+{
+    clear();
+}
+
+void NoteUpdate::clear()
+{
+    if (allocated_)
+        delete[] events_;
+    events_ = nullptr;
+    count_ = 0;
+    allocated_ = false;
+}
+
+void NoteUpdate::setEvents(const std::pair<uint32_t, float>* events, uint32_t count, bool copy)
+{
+    clear();
+
+    if (copy) {
+        auto *buffer = new std::pair<uint32_t, float>[count];
+        std::memcpy(buffer, events, count);
+        events = buffer;
+    }
+
+    events_ = events;
+    count_ = count;
+    allocated_ = copy;
+}

--- a/plugins/vst/SfizzVstUpdates.h
+++ b/plugins/vst/SfizzVstUpdates.h
@@ -40,6 +40,33 @@ private:
 };
 
 /**
+ * @brief Update which notifies one or more note on/off events
+ * Is is supposed to be used synchronously.
+ * (ie. FObject::changed or UpdateHandler::triggerUpdates)
+ */
+class NoteUpdate : public Steinberg::FObject {
+public:
+    NoteUpdate() = default;
+    ~NoteUpdate();
+    void clear();
+    void setEvents(const std::pair<uint32_t, float>* events, uint32_t count, bool copy);
+
+    const std::pair<uint32_t, float>* events() const noexcept { return events_; }
+    const uint32_t count() const noexcept { return count_; }
+
+    OBJ_METHODS(NoteUpdate, FObject)
+
+private:
+    const std::pair<uint32_t, float>* events_ = nullptr;
+    uint32_t count_ = 0;
+    bool allocated_ = false;
+
+private:
+    NoteUpdate(const NoteUpdate&) = delete;
+    NoteUpdate& operator=(const NoteUpdate&) = delete;
+};
+
+/**
  * @brief Update which notifies a change of file path pseudo-parameter
  * The message ID is used to indicate which path it is.
  */


### PR DESCRIPTION
This notifies the midi notes to the editor, and shows them in VK accordingly.
The notifications are pairs (key, velocity) where velocity=0 means off.

There is a problem about doing this feature in LV2, which I have trouble to solve.
When writing these notification messages, LV2 UI is not receiving all of them, leading to stuck keys display.
That's although the atom forge reports no error writing the buffer.
Another curiosity which I noticed, output control ports are notifying to UI non-stop, although the value is not changed.