### PR TITLE
Load equal temperament if scl loading fails

### DIFF
--- a/src/sfizz/Tuning.cpp
+++ b/src/sfizz/Tuning.cpp
@@ -162,50 +162,59 @@ Tuning::~Tuning()
 
 bool Tuning::loadScalaFile(const fs::path& path)
 {
+    Tunings::Scale scl;
     fs::ifstream stream(path);
+
     if (stream.bad()) {
         DBG("Cannot open scale file: " << path);
-        return false;
+        goto failure;
     }
 
-    Tunings::Scale scl;
     try {
         scl = Tunings::readSCLStream(stream);
     }
     catch (Tunings::TuningError& error) {
         DBG("Tuning: " << error.what());
-        return false;
+        goto failure;
     }
 
     if (scl.count <= 0) {
         DBG("The scale file is empty: " << path);
-        return false;
+        goto failure;
     }
 
     impl_->updateScale(scl, path);
     return true;
+
+failure:
+    loadEqualTemperamentScale();
+    return false;
 }
 
 bool Tuning::loadScalaString(const std::string& text)
 {
+    Tunings::Scale scl;
     std::istringstream stream(text);
 
-    Tunings::Scale scl;
     try {
         scl = Tunings::readSCLStream(stream);
     }
     catch (Tunings::TuningError& error) {
         DBG("Tuning: " << error.what());
-        return false;
+        goto failure;
     }
 
     if (scl.count <= 0) {
         DBG("Error loading scala string: " << text);
-        return false;
+        goto failure;
     }
 
     impl_->updateScale(scl);
     return true;
+
+failure:
+    loadEqualTemperamentScale();
+    return false;
 }
 
 void Tuning::setScalaRootKey(int rootKey)


### PR DESCRIPTION
If loading the Scala file fails for any reason, fall back to equal temperament.
This ensures something to be reloaded, and it won't stay on a previously loaded scale.

The problem is when loading a patch into the plugin, scl fails, it stays on the tuning of the old patch.
It's the simple way to fix it, and it consistent with sfz API behavior (clear on loading failure).