### PR TITLE
Check zenity presence, and block editor with message if missing

### DIFF
--- a/plugins/editor/src/editor/Editor.cpp
+++ b/plugins/editor/src/editor/Editor.cpp
@@ -768,6 +768,31 @@ void Editor::Impl::createFrameContents()
 
         mainView->setBackgroundColor(frameBackground);
 
+#if LINUX
+        if (!isZenityAvailable()) {
+            CRect bounds = mainView->getViewSize();
+
+            CViewContainer* box = new CViewContainer(bounds);
+            mainView->addView(box);
+            box->setBackgroundColor(CColor(0x00, 0x00, 0x00, 0xc0));
+
+            CRect textSize = CRect(0, 0, 400, 80).centerInside(bounds);
+            CMultiLineTextLabel* textLabel = new CMultiLineTextLabel(textSize);
+            box->addView(textLabel);
+            textLabel->setTextInset(CPoint(10.0, 10.0));
+            textLabel->setStyle(CParamDisplay::kRoundRectStyle);
+            textLabel->setRoundRectRadius(10.0);
+            textLabel->setFrameColor(CColor(0xb2, 0xb2, 0xb2));
+            textLabel->setBackColor(CColor(0x2e, 0x34, 0x36));
+            auto font = makeOwned<CFontDesc>("Roboto", 16.0);
+            textLabel->setFont(font);
+            textLabel->setLineLayout(CMultiLineTextLabel::LineLayout::wrap);
+            textLabel->setText(
+                "The required program \"zenity\" is missing.\n"
+                "Install this software package first, and restart sfizz.");
+        }
+#endif
+
         mainView_ = owned(mainView);
     }
 

--- a/plugins/editor/src/editor/NativeHelpers.cpp
+++ b/plugins/editor/src/editor/NativeHelpers.cpp
@@ -112,10 +112,12 @@ static std::vector<char *> createForkEnviron()
     return newEnv;
 }
 
+static constexpr char zenityPath[] = "/usr/bin/zenity";
+
 bool askQuestion(const char *text)
 {
     char *argv[] = {
-        const_cast<char *>("/usr/bin/zenity"),
+        const_cast<char *>(zenityPath),
         const_cast<char *>("--question"),
         const_cast<char *>("--text"),
         const_cast<char *>(text),
@@ -144,5 +146,10 @@ bool askQuestion(const char *text)
         return false;
 
     return WEXITSTATUS(wstatus) == 0;
+}
+
+bool isZenityAvailable()
+{
+    return access(zenityPath, X_OK) == 0;
 }
 #endif

--- a/plugins/editor/src/editor/NativeHelpers.h
+++ b/plugins/editor/src/editor/NativeHelpers.h
@@ -9,3 +9,7 @@
 bool openFileInExternalEditor(const char *filename);
 bool openDirectoryInExplorer(const char *filename);
 bool askQuestion(const char *text);
+
+#if !defined(_WIN32) && !defined(__APPLE__)
+bool isZenityAvailable();
+#endif


### PR DESCRIPTION
Warn the user about missing Zenity, and disable the editor.
It should end the reports that we are frequently getting about this problem.
