### PR TITLE
Prevent window input while file dialog is open

### DIFF
--- a/plugins/editor/CMakeLists.txt
+++ b/plugins/editor/CMakeLists.txt
@@ -34,6 +34,8 @@ add_library(sfizz_editor STATIC EXCLUDE_FROM_ALL
     src/editor/EditorController.h
     src/editor/GUIComponents.h
     src/editor/GUIComponents.cpp
+    src/editor/GUIHelpers.h
+    src/editor/GUIHelpers.cpp
     src/editor/GUIPiano.h
     src/editor/GUIPiano.cpp
     src/editor/ColorHelpers.h

--- a/plugins/editor/src/editor/GUIHelpers.cpp
+++ b/plugins/editor/src/editor/GUIHelpers.cpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "GUIHelpers.h"
+
+class SFrameDisabler::KeyAndMouseHook : public CBaseObject,
+                                        public IKeyboardHook,
+                                        public IMouseObserver {
+public:
+    void setEnabled(bool value) { enabled_ = value; }
+
+protected:
+    int32_t onKeyDown(const VstKeyCode&, CFrame*) { return enabled_ ? -1 : 1; }
+    int32_t onKeyUp(const VstKeyCode&, CFrame*) { return enabled_ ? -1 : 1; }
+    void onMouseEntered(CView*, CFrame*) {}
+    void onMouseExited(CView*, CFrame*) {}
+    CMouseEventResult onMouseMoved(CFrame*, const CPoint&, const CButtonState&) { return enabled_ ? kMouseEventNotHandled : kMouseEventHandled; }
+    CMouseEventResult onMouseDown(CFrame*, const CPoint&, const CButtonState&) { return enabled_ ? kMouseEventNotHandled : kMouseEventHandled; }
+
+private:
+    bool enabled_ = true;
+};
+
+SFrameDisabler::SFrameDisabler(CFrame* frame)
+    : frame_(frame), hook_(makeOwned<KeyAndMouseHook>())
+{
+    frame->registerKeyboardHook(hook_);
+    frame->registerMouseObserver(hook_);
+
+    delayedEnabler_ = makeOwned<CVSTGUITimer>(
+        [this](CVSTGUITimer* t) { hook_->setEnabled(true); t->stop(); },
+        1, false);
+}
+
+SFrameDisabler::~SFrameDisabler()
+{
+    frame_->unregisterKeyboardHook(hook_);
+    frame_->unregisterMouseObserver(hook_);
+}
+
+void SFrameDisabler::enable()
+{
+    delayedEnabler_->start();
+}
+
+void SFrameDisabler::disable()
+{
+    hook_->setEnabled(false);
+    delayedEnabler_->stop();
+}

--- a/plugins/editor/src/editor/GUIHelpers.h
+++ b/plugins/editor/src/editor/GUIHelpers.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include "utility/vstgui_before.h"
+#include <vstgui/lib/cframe.h>
+#include <vstgui/lib/cvstguitimer.h>
+#include "utility/vstgui_after.h"
+
+using namespace VSTGUI;
+
+class SFrameDisabler : public CBaseObject {
+public:
+    explicit SFrameDisabler(CFrame* frame);
+    ~SFrameDisabler();
+
+    void enable();
+    void disable();
+
+private:
+    class KeyAndMouseHook;
+
+private:
+    CFrame* frame_ = nullptr;
+    SharedPointer<KeyAndMouseHook> hook_;
+    SharedPointer<CVSTGUITimer> delayedEnabler_;
+};


### PR DESCRIPTION
This is a solution which prevents this UI problem:

When "load file" is clicked, a file dialog will show. As the dialog is shown, if the editor window is clicked, these mouse events will buffer, and they will perform after the closure of the file dialog.

So if clicking 10 times "load file" during this period, the dialog will pop up latently another 10 times.

The solution disables key and mouse during the time frame that the dialog is popped up.