### PR TITLE
Deduplicate LFO code in core/fx

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,8 +44,6 @@ set(SFIZZ_HEADERS
     sfizz/effects/impl/ResonantStringAVX.h
     sfizz/effects/impl/ResonantStringSSE.h
     sfizz/effects/Apan.h
-    sfizz/effects/CommonLFO.h
-    sfizz/effects/CommonLFO.hpp
     sfizz/effects/Compressor.h
     sfizz/effects/Disto.h
     sfizz/effects/Eq.h
@@ -75,6 +73,8 @@ set(SFIZZ_HEADERS
     sfizz/Interpolators.hpp
     sfizz/Logger.h
     sfizz/LFO.h
+    sfizz/LFOCommon.h
+    sfizz/LFOCommon.hpp
     sfizz/LFODescription.h
     sfizz/MathHelpers.h
     sfizz/Metronome.h

--- a/src/sfizz/Defaults.cpp
+++ b/src/sfizz/Defaults.cpp
@@ -132,7 +132,7 @@ extern const OpcodeSpec<int> octaveOffset { 0, Range<int>(-10, 10), 0 };
 extern const OpcodeSpec<int> noteOffset { 0, Range<int>(-127, 127), 0 };
 extern const OpcodeSpec<float> effect { 0.0f, Range<float>(0.0f, 100.0f), kNormalizePercent };
 extern const OpcodeSpec<float> effectPercent { 0.0f, Range<float>(0.0f, 100.0f), 0 };
-extern const OpcodeSpec<int> apanWaveform { 0, Range<int>(0, std::numeric_limits<int>::max()), 0 };
+extern const OpcodeSpec<LFOWave> apanWaveform { LFOWave::Triangle, Range<LFOWave>(LFOWave::Triangle, LFOWave::Saw), 0 };
 extern const OpcodeSpec<float> apanFrequency { 0.0f, Range<float>(0.0f, std::numeric_limits<float>::max()), 0 };
 extern const OpcodeSpec<float> apanPhase { 0.5f, Range<float>(0.0f, 1.0f), kWrapPhase };
 extern const OpcodeSpec<float> apanLevel { 0.0f, Range<float>(0.0f, 100.0f), kNormalizePercent };

--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -31,6 +31,7 @@
 #include "Config.h"
 #include "SfzFilter.h"
 #include "SfzHelpers.h"
+#include "LFOCommon.h"
 #include "MathHelpers.h"
 
 
@@ -44,18 +45,6 @@ enum class VelocityOverride { current = 0, previous };
 enum class CrossfadeCurve { gain = 0, power };
 enum class SelfMask { mask = 0, dontMask };
 enum class OscillatorEnabled { Auto = -1, Off = 0, On = 1 };
-enum class LFOWave : int {
-    Triangle,
-    Sine,
-    Pulse75,
-    Square,
-    Pulse25,
-    Pulse12_5,
-    Ramp,
-    Saw,
-    // ARIA extra
-    RandomSH = 12,
-};
 
 enum OpcodeFlags : int {
     kCanBeNote = 1,
@@ -251,7 +240,7 @@ namespace Default
     extern const OpcodeSpec<int> noteOffset;
     extern const OpcodeSpec<float> effect;
     extern const OpcodeSpec<float> effectPercent;
-    extern const OpcodeSpec<int> apanWaveform;
+    extern const OpcodeSpec<LFOWave> apanWaveform;
     extern const OpcodeSpec<float> apanFrequency;
     extern const OpcodeSpec<float> apanPhase;
     extern const OpcodeSpec<float> apanLevel;

--- a/src/sfizz/LFOCommon.h
+++ b/src/sfizz/LFOCommon.h
@@ -7,24 +7,25 @@
 #pragma once
 
 namespace sfz {
-namespace fx {
-namespace lfo {
 
-enum Wave {
-    kTriangle,
-    kSine,
-    kPulse75,
-    kSquare,
-    kPulse25,
-    kPulse12_5,
-    kRamp,
-    kSaw,
+enum class LFOWave : int {
+    Triangle,
+    Sine,
+    Pulse75,
+    Square,
+    Pulse25,
+    Pulse12_5,
+    Ramp,
+    Saw,
+    // ARIA extra
+    RandomSH = 12,
 };
 
-template <int Wave> float evaluateAtPhase(float phase);
+namespace lfo {
+
+template <LFOWave Wave> float evaluateAtPhase(float phase);
 
 } // namespace lfo
-} // namespace fx
 } // namespace sfz
 
-#include "CommonLFO.hpp"
+#include "LFOCommon.hpp"

--- a/src/sfizz/LFOCommon.hpp
+++ b/src/sfizz/LFOCommon.hpp
@@ -4,11 +4,10 @@
 // license. You should have receive a LICENSE.md file along with the code.
 // If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
 
-#include "CommonLFO.h"
+#include "LFOCommon.h"
 #include <cmath>
 
 namespace sfz {
-namespace fx {
 namespace lfo {
 
     // Pulse and Square levels
@@ -16,7 +15,7 @@ namespace lfo {
     static constexpr float hiPulse = 1.0f;
 
     template <>
-    inline float evaluateAtPhase<kTriangle>(float phase)
+    inline float evaluateAtPhase<LFOWave::Triangle>(float phase)
     {
         float y = -4 * phase + 2;
         y = (phase < 0.25f) ? (4 * phase) : y;
@@ -25,48 +24,47 @@ namespace lfo {
     }
 
     template <>
-    inline float evaluateAtPhase<kSine>(float phase)
+    inline float evaluateAtPhase<LFOWave::Sine>(float phase)
     {
         float x = phase + phase - 1;
         return -4 * x * (1 - std::fabs(x));
     }
 
     template <>
-    inline float evaluateAtPhase<kPulse75>(float phase)
+    inline float evaluateAtPhase<LFOWave::Pulse75>(float phase)
     {
         return (phase < 0.75f) ? hiPulse : loPulse;
     }
 
     template <>
-    inline float evaluateAtPhase<kSquare>(float phase)
+    inline float evaluateAtPhase<LFOWave::Square>(float phase)
     {
         return (phase < 0.5f) ? hiPulse : loPulse;
     }
 
     template <>
-    inline float evaluateAtPhase<kPulse25>(float phase)
+    inline float evaluateAtPhase<LFOWave::Pulse25>(float phase)
     {
         return (phase < 0.25f) ? hiPulse : loPulse;
     }
 
     template <>
-    inline float evaluateAtPhase<kPulse12_5>(float phase)
+    inline float evaluateAtPhase<LFOWave::Pulse12_5>(float phase)
     {
         return (phase < 0.125f) ? hiPulse : loPulse;
     }
 
     template <>
-    inline float evaluateAtPhase<kRamp>(float phase)
+    inline float evaluateAtPhase<LFOWave::Ramp>(float phase)
     {
         return 2 * phase - 1;
     }
 
     template <>
-    inline float evaluateAtPhase<kSaw>(float phase)
+    inline float evaluateAtPhase<LFOWave::Saw>(float phase)
     {
         return 1 - 2 * phase;
     }
 
 } // namespace lfo
-} // namespace fx
 } // namespace sfz

--- a/src/sfizz/effects/Apan.cpp
+++ b/src/sfizz/effects/Apan.cpp
@@ -22,7 +22,7 @@
 
 #include "Apan.h"
 #include "Macros.h"
-#include "CommonLFO.h"
+#include "LFOCommon.h"
 #include "Opcode.h"
 #include <limits>
 #include <cmath>
@@ -107,22 +107,22 @@ namespace fx {
     void Apan::computeLfos(float* left, float* right, unsigned nframes)
     {
         switch (_lfoWave) {
-        #define CASE(X) case lfo::X:                          \
-            computeLfos<lfo::X>(left, right, nframes); break;
+        #define CASE(X) case X:                          \
+            computeLfos<X>(left, right, nframes); break;
         default:
-        CASE(kTriangle)
-        CASE(kSine)
-        CASE(kPulse75)
-        CASE(kSquare)
-        CASE(kPulse25)
-        CASE(kPulse12_5)
-        CASE(kRamp)
-        CASE(kSaw)
+        CASE(LFOWave::Triangle)
+        CASE(LFOWave::Sine)
+        CASE(LFOWave::Pulse75)
+        CASE(LFOWave::Square)
+        CASE(LFOWave::Pulse25)
+        CASE(LFOWave::Pulse12_5)
+        CASE(LFOWave::Ramp)
+        CASE(LFOWave::Saw)
         #undef CASE
         }
     }
 
-    template <int Wave> void Apan::computeLfos(float* left, float* right, unsigned nframes)
+    template <LFOWave Wave> void Apan::computeLfos(float* left, float* right, unsigned nframes)
     {
         float samplePeriod = _samplePeriod;
         float frequency = _lfoFrequency;

--- a/src/sfizz/effects/Apan.h
+++ b/src/sfizz/effects/Apan.h
@@ -44,7 +44,7 @@ namespace fx {
 
     private:
         void computeLfos(float* left, float* right, unsigned nframes);
-        template <int Wave> void computeLfos(float* left, float* right, unsigned nframes);
+        template <LFOWave Wave> void computeLfos(float* left, float* right, unsigned nframes);
 
     private:
         float _samplePeriod { 0.0f };
@@ -55,7 +55,7 @@ namespace fx {
         float _dry { Default::apanLevel };
         float _wet { Default::apanLevel };
         float _depth { Default::apanLevel };
-        int _lfoWave { Default::apanWaveform };
+        LFOWave _lfoWave { Default::apanWaveform };
         float _lfoFrequency { Default::apanFrequency };
         float _lfoPhaseOffset { Default::apanPhase };
 


### PR DESCRIPTION
Effects and engine can share LFO code which is identical.
Remove the duplication.