### PR TITLE
Update the sample rate of Flex EG

### DIFF
--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -551,6 +551,9 @@ void Voice::setSampleRate(float sampleRate) noexcept
     for (WavetableOscillator& osc : impl.waveOscillators_)
         osc.init(sampleRate);
 
+    for (auto& eg : impl.flexEGs_)
+        eg->setSampleRate(sampleRate);
+
     for (auto& lfo : impl.lfos_)
         lfo->setSampleRate(sampleRate);
 


### PR DESCRIPTION
The sample rate of the flex EG would not be updated by `setSampleRate` API.