### PR TITLE
Refactor the opcode handling for LFO and EG

### DIFF
--- a/src/sfizz/Opcode.cpp
+++ b/src/sfizz/Opcode.cpp
@@ -53,6 +53,28 @@ static absl::string_view extractBackInteger(absl::string_view opcodeName)
     return opcodeName.substr(i);
 }
 
+std::string Opcode::getLetterOnlyName() const
+{
+    absl::string_view name { this->name };
+
+    std::string letterOnlyName;
+    letterOnlyName.reserve(name.size());
+
+    bool charWasDigit = false;
+    for (unsigned char c : name) {
+        bool charIsDigit = absl::ascii_isdigit(c);
+
+        if (!charIsDigit)
+            letterOnlyName.push_back(c);
+        else if (!charWasDigit)
+            letterOnlyName.push_back('&');
+
+        charWasDigit = charIsDigit;
+    }
+
+    return letterOnlyName;
+}
+
 std::string Opcode::getDerivedName(OpcodeCategory newCategory, unsigned number) const
 {
     std::string derivedName(name);

--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -82,6 +82,12 @@ struct Opcode {
      */
     Opcode cleanUp(OpcodeScope scope) const;
 
+    /**
+     * @brief Calculate a letter-only name, replacing any digit sequence with
+     * in the opcode name with a single ampersand character.
+     */
+    std::string getLetterOnlyName() const;
+
     /*
      * @brief Get the derived opcode name to convert it to another category.
      *

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -267,6 +267,22 @@ struct Region {
      */
     bool parseEGOpcode(const Opcode& opcode, absl::optional<EGDescription>& eg);
     /**
+     * @brief Parse a opcode which is specific to a particular SFZv2 LFO: lfoN.
+     *
+     * @param opcode
+     * @return true if the opcode was properly read and stored.
+     * @return false
+     */
+    bool parseLFOOpcodeV2(const Opcode& opcode);
+    /**
+     * @brief Parse a opcode which is specific to a particular SFZv2 EG: egN.
+     *
+     * @param opcode
+     * @return true if the opcode was properly read and stored.
+     * @return false
+     */
+    bool parseEGOpcodeV2(const Opcode& opcode);
+    /**
      * @brief Process a generic CC opcode, and fill the modulation parameters.
      *
      * @param opcode


### PR DESCRIPTION
This is a refactor of the opcode handling in regions.

It detects opcodes by ampersand-prefix (like `lfo&_`), and redirects that to a sub-function that specifically handles LFOv2 opcodes.

At the beginning of such functions, there goes the `extendIfNecessary` kind of code, such that it's not duplicated under every single opcode.
There remains FilterV1 and EqV1 which are candidates for such a rewrite.

Reason:
It's wanted to have LFOv1 and v2 with the same `LFO` and `LFODescription` implementations.
At present it's made difficult by this fact that v1 and v2 are modulated by `ModKey`s with different patterns.
So I want to keep the `ModKey`s inside `LFODescription`, at the time that opcode create the LFOs, but while avoiding to duplicate this code absolutely everywhere.