### PR TITLE
Don't use VSTGUI::CNewFileSelector::setDefaultExtension

### DIFF
--- a/plugins/editor/src/editor/Editor.cpp
+++ b/plugins/editor/src/editor/Editor.cpp
@@ -1067,7 +1067,7 @@ void Editor::Impl::chooseSfzFile()
     SharedPointer<CNewFileSelector> fs = owned(CNewFileSelector::create(frame_));
 
     fs->setTitle("Load SFZ file");
-    fs->setDefaultExtension(CFileExtension("SFZ", "sfz"));
+    fs->addFileExtension(CFileExtension("SFZ", "sfz"));
 
     // also add extensions of importable files
     fs->addFileExtension(CFileExtension("WAV", "wav"));
@@ -1110,7 +1110,7 @@ void Editor::Impl::createNewSfzFile()
     SharedPointer<CNewFileSelector> fs = owned(CNewFileSelector::create(frame_, CNewFileSelector::kSelectSaveFile));
 
     fs->setTitle("Create SFZ file");
-    fs->setDefaultExtension(CFileExtension("SFZ", "sfz"));
+    fs->addFileExtension(CFileExtension("SFZ", "sfz"));
 
     std::string initialDir = getFileChooserInitialDir(currentSfzFile_);
     if (!initialDir.empty())
@@ -1202,7 +1202,7 @@ void Editor::Impl::chooseScalaFile()
     SharedPointer<CNewFileSelector> fs = owned(CNewFileSelector::create(frame_));
 
     fs->setTitle("Load Scala file");
-    fs->setDefaultExtension(CFileExtension("SCL", "scl"));
+    fs->addFileExtension(CFileExtension("SCL", "scl"));
 
     std::string initialDir = getFileChooserInitialDir(currentScalaFile_);
     if (!initialDir.empty())


### PR DESCRIPTION
This fixes a wrong file extension filter in the file dialog under Windows.
It seems that the last added extension is selected as default one due to some wrong selection index. So use the All Files filter as workaround.