### PR TITLE
Reset the smoothers

### DIFF
--- a/src/sfizz/BeatClock.cpp
+++ b/src/sfizz/BeatClock.cpp
@@ -157,6 +157,12 @@ absl::Span<const float> BeatClock::getRunningBeatPosition()
     return absl::MakeConstSpan(runningBeatPosition_.data(), currentCycleFrames_);
 }
 
+float BeatClock::getLastBeatPosition() const
+{
+    double beats = lastClientPos_.toBeats(timeSig_);
+    return static_cast<float>(beats);
+}
+
 absl::Span<const int> BeatClock::getRunningBeatsPerBar()
 {
     fillBufferUpTo(currentCycleFrames_);
@@ -175,31 +181,34 @@ void BeatClock::fillBufferUpTo(unsigned delay)
     for (unsigned i = fillIdx; i < delay; ++i)
         beatsPerBarData[i] = sig.beatsPerBar;
 
-    if (!isPlaying_) {
-        if (fillIdx < delay) {
-            fill(absl::MakeSpan(&beatNumberData[fillIdx], delay - fillIdx), 0);
-            fill(absl::MakeSpan(&beatNumberPosition[fillIdx], delay - fillIdx), 0.0f);
-        }
-        currentCycleFill_ = fillIdx;
-        return;
-    }
-
     BBT clientPos = lastClientPos_;
-    const double beatsPerFrame = beatsPerSecond_ * samplePeriod_;
-
     const BBT hostPos = lastHostPos_;
     bool mustApplyHostPos = mustApplyHostPos_;
 
-    for (; fillIdx < delay; ++fillIdx) {
-        clientPos = BBT::fromBeats(sig, clientPos.toBeats(sig) + beatsPerFrame);
+    if (!isPlaying_) {
         clientPos = mustApplyHostPos ? hostPos : clientPos;
         mustApplyHostPos = false;
 
-        // quantization to nearest for prevention of rounding errors
-        double beats = clientPos.toBeats(sig);
-        beatNumberData[fillIdx] = dequantize<int>(quantize(beats));
-        beatNumberPosition[fillIdx] = static_cast<float>(beats);
+        if (fillIdx < delay) {
+            double beats = clientPos.toBeats(sig);
+            // quantization to nearest for prevention of rounding errors
+            fill(absl::MakeSpan(&beatNumberData[fillIdx], delay - fillIdx), dequantize<int>(quantize(beats)));
+            fill(absl::MakeSpan(&beatNumberPosition[fillIdx], delay - fillIdx), static_cast<float>(beats));
+            fillIdx = delay;
+        }
+    } else {
+        for (; fillIdx < delay; ++fillIdx) {
+            clientPos = BBT::fromBeats(sig, clientPos.toBeats(sig) + getBeatsPerFrame());
+            clientPos = mustApplyHostPos ? hostPos : clientPos;
+            mustApplyHostPos = false;
+
+            // quantization to nearest for prevention of rounding errors
+            double beats = clientPos.toBeats(sig);
+            beatNumberData[fillIdx] = dequantize<int>(quantize(beats));
+            beatNumberPosition[fillIdx] = static_cast<float>(beats);
+        }
     }
+
 
     currentCycleFill_ = fillIdx;
     lastClientPos_ = clientPos;

--- a/src/sfizz/BeatClock.cpp
+++ b/src/sfizz/BeatClock.cpp
@@ -157,10 +157,9 @@ absl::Span<const float> BeatClock::getRunningBeatPosition()
     return absl::MakeConstSpan(runningBeatPosition_.data(), currentCycleFrames_);
 }
 
-float BeatClock::getLastBeatPosition() const
+double BeatClock::getLastBeatPosition() const
 {
-    double beats = lastClientPos_.toBeats(timeSig_);
-    return static_cast<float>(beats);
+    return lastClientPos_.toBeats(timeSig_);
 }
 
 absl::Span<const int> BeatClock::getRunningBeatsPerBar()

--- a/src/sfizz/BeatClock.h
+++ b/src/sfizz/BeatClock.h
@@ -145,7 +145,7 @@ public:
      *
      * @return float
      */
-    float getLastBeatPosition() const;
+    double getLastBeatPosition() const;
     /**
      * @brief Get the Beats Per Frame object
      *

--- a/src/sfizz/BeatClock.h
+++ b/src/sfizz/BeatClock.h
@@ -103,6 +103,11 @@ public:
      */
     void setTimeSignature(unsigned delay, TimeSignature newSig);
     /**
+     * @brief Get the time signature
+     *
+     */
+    TimeSignature getTimeSignature() const noexcept { return timeSig_; }
+    /**
      * @brief Set the time position.
      */
     void setTimePosition(unsigned delay, BBT newPos);
@@ -134,6 +139,19 @@ public:
      * @brief Get the time signature numerator for each frame of the current cycle.
      */
     absl::Span<const int> getRunningBeatsPerBar();
+
+    /**
+     * @brief Get the last BeatPosition
+     *
+     * @return float
+     */
+    float getLastBeatPosition() const;
+    /**
+     * @brief Get the Beats Per Frame object
+     *
+     * @return float
+     */
+    double getBeatsPerFrame() const { return beatsPerSecond_ * samplePeriod_; }
     /**
      * @brief Create a normalized phase signal for LFO which completes a
      *        period every N-th beat.

--- a/src/sfizz/MidiState.h
+++ b/src/sfizz/MidiState.h
@@ -130,11 +130,18 @@ public:
     /**
      * @brief Advances the internal clock of a given amount of samples.
      * You should call this at each callback. This will flush the events
-     * in the midistate memory.
+     * in the midistate memory by calling flushEvents().
      *
      * @param numSamples the number of samples of clock advance
      */
     void advanceTime(int numSamples) noexcept;
+
+    /**
+     * @brief Flush events in all states, keeping only the last one as the "base" state
+     *
+     */
+    void flushEvents() noexcept;
+
     /**
      * @brief Get the CC value for CC number
      *

--- a/src/sfizz/Smoothers.cpp
+++ b/src/sfizz/Smoothers.cpp
@@ -31,6 +31,12 @@ void OnePoleSmoother::setSmoothing(unsigned smoothValue, float sampleRate)
 void OnePoleSmoother::reset(float value)
 {
     filter.reset(value);
+    target_ = value;
+}
+
+void OnePoleSmoother::resetToTarget()
+{
+    reset(target_);
 }
 
 void OnePoleSmoother::process(absl::Span<const float> input, absl::Span<float> output, bool canShortcut)
@@ -55,6 +61,8 @@ void OnePoleSmoother::process(absl::Span<const float> input, absl::Span<float> o
     } else if (input.data() != output.data()) {
         copy<float>(input, output);
     }
+
+    target_ = input.back();
 }
 
 ///
@@ -74,6 +82,11 @@ void LinearSmoother::reset(float value)
     target_ = value;
     step_ = 0.0;
     //framesToTarget_ = 0;
+}
+
+void LinearSmoother::resetToTarget()
+{
+    reset(target_);
 }
 
 void LinearSmoother::process(absl::Span<const float> input, absl::Span<float> output, bool canShortcut)

--- a/src/sfizz/Smoothers.h
+++ b/src/sfizz/Smoothers.h
@@ -32,6 +32,10 @@ public:
      */
     void reset(float value = 0.0f);
     /**
+     * @brief Reset to the target value (the back of the last vector passed)
+     */
+    void resetToTarget();
+    /**
      * @brief Process a span of data. Input and output can refer to the same
      * memory.
      *
@@ -47,6 +51,7 @@ public:
 private:
     bool smoothing { false };
     OnePoleFilter<float> filter {};
+    float target_ { 0.0f };
 };
 
 /**
@@ -70,6 +75,10 @@ public:
      * @param value
      */
     void reset(float value = 0.0f);
+    /**
+     * @brief Reset to the target value (the back of the last vector passed)
+     */
+    void resetToTarget();
     /**
      * @brief Process a span of data. Input and output can refer to the same
      * memory.

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -258,6 +258,7 @@ void Synth::Impl::clear()
     groupOpcodes_.clear();
     unknownOpcodes_.clear();
     modificationTime_ = absl::nullopt;
+    playheadMoved_ = false;
 
     // set default controllers
     // midistate is reset above
@@ -913,6 +914,12 @@ void Synth::renderBlock(AudioSpan<float> buffer) noexcept
     BeatClock& bc = impl.resources_.beatClock;
     bc.beginCycle(numFrames);
 
+    if (impl.playheadMoved_ && impl.resources_.beatClock.isPlaying()) {
+        impl.resources_.midiState.flushEvents();
+        impl.genController_->resetSmoothers();
+        impl.playheadMoved_ = false;
+    }
+
     { // Clear effect busses
         ScopedTiming logger { callbackBreakdown.effects };
         for (auto& bus : impl.effectBuses_) {
@@ -1301,7 +1308,16 @@ void Synth::timePosition(int delay, int bar, double barBeat)
     Impl& impl = *impl_;
     ScopedTiming logger { impl.dispatchDuration_, ScopedTiming::Operation::addToDuration };
 
-    impl.resources_.beatClock.setTimePosition(delay, BBT(bar, barBeat));
+    const auto newPosition = BBT(bar, barBeat);
+    const auto newBeatPosition = newPosition.toBeats(impl.resources_.beatClock.getTimeSignature());
+    const auto currentBeatPosition = impl.resources_.beatClock.getLastBeatPosition();
+    const auto positionDifference = std::abs(newBeatPosition - currentBeatPosition);
+    const auto threshold = 2 * static_cast<float>(impl.resources_.beatClock.getBeatsPerFrame());
+
+    if (positionDifference > threshold)
+        impl.playheadMoved_ = true;
+
+    impl.resources_.beatClock.setTimePosition(delay, newPosition);
 }
 
 void Synth::playbackState(int delay, int playbackState)

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1312,7 +1312,7 @@ void Synth::timePosition(int delay, int bar, double barBeat)
     const auto newBeatPosition = newPosition.toBeats(impl.resources_.beatClock.getTimeSignature());
     const auto currentBeatPosition = impl.resources_.beatClock.getLastBeatPosition();
     const auto positionDifference = std::abs(newBeatPosition - currentBeatPosition);
-    const auto threshold = 2 * static_cast<float>(impl.resources_.beatClock.getBeatsPerFrame());
+    const auto threshold = 2 * impl.resources_.beatClock.getBeatsPerFrame();
 
     if (positionDifference > threshold)
         impl.playheadMoved_ = true;

--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -309,6 +309,8 @@ struct Synth::Impl final: public Parser::Listener {
         client.setReceiveCallback(broadcastReceiver);
         return client;
     }
+
+    bool playheadMoved_ { false };
 };
 
 } // namespace sfz

--- a/src/sfizz/modulations/sources/Controller.cpp
+++ b/src/sfizz/modulations/sources/Controller.cpp
@@ -16,6 +16,7 @@
 namespace sfz {
 
 struct ControllerSource::Impl {
+    float getLastTransformedValue(uint16_t cc, uint8_t curve) const noexcept;
     double sampleRate_ = config::defaultSampleRate;
     Resources* res_ = nullptr;
     absl::flat_hash_map<ModKey, Smoother> smoother_;
@@ -29,6 +30,22 @@ ControllerSource::ControllerSource(Resources& res)
 
 ControllerSource::~ControllerSource()
 {
+}
+
+float ControllerSource::Impl::getLastTransformedValue(uint16_t cc, uint8_t curveIndex) const noexcept
+{
+    ASSERT(res_);
+    const Curve& curve = res_->curves.getCurve(curveIndex);
+    const auto lastCCValue = res_->midiState.getCCValue(cc);
+    return curve.evalNormalized(lastCCValue);
+}
+
+void ControllerSource::resetSmoothers()
+{
+    for (auto& item : impl_->smoother_) {
+        const ModKey::Parameters p = item.first.parameters();
+        item.second.reset(impl_->getLastTransformedValue(p.cc, p.curve));
+    }
 }
 
 void ControllerSource::setSampleRate(double sampleRate)
@@ -58,6 +75,7 @@ void ControllerSource::init(const ModKey& sourceKey, NumericId<Voice> voiceId, u
     if (p.smooth > 0) {
         Smoother s;
         s.setSmoothing(p.smooth, impl_->sampleRate_);
+        s.reset(impl_->getLastTransformedValue(p.cc, p.curve));
         impl_->smoother_[sourceKey] = s;
     }
     else {

--- a/src/sfizz/modulations/sources/Controller.h
+++ b/src/sfizz/modulations/sources/Controller.h
@@ -21,6 +21,10 @@ public:
     void init(const ModKey& sourceKey, NumericId<Voice> voiceId, unsigned delay) override;
     void generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer) override;
 
+    /**
+     * @brief Reset the smoothers.
+     */
+    void resetSmoothers();
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;


### PR DESCRIPTION
Closes: #382 

In the end I added some code to check if the playhead moved. *If* the playhead moved and we're rendering with transport is playing, the smoothers are reset *and* the CC state is flushed. 

It seemed to match sforzando behavior in Reaper on Windows. It's not entirely what we discussed because upon looping you will have a discrete jump and no smoothing. The alternative is not as straightforward though, because looping seems to always involve splitting buffers in Reaper (as expected), which in turns mean you have a non-deterministic behavior of the smoother. To give an example, assuming a block size of 256:
- Upon looping the first time, the buffer ends exactly at the loop point. Rendering the new buffer, the host sends the CC state at delay 0, which "replaces" the previous state at loop end and no smoothing occurs.
- Upon looping the second time, loop point is mid buffer. The host splits the buffer and sends a CC state at delay 128. Now, a short smoothing will occur between delay 0 and 128.

All of this can be discussed and tweaked for sure. I'll try to compare more with the DAWs I have at hand, which is mainly Ardour now...

I also corrected some things in the BeatClock, @jpcima you might want to validate it. I'll comment them inline. There's also a small change in the MidiState which is actually a bug correction I think.