### PR TITLE
Add UncheckedRange

### DIFF
--- a/tests/RangeT.cpp
+++ b/tests/RangeT.cpp
@@ -62,6 +62,32 @@ TEST_CASE("[Range] Contains")
     REQUIRE(floatRange.containsWithEnd(10.0));
 }
 
+TEST_CASE("[Range] Unchecked ranges")
+{
+    sfz::UncheckedRange<int> intRange { 10, 1 };
+    REQUIRE(intRange.getStart() == 10);
+    REQUIRE(intRange.getEnd() == 1);
+    REQUIRE(!intRange.isValid());
+    for (int v : {0, 1, 5, 10}) {
+        REQUIRE(!intRange.contains(v));
+        REQUIRE(!intRange.containsWithEnd(v));
+    }
+
+    sfz::UncheckedRange<float> floatRange { 10.0, 1.0 };
+    REQUIRE(floatRange.getStart() == 10.0f);
+    REQUIRE(floatRange.getEnd() == 1.0f);
+    REQUIRE(!floatRange.isValid());
+    for (float v : {0.0f, 1.0f, 5.0f, 10.0f}) {
+        REQUIRE(!floatRange.contains(v));
+        REQUIRE(!floatRange.containsWithEnd(v));
+    }
+
+    REQUIRE(sfz::UncheckedRange<int> { 1, 10 }.isValid());
+    REQUIRE(sfz::UncheckedRange<int> { 1, 1 }.isValid());
+    REQUIRE(sfz::UncheckedRange<float> { 1.0, 10.0 }.isValid());
+    REQUIRE(sfz::UncheckedRange<float> { 10.0, 10.0 }.isValid());
+}
+
 TEST_CASE("[Range] Clamp")
 {
     sfz::Range<int> intRange { 1, 10 };


### PR DESCRIPTION
The helper `UncheckedRange<T>` is like `Range<R>` except it does not have to validate the invariant (start≤end).
It's intended for accurate behavior of opcodes which work with lo/hi pairs.