### PR TITLE
API with reference counter

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -296,7 +296,7 @@ endif()
 sfizz_enable_fast_math(sfizz_internal)
 
 # Sfizz static library
-add_library(sfizz_static STATIC sfizz/sfizz_wrapper.cpp sfizz/sfizz.cpp)
+add_library(sfizz_static STATIC sfizz/sfizz_wrapper.cpp sfizz/sfizz.cpp sfizz/sfizz_private.hpp)
 add_library(sfizz::static ALIAS sfizz_static)
 target_include_directories(sfizz_static PUBLIC .)
 target_link_libraries(sfizz_static PRIVATE sfizz::internal)

--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -92,6 +92,14 @@ SFIZZ_EXPORTED_API sfizz_synth_t* sfizz_create_synth();
 SFIZZ_EXPORTED_API void sfizz_free(sfizz_synth_t* synth);
 
 /**
+ * @brief Adds a reference to an existing sfizz synth.
+ * @since 0.6.0
+ *
+ * @param synth  The synth to reference.
+ */
+SFIZZ_EXPORTED_API void sfizz_add_ref(sfizz_synth_t* synth);
+
+/**
  * @brief Loads an SFZ file.
  *
  * The file path can be absolute or relative. All file operations for this SFZ

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -26,9 +26,10 @@
   #define SFIZZ_EXPORTED_API
 #endif
 
+struct sfizz_synth_t;
+
 namespace sfz
 {
-class Synth;
 class Client;
 /**
  * @brief Synthesizer for SFZ instruments
@@ -61,6 +62,22 @@ public:
      */
     Sfizz();
     ~Sfizz();
+
+    Sfizz(Sfizz&& other) noexcept;
+    Sfizz& operator=(Sfizz&& other) noexcept;
+
+    Sfizz(const Sfizz& other) = delete;
+    Sfizz& operator=(const Sfizz& other) = delete;
+
+    /**
+     * @brief Reference an existing synth handle.
+     */
+    explicit Sfizz(sfizz_synth_t* synth);
+
+    /**
+     * @brief Get the synth handle.
+     */
+    sfizz_synth_t* handle() const noexcept { return synth; }
 
     /**
      * @brief Processing mode.
@@ -809,7 +826,7 @@ public:
      */
 
 private:
-    std::unique_ptr<sfz::Synth> synth;
+    sfizz_synth_t* synth {};
 };
 
 using ClientPtr = Sfizz::ClientPtr;

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -7,196 +7,222 @@
 #include "Synth.h"
 #include "Messaging.h"
 #include "sfizz.hpp"
+#include "sfizz_private.hpp"
 #include "absl/memory/memory.h"
 
 sfz::Sfizz::Sfizz()
+    : synth(new sfizz_synth_t)
 {
-    synth = absl::make_unique<sfz::Synth>();
 }
 
 sfz::Sfizz::~Sfizz()
 {
+    if (synth)
+        synth->forget();
+}
 
+sfz::Sfizz::Sfizz(sfizz_synth_t* synth)
+    : synth(synth)
+{
+    if (synth)
+        synth->remember();
+}
+
+sfz::Sfizz::Sfizz(Sfizz&& other) noexcept
+    : synth(other.synth)
+{
+    other.synth = nullptr;
+}
+
+sfz::Sfizz& sfz::Sfizz::operator=(Sfizz&& other) noexcept
+{
+    if (this != &other) {
+        if (synth)
+            synth->forget();
+        synth = other.synth;
+        other.synth = nullptr;
+    }
+    return *this;
 }
 
 bool sfz::Sfizz::loadSfzFile(const std::string& path)
 {
-    return synth->loadSfzFile(path);
+    return synth->synth.loadSfzFile(path);
 }
 
 bool sfz::Sfizz::loadSfzString(const std::string& path, const std::string& text)
 {
-    return synth->loadSfzString(path, text);
+    return synth->synth.loadSfzString(path, text);
 }
 
 bool sfz::Sfizz::loadScalaFile(const std::string& path)
 {
-    return synth->loadScalaFile(path);
+    return synth->synth.loadScalaFile(path);
 }
 
 bool sfz::Sfizz::loadScalaString(const std::string& text)
 {
-    return synth->loadScalaString(text);
+    return synth->synth.loadScalaString(text);
 }
 
 void sfz::Sfizz::setScalaRootKey(int rootKey)
 {
-    return synth->setScalaRootKey(rootKey);
+    return synth->synth.setScalaRootKey(rootKey);
 }
 
 int sfz::Sfizz::getScalaRootKey() const
 {
-    return synth->getScalaRootKey();
+    return synth->synth.getScalaRootKey();
 }
 
 void sfz::Sfizz::setTuningFrequency(float frequency)
 {
-    return synth->setTuningFrequency(frequency);
+    return synth->synth.setTuningFrequency(frequency);
 }
 
 float sfz::Sfizz::getTuningFrequency() const
 {
-    return synth->getTuningFrequency();
+    return synth->synth.getTuningFrequency();
 }
 
 void sfz::Sfizz::loadStretchTuningByRatio(float ratio)
 {
-    return synth->loadStretchTuningByRatio(ratio);
+    return synth->synth.loadStretchTuningByRatio(ratio);
 }
 
 int sfz::Sfizz::getNumRegions() const noexcept
 {
-    return synth->getNumRegions();
+    return synth->synth.getNumRegions();
 }
 
 int sfz::Sfizz::getNumGroups() const noexcept
 {
-    return synth->getNumGroups();
+    return synth->synth.getNumGroups();
 }
 
 int sfz::Sfizz::getNumMasters() const noexcept
 {
-    return synth->getNumMasters();
+    return synth->synth.getNumMasters();
 }
 
 int sfz::Sfizz::getNumCurves() const noexcept
 {
-    return synth->getNumCurves();
+    return synth->synth.getNumCurves();
 }
 
 const std::vector<std::string>& sfz::Sfizz::getUnknownOpcodes() const noexcept
 {
-    return synth->getUnknownOpcodes();
+    return synth->synth.getUnknownOpcodes();
 }
 
 size_t sfz::Sfizz::getNumPreloadedSamples() const noexcept
 {
-    return synth->getNumPreloadedSamples();
+    return synth->synth.getNumPreloadedSamples();
 }
 
 void sfz::Sfizz::setSamplesPerBlock(int samplesPerBlock) noexcept
 {
-    synth->setSamplesPerBlock(samplesPerBlock);
+    synth->synth.setSamplesPerBlock(samplesPerBlock);
 }
 
 void sfz::Sfizz::setSampleRate(float sampleRate) noexcept
 {
-    synth->setSampleRate(sampleRate);
+    synth->synth.setSampleRate(sampleRate);
 }
 
 int sfz::Sfizz::getSampleQuality(ProcessMode mode)
 {
-    return synth->getSampleQuality(static_cast<sfz::Synth::ProcessMode>(mode));
+    return synth->synth.getSampleQuality(static_cast<sfz::Synth::ProcessMode>(mode));
 }
 
 void sfz::Sfizz::setSampleQuality(ProcessMode mode, int quality)
 {
-    synth->setSampleQuality(static_cast<sfz::Synth::ProcessMode>(mode), quality);
+    synth->synth.setSampleQuality(static_cast<sfz::Synth::ProcessMode>(mode), quality);
 }
 
 float sfz::Sfizz::getVolume() const noexcept
 {
-    return synth->getVolume();
+    return synth->synth.getVolume();
 }
 
 void sfz::Sfizz::setVolume(float volume) noexcept
 {
-    synth->setVolume(volume);
+    synth->synth.setVolume(volume);
 }
 
 void sfz::Sfizz::noteOn(int delay, int noteNumber, uint8_t velocity) noexcept
 {
-    synth->noteOn(delay, noteNumber, velocity);
+    synth->synth.noteOn(delay, noteNumber, velocity);
 }
 
 void sfz::Sfizz::noteOff(int delay, int noteNumber, uint8_t velocity) noexcept
 {
-    synth->noteOff(delay, noteNumber, velocity);
+    synth->synth.noteOff(delay, noteNumber, velocity);
 }
 
 void sfz::Sfizz::cc(int delay, int ccNumber, uint8_t ccValue) noexcept
 {
-    synth->cc(delay, ccNumber, ccValue);
+    synth->synth.cc(delay, ccNumber, ccValue);
 }
 
 void sfz::Sfizz::hdcc(int delay, int ccNumber, float normValue) noexcept
 {
-    synth->hdcc(delay, ccNumber, normValue);
+    synth->synth.hdcc(delay, ccNumber, normValue);
 }
 
 void sfz::Sfizz::automateHdcc(int delay, int ccNumber, float normValue) noexcept
 {
-    synth->automateHdcc(delay, ccNumber, normValue);
+    synth->synth.automateHdcc(delay, ccNumber, normValue);
 }
 
 void sfz::Sfizz::pitchWheel(int delay, int pitch) noexcept
 {
-    synth->pitchWheel(delay, pitch);
+    synth->synth.pitchWheel(delay, pitch);
 }
 
 void sfz::Sfizz::aftertouch(int delay, uint8_t aftertouch) noexcept
 {
-    synth->aftertouch(delay, aftertouch);
+    synth->synth.aftertouch(delay, aftertouch);
 }
 
 void sfz::Sfizz::tempo(int delay, float secondsPerBeat) noexcept
 {
-    synth->tempo(delay, secondsPerBeat);
+    synth->synth.tempo(delay, secondsPerBeat);
 }
 
 void sfz::Sfizz::timeSignature(int delay, int beatsPerBar, int beatUnit)
 {
-    synth->timeSignature(delay, beatsPerBar, beatUnit);
+    synth->synth.timeSignature(delay, beatsPerBar, beatUnit);
 }
 
 void sfz::Sfizz::timePosition(int delay, int bar, double barBeat)
 {
-    synth->timePosition(delay, bar, barBeat);
+    synth->synth.timePosition(delay, bar, barBeat);
 }
 
 void sfz::Sfizz::playbackState(int delay, int playbackState)
 {
-    synth->playbackState(delay, playbackState);
+    synth->synth.playbackState(delay, playbackState);
 }
 
 void sfz::Sfizz::renderBlock(float** buffers, size_t numSamples, int /*numOutputs*/) noexcept
 {
-    synth->renderBlock({{buffers[0], buffers[1]}, numSamples});
+    synth->synth.renderBlock({{buffers[0], buffers[1]}, numSamples});
 }
 
 int sfz::Sfizz::getNumActiveVoices() const noexcept
 {
-    return synth->getNumActiveVoices();
+    return synth->synth.getNumActiveVoices();
 }
 
 int sfz::Sfizz::getNumVoices() const noexcept
 {
-    return synth->getNumVoices();
+    return synth->synth.getNumVoices();
 }
 
 void sfz::Sfizz::setNumVoices(int numVoices) noexcept
 {
-    synth->setNumVoices(numVoices);
+    synth->synth.setNumVoices(numVoices);
 }
 
 bool sfz::Sfizz::setOversamplingFactor(int factor) noexcept
@@ -205,16 +231,16 @@ bool sfz::Sfizz::setOversamplingFactor(int factor) noexcept
     switch(factor)
     {
         case 1:
-            synth->setOversamplingFactor(sfz::Oversampling::x1);
+            synth->synth.setOversamplingFactor(sfz::Oversampling::x1);
             return true;
         case 2:
-            synth->setOversamplingFactor(sfz::Oversampling::x2);
+            synth->synth.setOversamplingFactor(sfz::Oversampling::x2);
             return true;
         case 4:
-            synth->setOversamplingFactor(sfz::Oversampling::x4);
+            synth->synth.setOversamplingFactor(sfz::Oversampling::x4);
             return true;
         case 8:
-            synth->setOversamplingFactor(sfz::Oversampling::x8);
+            synth->synth.setOversamplingFactor(sfz::Oversampling::x8);
             return true;
         default:
             return false;
@@ -224,92 +250,92 @@ bool sfz::Sfizz::setOversamplingFactor(int factor) noexcept
 
 int sfz::Sfizz::getOversamplingFactor() const noexcept
 {
-    return static_cast<int>(synth->getOversamplingFactor());
+    return static_cast<int>(synth->synth.getOversamplingFactor());
 }
 
 void sfz::Sfizz::setPreloadSize(uint32_t preloadSize) noexcept
 {
-    synth->setPreloadSize(preloadSize);
+    synth->synth.setPreloadSize(preloadSize);
 }
 
 uint32_t sfz::Sfizz::getPreloadSize() const noexcept
 {
-    return synth->getPreloadSize();
+    return synth->synth.getPreloadSize();
 }
 
 int sfz::Sfizz::getAllocatedBuffers() const noexcept
 {
-    return synth->getAllocatedBuffers();
+    return synth->synth.getAllocatedBuffers();
 }
 
 int sfz::Sfizz::getAllocatedBytes() const noexcept
 {
-    return synth->getAllocatedBytes();
+    return synth->synth.getAllocatedBytes();
 }
 
 void sfz::Sfizz::enableFreeWheeling() noexcept
 {
-    synth->enableFreeWheeling();
+    synth->synth.enableFreeWheeling();
 }
 
 void sfz::Sfizz::disableFreeWheeling() noexcept
 {
-    synth->disableFreeWheeling();
+    synth->synth.disableFreeWheeling();
 }
 
 bool sfz::Sfizz::shouldReloadFile()
 {
-    return synth->shouldReloadFile();
+    return synth->synth.shouldReloadFile();
 }
 
 bool sfz::Sfizz::shouldReloadScala()
 {
-    return synth->shouldReloadScala();
+    return synth->synth.shouldReloadScala();
 }
 
 void sfz::Sfizz::enableLogging() noexcept
 {
-    synth->enableLogging();
+    synth->synth.enableLogging();
 }
 
 void sfz::Sfizz::enableLogging(const std::string& prefix) noexcept
 {
-    synth->enableLogging(prefix);
+    synth->synth.enableLogging(prefix);
 }
 
 void sfz::Sfizz::setLoggingPrefix(const std::string& prefix) noexcept
 {
-    synth->setLoggingPrefix(prefix);
+    synth->synth.setLoggingPrefix(prefix);
 }
 
 void sfz::Sfizz::disableLogging() noexcept
 {
-    synth->disableLogging();
+    synth->synth.disableLogging();
 }
 
 void sfz::Sfizz::allSoundOff() noexcept
 {
-    synth->allSoundOff();
+    synth->synth.allSoundOff();
 }
 
 void sfz::Sfizz::addExternalDefinition(const std::string& id, const std::string& value)
 {
-    synth->getParser().addExternalDefinition(id, value);
+    synth->synth.getParser().addExternalDefinition(id, value);
 }
 
 void sfz::Sfizz::clearExternalDefinitions()
 {
-    synth->getParser().clearExternalDefinitions();
+    synth->synth.getParser().clearExternalDefinitions();
 }
 
 const std::vector<std::pair<uint8_t, std::string>>& sfz::Sfizz::getKeyLabels() const noexcept
 {
-    return synth->getKeyLabels();
+    return synth->synth.getKeyLabels();
 }
 
 const std::vector<std::pair<uint16_t, std::string>>& sfz::Sfizz::getCCLabels() const noexcept
 {
-    return synth->getCCLabels();
+    return synth->synth.getCCLabels();
 }
 
 void sfz::Sfizz::ClientDeleter::operator()(Client *client) const noexcept
@@ -334,10 +360,10 @@ void sfz::Sfizz::setReceiveCallback(Client& client, sfizz_receive_t* receive)
 
 void sfz::Sfizz::sendMessage(Client& client, int delay, const char* path, const char* sig, const sfizz_arg_t* args)
 {
-    synth->dispatchMessage(client, delay, path, sig, args);
+    synth->synth.dispatchMessage(client, delay, path, sig, args);
 }
 
 void sfz::Sfizz::setBroadcastCallback(sfizz_receive_t* broadcast, void* data)
 {
-    synth->setBroadcastCallback(broadcast, data);
+    synth->synth.setBroadcastCallback(broadcast, data);
 }

--- a/src/sfizz/sfizz_private.hpp
+++ b/src/sfizz/sfizz_private.hpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include "Synth.h"
+#include <atomic>
+
+struct sfizz_synth_t {
+public:
+    sfizz_synth_t() : rc{1} {}
+
+    sfizz_synth_t(const sfizz_synth_t&) = delete;
+    sfizz_synth_t& operator=(const sfizz_synth_t&) = delete;
+    sfizz_synth_t(sfizz_synth_t&&) = delete;
+    sfizz_synth_t& operator=(sfizz_synth_t&&) = delete;
+
+private:
+    ~sfizz_synth_t() {}
+
+public:
+    void remember()
+    {
+        rc.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void forget()
+    {
+        if (rc.fetch_sub(1, std::memory_order_acq_rel) == 1)
+            delete this;
+    }
+
+    sfz::Synth synth;
+    std::atomic<size_t> rc;
+};

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -9,6 +9,7 @@
 #include "Synth.h"
 #include "Messaging.h"
 #include "sfizz.h"
+#include "sfizz_private.hpp"
 #include <limits>
 
 #ifdef __cplusplus
@@ -17,214 +18,185 @@ extern "C" {
 
 sfizz_synth_t* sfizz_create_synth()
 {
-    return reinterpret_cast<sfizz_synth_t*>(new sfz::Synth());
+    return new sfizz_synth_t;
 }
 
 bool sfizz_load_file(sfizz_synth_t* synth, const char* path)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->loadSfzFile(path);
+    return synth->synth.loadSfzFile(path);
 }
 
 bool sfizz_load_string(sfizz_synth_t* synth, const char* path, const char* text)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->loadSfzString(path, text);
+    return synth->synth.loadSfzString(path, text);
 }
 
 bool sfizz_load_scala_file(sfizz_synth_t* synth, const char* path)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->loadScalaFile(path);
+    return synth->synth.loadScalaFile(path);
 }
 
 bool sfizz_load_scala_string(sfizz_synth_t* synth, const char* text)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->loadScalaString(text);
+    return synth->synth.loadScalaString(text);
 }
 
 void sfizz_set_scala_root_key(sfizz_synth_t* synth, int root_key)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->setScalaRootKey(root_key);
+    synth->synth.setScalaRootKey(root_key);
 }
 
 int sfizz_get_scala_root_key(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getScalaRootKey();
+    return synth->synth.getScalaRootKey();
 }
 
 void sfizz_set_tuning_frequency(sfizz_synth_t* synth, float frequency)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->setTuningFrequency(frequency);
+    synth->synth.setTuningFrequency(frequency);
 }
 
 float sfizz_get_tuning_frequency(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getTuningFrequency();
+    return synth->synth.getTuningFrequency();
 }
 
 void sfizz_load_stretch_tuning_by_ratio(sfizz_synth_t* synth, float ratio)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->loadStretchTuningByRatio(ratio);
+    synth->synth.loadStretchTuningByRatio(ratio);
+}
+
+void sfizz_add_ref(sfizz_synth_t* synth)
+{
+    synth->remember();
 }
 
 void sfizz_free(sfizz_synth_t* synth)
 {
-    delete reinterpret_cast<sfz::Synth*>(synth);
+    synth->forget();
 }
 
 int sfizz_get_num_regions(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getNumRegions();
+    return synth->synth.getNumRegions();
 }
 int sfizz_get_num_groups(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getNumGroups();
+    return synth->synth.getNumGroups();
 }
 int sfizz_get_num_masters(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getNumMasters();
+    return synth->synth.getNumMasters();
 }
 int sfizz_get_num_curves(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getNumCurves();
+    return synth->synth.getNumCurves();
 }
 char* sfizz_export_midnam(sfizz_synth_t* synth, const char* model)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return strdup(self->exportMidnam(model ? model : "").c_str());
+    return strdup(synth->synth.exportMidnam(model ? model : "").c_str());
 }
 size_t sfizz_get_num_preloaded_samples(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getNumPreloadedSamples();
+    return synth->synth.getNumPreloadedSamples();
 }
 int sfizz_get_num_active_voices(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getNumActiveVoices();
+    return synth->synth.getNumActiveVoices();
 }
 
 void sfizz_set_samples_per_block(sfizz_synth_t* synth, int samples_per_block)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->setSamplesPerBlock(samples_per_block);
+    synth->synth.setSamplesPerBlock(samples_per_block);
 }
 void sfizz_set_sample_rate(sfizz_synth_t* synth, float sample_rate)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->setSampleRate(sample_rate);
+    synth->synth.setSampleRate(sample_rate);
 }
 
 void sfizz_send_note_on(sfizz_synth_t* synth, int delay, int note_number, char velocity)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->noteOn(delay, note_number, velocity);
+    synth->synth.noteOn(delay, note_number, velocity);
 }
 void sfizz_send_note_off(sfizz_synth_t* synth, int delay, int note_number, char velocity)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->noteOff(delay, note_number, velocity);
+    synth->synth.noteOff(delay, note_number, velocity);
 }
 void sfizz_send_cc(sfizz_synth_t* synth, int delay, int cc_number, char cc_value)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->cc(delay, cc_number, cc_value);
+    synth->synth.cc(delay, cc_number, cc_value);
 }
 void sfizz_send_hdcc(sfizz_synth_t* synth, int delay, int cc_number, float norm_value)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->hdcc(delay, cc_number, norm_value);
+    synth->synth.hdcc(delay, cc_number, norm_value);
 }
 void sfizz_automate_hdcc(sfizz_synth_t* synth, int delay, int cc_number, float norm_value)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->automateHdcc(delay, cc_number, norm_value);
+    synth->synth.automateHdcc(delay, cc_number, norm_value);
 }
 void sfizz_send_pitch_wheel(sfizz_synth_t* synth, int delay, int pitch)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->pitchWheel(delay, pitch);
+    synth->synth.pitchWheel(delay, pitch);
 }
 void sfizz_send_aftertouch(sfizz_synth_t* synth, int delay, char aftertouch)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->aftertouch(delay, aftertouch);
+    synth->synth.aftertouch(delay, aftertouch);
 }
 void sfizz_send_tempo(sfizz_synth_t* synth, int delay, float seconds_per_quarter)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->tempo(delay, seconds_per_quarter);
+    synth->synth.tempo(delay, seconds_per_quarter);
 }
 void sfizz_send_time_signature(sfizz_synth_t* synth, int delay, int beats_per_bar, int beat_unit)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->timeSignature(delay, beats_per_bar, beat_unit);
+    synth->synth.timeSignature(delay, beats_per_bar, beat_unit);
 }
 void sfizz_send_time_position(sfizz_synth_t* synth, int delay, int bar, double bar_beat)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->timePosition(delay, bar, bar_beat);
+    synth->synth.timePosition(delay, bar, bar_beat);
 }
 void sfizz_send_playback_state(sfizz_synth_t* synth, int delay, int playback_state)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->playbackState(delay, playback_state);
+    synth->synth.playbackState(delay, playback_state);
 }
 
 void sfizz_render_block(sfizz_synth_t* synth, float** channels, int num_channels, int num_frames)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
     // Only stereo output is supported for now
     ASSERT(num_channels == 2);
     UNUSED(num_channels);
-    self->renderBlock({{channels[0], channels[1]}, static_cast<size_t>(num_frames)});
+    synth->synth.renderBlock({{channels[0], channels[1]}, static_cast<size_t>(num_frames)});
 }
 
 unsigned int sfizz_get_preload_size(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getPreloadSize();
+    return synth->synth.getPreloadSize();
 }
 void sfizz_set_preload_size(sfizz_synth_t* synth, unsigned int preload_size)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->setPreloadSize(preload_size);
+    synth->synth.setPreloadSize(preload_size);
 }
 
 sfizz_oversampling_factor_t sfizz_get_oversampling_factor(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return static_cast<sfizz_oversampling_factor_t>(self->getOversamplingFactor());
+    return static_cast<sfizz_oversampling_factor_t>(synth->synth.getOversamplingFactor());
 }
 
 bool sfizz_set_oversampling_factor(sfizz_synth_t* synth, sfizz_oversampling_factor_t oversampling)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
     using sfz::Oversampling;
     switch(oversampling)
     {
         case SFIZZ_OVERSAMPLING_X1:
-            self->setOversamplingFactor(sfz::Oversampling::x1);
+            synth->synth.setOversamplingFactor(sfz::Oversampling::x1);
             return true;
         case SFIZZ_OVERSAMPLING_X2:
-            self->setOversamplingFactor(sfz::Oversampling::x2);
+            synth->synth.setOversamplingFactor(sfz::Oversampling::x2);
             return true;
         case SFIZZ_OVERSAMPLING_X4:
-            self->setOversamplingFactor(sfz::Oversampling::x4);
+            synth->synth.setOversamplingFactor(sfz::Oversampling::x4);
             return true;
         case SFIZZ_OVERSAMPLING_X8:
-            self->setOversamplingFactor(sfz::Oversampling::x8);
+            synth->synth.setOversamplingFactor(sfz::Oversampling::x8);
             return true;
         default:
             return false;
@@ -233,68 +205,57 @@ bool sfizz_set_oversampling_factor(sfizz_synth_t* synth, sfizz_oversampling_fact
 
 int sfizz_get_sample_quality(sfizz_synth_t* synth, sfizz_process_mode_t mode)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getSampleQuality(static_cast<sfz::Synth::ProcessMode>(mode));
+    return synth->synth.getSampleQuality(static_cast<sfz::Synth::ProcessMode>(mode));
 }
 
 void sfizz_set_sample_quality(sfizz_synth_t* synth, sfizz_process_mode_t mode, int quality)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->setSampleQuality(static_cast<sfz::Synth::ProcessMode>(mode), quality);
+    return synth->synth.setSampleQuality(static_cast<sfz::Synth::ProcessMode>(mode), quality);
 }
 
 void sfizz_set_volume(sfizz_synth_t* synth, float volume)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->setVolume(volume);
+    synth->synth.setVolume(volume);
 }
 
 float sfizz_get_volume(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getVolume();
+    return synth->synth.getVolume();
 }
 
 void sfizz_set_num_voices(sfizz_synth_t* synth, int num_voices)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->setNumVoices(num_voices);
+    synth->synth.setNumVoices(num_voices);
 }
 
 int sfizz_get_num_voices(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getNumVoices();
+    return synth->synth.getNumVoices();
 }
 
 int sfizz_get_num_buffers(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getAllocatedBuffers();
+    return synth->synth.getAllocatedBuffers();
 }
 
 int sfizz_get_num_bytes(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getAllocatedBytes();
+    return synth->synth.getAllocatedBytes();
 }
 
 void sfizz_enable_freewheeling(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->enableFreeWheeling();
+    synth->synth.enableFreeWheeling();
 }
 
 void sfizz_disable_freewheeling(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->disableFreeWheeling();
+    synth->synth.disableFreeWheeling();
 }
 
 char* sfizz_get_unknown_opcodes(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    const auto unknownOpcodes = self->getUnknownOpcodes();
+    const auto unknownOpcodes = synth->synth.getUnknownOpcodes();
     size_t totalLength = 0;
     for (auto& opcode: unknownOpcodes)
         totalLength += opcode.length() + 1;
@@ -315,62 +276,52 @@ char* sfizz_get_unknown_opcodes(sfizz_synth_t* synth)
 
 bool sfizz_should_reload_file(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->shouldReloadFile();
+    return synth->synth.shouldReloadFile();
 }
 
 bool sfizz_should_reload_scala(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->shouldReloadScala();
+    return synth->synth.shouldReloadScala();
 }
 
 void sfizz_enable_logging(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->enableLogging();
+    return synth->synth.enableLogging();
 }
 
 void sfizz_set_logging_prefix(sfizz_synth_t* synth, const char* prefix)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->setLoggingPrefix(prefix);
+    return synth->synth.setLoggingPrefix(prefix);
 }
 
 void sfizz_disable_logging(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->disableLogging();
+    return synth->synth.disableLogging();
 }
 
 void sfizz_all_sound_off(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->allSoundOff();
+    return synth->synth.allSoundOff();
 }
 
 void sfizz_add_external_definitions(sfizz_synth_t* synth, const char* id, const char* value)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->getParser().addExternalDefinition(id, value);
+    synth->synth.getParser().addExternalDefinition(id, value);
 }
 
 void sfizz_clear_external_definitions(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->getParser().clearExternalDefinitions();
+    synth->synth.getParser().clearExternalDefinitions();
 }
 
 unsigned int sfizz_get_num_key_labels(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getKeyLabels().size();
+    return synth->synth.getKeyLabels().size();
 }
 
 int sfizz_get_key_label_number(sfizz_synth_t* synth, int label_index)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    const auto keyLabels = self->getKeyLabels();
+    const auto keyLabels = synth->synth.getKeyLabels();
     if (label_index < 0)
         return SFIZZ_OUT_OF_BOUNDS_LABEL_INDEX;
 
@@ -387,8 +338,7 @@ int sfizz_get_key_label_number(sfizz_synth_t* synth, int label_index)
 
 const char * sfizz_get_key_label_text(sfizz_synth_t* synth, int label_index)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    const auto keyLabels = self->getKeyLabels();
+    const auto keyLabels = synth->synth.getKeyLabels();
     if (label_index < 0)
         return NULL;
 
@@ -400,14 +350,12 @@ const char * sfizz_get_key_label_text(sfizz_synth_t* synth, int label_index)
 
 unsigned int sfizz_get_num_cc_labels(sfizz_synth_t* synth)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    return self->getCCLabels().size();
+    return synth->synth.getCCLabels().size();
 }
 
 int sfizz_get_cc_label_number(sfizz_synth_t* synth, int label_index)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    const auto ccLabels = self->getCCLabels();
+    const auto ccLabels = synth->synth.getCCLabels();
     if (label_index < 0)
         return SFIZZ_OUT_OF_BOUNDS_LABEL_INDEX;
 
@@ -424,8 +372,7 @@ int sfizz_get_cc_label_number(sfizz_synth_t* synth, int label_index)
 
 const char * sfizz_get_cc_label_text(sfizz_synth_t* synth, int label_index)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    const auto ccLabels = self->getCCLabels();
+    const auto ccLabels = synth->synth.getCCLabels();
     if (label_index < 0)
         return NULL;
 
@@ -457,14 +404,12 @@ void sfizz_set_receive_callback(sfizz_client_t* client, sfizz_receive_t* receive
 
 void sfizz_send_message(sfizz_synth_t* synth, sfizz_client_t* client, int delay, const char* path, const char* sig, const sfizz_arg_t* args)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->dispatchMessage(*reinterpret_cast<sfz::Client*>(client), delay, path, sig, args);
+    synth->synth.dispatchMessage(*reinterpret_cast<sfz::Client*>(client), delay, path, sig, args);
 }
 
 void sfizz_set_broadcast_callback(sfizz_synth_t* synth, sfizz_receive_t* broadcast, void* data)
 {
-    auto* self = reinterpret_cast<sfz::Synth*>(synth);
-    self->setBroadcastCallback(broadcast, data);
+    synth->synth.setBroadcastCallback(broadcast, data);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Related to sfztools/sfizz-ui#64

It's the ABI-breaking sfizz interface.
(or maybe not depending on platform, it replaces unique_ptr with a raw pointer)

- define the opaque structure `sfizz_synth_t` containing synth and reference counter
- modify C interface to use this structure instead
- add `sfizz_add_ref` for increasing the reference counter. (decreasing is `sfizz_free`)
- the C++ sfz::Sfizz receives API to wrap and access the `sfizz_synth_t`