### PR TITLE
Fix Range ADL for some MSVC versions

### DIFF
--- a/src/sfizz/Range.h
+++ b/src/sfizz/Range.h
@@ -7,7 +7,6 @@
 #pragma once
 #include "MathHelpers.h"
 #include "Macros.h"
-#include <initializer_list>
 #include <type_traits>
 #include <limits>
 
@@ -159,29 +158,16 @@ private:
 
 template <class T> using UncheckedRange = Range<T, false>;
 
+template <class Type, bool C1, bool C2>
+bool operator==(const Range<Type, C1>& lhs, const Range<Type, C2>& rhs) noexcept
+{
+    return lhs.getStart() == rhs.getStart() && lhs.getEnd() == rhs.getEnd();
 }
 
 template <class Type, bool C1, bool C2>
-bool operator==(const sfz::Range<Type, C1>& lhs, const sfz::Range<Type, C2>& rhs)
+bool operator!=(const Range<Type, C1>& lhs, const Range<Type, C2>& rhs) noexcept
 {
-    return (lhs.getStart() == rhs.getStart()) && (lhs.getEnd() == rhs.getEnd());
+    return !operator==(lhs, rhs);
 }
 
-template <class Type, bool C1, bool C2>
-bool operator!=(const sfz::Range<Type, C1>& lhs, const sfz::Range<Type, C2>& rhs)
-{
-    return (lhs.getStart() != rhs.getStart()) || (lhs.getEnd() != rhs.getEnd());
-}
-
-
-template <class Type, bool C>
-bool operator==(const sfz::Range<Type, C>& lhs, const std::pair<Type, Type>& rhs)
-{
-    return (lhs.getStart() == rhs.first) && (lhs.getEnd() == rhs.second);
-}
-
-template <class Type, bool C>
-bool operator==(const std::pair<Type, Type>& lhs, const sfz::Range<Type, C>& rhs)
-{
-    return rhs == lhs;
-}
+} // namespace sfz

--- a/tests/RangeT.cpp
+++ b/tests/RangeT.cpp
@@ -12,13 +12,9 @@ TEST_CASE("[Range] Equality operators")
 {
     sfz::Range<int> intRange { 1, 1 };
     REQUIRE(intRange == sfz::Range<int>(1, 1));
-    REQUIRE(intRange == std::pair<int, int>(1, 1));
-    REQUIRE(std::pair<int, int>(1, 1) == intRange);
 
     sfz::Range<float> floatRange { 1.0f, 1.0f };
     REQUIRE(floatRange == sfz::Range<float>(1.0f, 1.0f));
-    REQUIRE(floatRange == std::pair<float, float>(1.0f, 1.0f));
-    REQUIRE(std::pair<float, float>(1.0f, 1.0f) == floatRange);
 }
 
 TEST_CASE("[Range] Default ranges for classical types")


### PR DESCRIPTION
This fixes build for MSVC which doesn't have identical ADL rules in some versions.
Removes comparison operators with `std::pair` because they seem unfixable and they aren't used.