### PR TITLE
Fix a parsing error in presence of # sign

### DIFF
--- a/src/sfizz/parser/Parser.cpp
+++ b/src/sfizz/parser/Parser.cpp
@@ -310,9 +310,19 @@ void Parser::processOpcode()
             // if there aren't non-space characters following, do not extract
             if (i == valueSize)
                 stop = true;
-            // if a "<" or "#" character is next, a header or a directive follows
-            else if (valueRaw[i] == '<' || valueRaw[i] == '#')
+            // if a "<" character is next, a header follows
+            else if (valueRaw[i] == '<')
                 stop = true;
+            // if a "#" character is next, check if a directive follows
+            else if (valueRaw[i] == '#') {
+                size_t dirStart = i + 1;
+                size_t dirEnd = dirStart;
+                while (dirEnd < valueSize && isIdentifierChar(valueRaw[dirEnd]))
+                    ++dirEnd;
+                absl::string_view dir(&valueRaw[dirStart], dirEnd - dirStart);
+                if (dir == "define" || dir == "include")
+                    stop = true;
+            }
             // if sequence of identifier chars and then "=", an opcode follows
             else if (isIdentifierChar(valueRaw[i])) {
                 ++i;

--- a/tests/ParsingT.cpp
+++ b/tests/ParsingT.cpp
@@ -585,13 +585,17 @@ TEST_CASE("[Parsing] Opcode value with inline directives")
         ParsingMocker mock;
         parser.setListener(&mock);
         parser.parseString("/opcodeValueWithInlineDirective.sfz",
-R"(<region>#define $VEL v1 sample=$VEL.wav #define $FOO bar)");
+R"(
+<region>#define $VEL v1 sample=$VEL.wav #define $FOO bar
+<region>#define $VEL v2 sample=$VEL.wav #notAdirective 123
+)");
 
         std::vector<std::vector<sfz::Opcode>> expectedMembers = {
             {{"sample", "v1.wav"}},
+            {{"sample", "v2.wav #notAdirective 123"}},
         };
         std::vector<std::string> expectedHeaders = {
-            "region"
+            "region", "region"
         };
         std::vector<sfz::Opcode> expectedOpcodes;
 


### PR DESCRIPTION
This permits to write `sample=D #.wav`, which is accepted in other sfz software.