### PR TITLE
Add modulation targets for the LFO targets

### DIFF
--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -1266,6 +1266,33 @@ bool sfz::Region::parseLFOOpcodeV2(const Opcode& opcode)
                 opcode.read(Default::volumeMod);
         }
         break;
+    case_any_ccN("lfo&_volume"):
+        {
+            const ModKey source = ModKey::createNXYZ(ModId::LFO, id, lfoNumber);
+            const ModKey target = ModKey::createNXYZ(ModId::Volume, id);
+            const ModKey depthModifier = ModKey::createNXYZ(ModId::LFOVolumeDepth, id);
+            getOrCreateConnection(source, target).sourceDepthMod = depthModifier;
+            processGenericCc(opcode, Default::volumeMod, depthModifier);
+        }
+        break;
+    case_any_ccN("lfo&_pitch"):
+        {
+            const ModKey source = ModKey::createNXYZ(ModId::LFO, id, lfoNumber);
+            const ModKey target = ModKey::createNXYZ(ModId::Pitch, id);
+            const ModKey depthModifier = ModKey::createNXYZ(ModId::LFOPitchDepth, id);
+            getOrCreateConnection(source, target).sourceDepthMod = depthModifier;
+            processGenericCc(opcode, Default::pitchMod, depthModifier);
+        }
+        break;
+    case_any_ccN("lfo&_cutoff"):
+        {
+            const ModKey source = ModKey::createNXYZ(ModId::LFO, id, lfoNumber);
+            const ModKey target = ModKey::createNXYZ(ModId::FilCutoff, id);
+            const ModKey depthModifier = ModKey::createNXYZ(ModId::LFOFilCutoffDepth, id);
+            getOrCreateConnection(source, target).sourceDepthMod = depthModifier;
+            processGenericCc(opcode, Default::filterCutoffMod, depthModifier);
+        }
+        break;
 
     case hash("lfo&_cutoff&"):
         LFO_EG_filter_EQ_target(ModId::LFO, ModId::FilCutoff, Default::filterCutoffMod);

--- a/src/sfizz/modulations/ModId.cpp
+++ b/src/sfizz/modulations/ModId.cpp
@@ -96,6 +96,12 @@ int ModIds::flags(ModId id) noexcept
         return kModIsPerVoice|kModIsAdditive;
     case ModId::LFOBeats:
         return kModIsPerVoice|kModIsAdditive;
+    case ModId::LFOVolumeDepth:
+        return kModIsPerVoice|kModIsAdditive;
+    case ModId::LFOPitchDepth:
+        return kModIsPerVoice|kModIsAdditive;
+    case ModId::LFOFilCutoffDepth:
+        return kModIsPerVoice|kModIsAdditive;
 
         // unknown
     default:

--- a/src/sfizz/modulations/ModId.h
+++ b/src/sfizz/modulations/ModId.h
@@ -63,6 +63,9 @@ enum class ModId : int {
     FilLFOFrequency,
     LFOFrequency,
     LFOBeats,
+    LFOVolumeDepth,
+    LFOFilCutoffDepth,
+    LFOPitchDepth,
 
     _TargetsEnd,
     // [/targets] --------------------------------------------------------------

--- a/src/sfizz/modulations/ModKey.cpp
+++ b/src/sfizz/modulations/ModKey.cpp
@@ -164,6 +164,12 @@ std::string ModKey::toString() const
         return absl::StrCat("LFOFrequency {", region_.number(), ", N=", 1 + params_.N, "}");
     case ModId::LFOBeats:
         return absl::StrCat("LFOBeats {", region_.number(), ", N=", 1 + params_.N, "}");
+    case ModId::LFOVolumeDepth:
+        return absl::StrCat("LFOVolumeDepth {", region_.number(), ", N=", 1 + params_.N, "}");
+    case ModId::LFOPitchDepth:
+        return absl::StrCat("LFOPitchDepth {", region_.number(), ", N=", 1 + params_.N, "}");
+    case ModId::LFOFilCutoffDepth:
+        return absl::StrCat("LFOFilCutoffDepth {", region_.number(), ", N=", 1 + params_.N, "}");
 
     default:
         return {};

--- a/src/sfizz/modulations/ModMatrix.cpp
+++ b/src/sfizz/modulations/ModMatrix.cpp
@@ -39,6 +39,7 @@ struct ModMatrix::Impl {
     struct ConnectionData {
         float sourceDepth_ {};
         ModKey sourceDepthMod_ {};
+        TargetId sourceDepthModId_ {};
         float velToDepth_ {};
     };
 
@@ -207,6 +208,7 @@ bool ModMatrix::connect(SourceId sourceId, TargetId targetId, float sourceDepth,
     Impl::ConnectionData& conn = target.connectedSources[sourceIndex];
     conn.sourceDepth_ = sourceDepth;
     conn.sourceDepthMod_ = sourceDepthMod;
+    conn.sourceDepthModId_ = findTarget(sourceDepthMod);
     conn.velToDepth_ = velToDepth;
 
     return true;
@@ -414,7 +416,7 @@ float* ModMatrix::getModulation(TargetId targetId)
                 sourceDepth += triggerValue * velToDepth;
             }
 
-            const float* sourceDepthMod = getModulationByKey(sourcesPos->second.sourceDepthMod_);
+            const float* sourceDepthMod = getModulation(sourcesPos->second.sourceDepthModId_);
 
             if (isFirstSource) {
                 if (sourceDepth == 1 && !sourceDepthMod)


### PR DESCRIPTION
I also removed the getModulationByKey and replaced them by a caching of the relevant target id, since this proved problematic in the past.