### PR TITLE
Onetime instrument info

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories(plugins-common PUBLIC "common")
 target_link_libraries(plugins-common
     PUBLIC sfizz::spin_mutex
     PUBLIC sfizz::filesystem absl::strings
-    PRIVATE sfizz::internal)
+    PRIVATE sfizz::internal sfizz::sfizz)
 add_library(sfizz::plugins-common ALIAS plugins-common)
 
 if((SFIZZ_LV2 AND SFIZZ_LV2_UI) OR SFIZZ_VST)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,10 +1,13 @@
 add_library(plugins-common STATIC EXCLUDE_FROM_ALL
     "common/plugin/MessageUtils.h"
-    "common/plugin/MessageUtils.cpp")
+    "common/plugin/MessageUtils.cpp"
+    "common/plugin/InstrumentDescription.h"
+    "common/plugin/InstrumentDescription.cpp")
 target_include_directories(plugins-common PUBLIC "common")
 target_link_libraries(plugins-common
     PUBLIC sfizz::spin_mutex
-    PUBLIC sfizz::filesystem absl::strings)
+    PUBLIC sfizz::filesystem absl::strings
+    PRIVATE sfizz::internal)
 add_library(sfizz::plugins-common ALIAS plugins-common)
 
 if((SFIZZ_LV2 AND SFIZZ_LV2_UI) OR SFIZZ_VST)

--- a/plugins/common/plugin/InstrumentDescription.cpp
+++ b/plugins/common/plugin/InstrumentDescription.cpp
@@ -93,6 +93,11 @@ std::string getDescriptionBlob(sfizz_synth_t* handle)
         }
     });
 
+    synth.sendMessage(*client, 0, "/num_regions", "", nullptr);
+    synth.sendMessage(*client, 0, "/num_groups", "", nullptr);
+    synth.sendMessage(*client, 0, "/num_masters", "", nullptr);
+    synth.sendMessage(*client, 0, "/num_curves", "", nullptr);
+    synth.sendMessage(*client, 0, "/num_samples", "", nullptr);
     synth.sendMessage(*client, 0, "/key/slots", "", nullptr);
     synth.sendMessage(*client, 0, "/sw/last/slots", "", nullptr);
     synth.sendMessage(*client, 0, "/cc/slots", "", nullptr);
@@ -125,7 +130,17 @@ InstrumentDescription parseDescriptionBlob(absl::string_view blob)
         };
 
         //
-        if (Messages::matchOSC("/key/slots", path, indices) && !strcmp(sig, "b"))
+        if (Messages::matchOSC("/num_regions", path, indices) && !strcmp(sig, "i"))
+            desc.numRegions = uint32_t(args[0].i);
+        else if (Messages::matchOSC("/num_groups", path, indices) && !strcmp(sig, "i"))
+            desc.numGroups = uint32_t(args[0].i);
+        else if (Messages::matchOSC("/num_masters", path, indices) && !strcmp(sig, "i"))
+            desc.numMasters = uint32_t(args[0].i);
+        else if (Messages::matchOSC("/num_curves", path, indices) && !strcmp(sig, "i"))
+            desc.numCurves = uint32_t(args[0].i);
+        else if (Messages::matchOSC("/num_samples", path, indices) && !strcmp(sig, "i"))
+            desc.numSamples = uint32_t(args[0].i);
+        else if (Messages::matchOSC("/key/slots", path, indices) && !strcmp(sig, "b"))
             copyArgToBitSpan(args[0], desc.keyUsed.span());
         else if (Messages::matchOSC("/sw/last/slots", path, indices) && !strcmp(sig, "b"))
             copyArgToBitSpan(args[0], desc.keyswitchUsed.span());
@@ -150,6 +165,12 @@ InstrumentDescription parseDescriptionBlob(absl::string_view blob)
 std::ostream& operator<<(std::ostream& os, const InstrumentDescription& desc)
 {
     os << "instrument:\n";
+
+    os << "  regions: " << desc.numRegions << "\n";
+    os << "  groups: " << desc.numGroups << "\n";
+    os << "  masters: " << desc.numMasters << "\n";
+    os << "  curves: " << desc.numCurves << "\n";
+    os << "  samples: " << desc.numSamples << "\n";
 
     os << "  keys:\n";
     for (unsigned i = 0; i < 128; ++i) {

--- a/plugins/common/plugin/InstrumentDescription.cpp
+++ b/plugins/common/plugin/InstrumentDescription.cpp
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "InstrumentDescription.h"
+#include "MessageUtils.h"
+#include "sfizz.hpp"
+#include <absl/strings/str_cat.h>
+#include <algorithm>
+#include <memory>
+#include <iostream>
+#include <cstring>
+#include <cstdint>
+
+template <class... Args>
+static void bufferedStrCat(std::string* buffer, const Args&... args)
+{
+    buffer->clear();
+    absl::StrAppend(buffer, args...);
+}
+
+std::string getDescriptionBlob(sfizz_synth_t* handle)
+{
+    std::string blob;
+    blob.reserve(128 * 1024);
+
+    std::vector<char> msgbuf;
+    msgbuf.resize(1024);
+
+    std::string pathbuf;
+    pathbuf.reserve(256);
+
+    struct ClientData {
+        sfz::Sfizz* synth = nullptr;
+        sfz::Client* client = nullptr;
+        std::string* blob = nullptr;
+        std::vector<char>* msgbuf = nullptr;
+        std::string* pathbuf = nullptr;
+    };
+
+    sfz::Sfizz synth(handle);
+    ClientData cdata;
+    sfz::ClientPtr client = synth.createClient(&cdata);
+    cdata.synth = &synth;
+    cdata.client = client.get();
+    cdata.blob = &blob;
+    cdata.msgbuf = &msgbuf;
+    cdata.pathbuf = &pathbuf;
+
+    synth.setReceiveCallback(*client, [](void* data, int, const char* path, const char* sig, const sfizz_arg_t* args) {
+        ClientData& cdata = *reinterpret_cast<ClientData*>(data);
+        unsigned indices[8];
+
+        ///
+        uint32_t msglen = sfizz_prepare_message(cdata.msgbuf->data(), cdata.msgbuf->size(), path, sig, args);
+        if (msglen > cdata.msgbuf->size()) {
+            cdata.msgbuf->resize(msglen);
+            sfizz_prepare_message(cdata.msgbuf->data(), cdata.msgbuf->size(), path, sig, args);
+        }
+        cdata.blob->append(cdata.msgbuf->data(), msglen);
+
+        ///
+        if (Messages::matchOSC("/key/slots", path, indices) && !strcmp(sig, "b")) {
+            ConstBitSpan bits(args[0].b->data, 8 * args[0].b->size);
+            for (unsigned key = 0; key < 128 && key < bits.bit_size(); ++key) {
+                if (bits.test(key)) {
+                    bufferedStrCat(cdata.pathbuf, "/key", key, "/label");
+                    cdata.synth->sendMessage(*cdata.client, 0, cdata.pathbuf->c_str(), "", nullptr);
+                }
+            }
+        }
+        else if (Messages::matchOSC("/sw/last/slots", path, indices) && !strcmp(sig, "b")) {
+            ConstBitSpan bits(args[0].b->data, 8 * args[0].b->size);
+            for (unsigned key = 0; key < 128 && key < bits.bit_size(); ++key) {
+                if (bits.test(key)) {
+                    bufferedStrCat(cdata.pathbuf, "/sw/last/", key, "/label");
+                    cdata.synth->sendMessage(*cdata.client, 0, cdata.pathbuf->c_str(), "", nullptr);
+                }
+            }
+        }
+        else if (Messages::matchOSC("/cc/slots", path, indices) && !strcmp(sig, "b")) {
+            ConstBitSpan bits(args[0].b->data, 8 * args[0].b->size);
+            for (unsigned cc = 0; cc < sfz::config::numCCs && cc < bits.bit_size(); ++cc) {
+                if (bits.test(cc)) {
+                    bufferedStrCat(cdata.pathbuf, "/cc", cc, "/label");
+                    cdata.synth->sendMessage(*cdata.client, 0, cdata.pathbuf->c_str(), "", nullptr);
+                    bufferedStrCat(cdata.pathbuf, "/cc", cc, "/default");
+                    cdata.synth->sendMessage(*cdata.client, 0, cdata.pathbuf->c_str(), "", nullptr);
+                }
+            }
+        }
+    });
+
+    synth.sendMessage(*client, 0, "/key/slots", "", nullptr);
+    synth.sendMessage(*client, 0, "/sw/last/slots", "", nullptr);
+    synth.sendMessage(*client, 0, "/cc/slots", "", nullptr);
+
+    blob.shrink_to_fit();
+    return blob;
+}
+
+InstrumentDescription parseDescriptionBlob(absl::string_view blob)
+{
+    InstrumentDescription desc;
+
+    const uint8_t* src = reinterpret_cast<const uint8_t*>(blob.data());
+    uint32_t srcSize = blob.size();
+    char buffer[1024];
+
+    const char* path;
+    const char* sig;
+    const sfizz_arg_t* args;
+
+    int32_t byteCount;
+    while ((byteCount = sfizz_extract_message(src, srcSize, buffer, sizeof(buffer), &path, &sig, &args)) > 0) {
+        unsigned indices[8];
+
+        ///
+        auto copyArgToBitSpan = [](const sfizz_arg_t& arg, BitSpan bits)
+        {
+            size_t size = std::min<size_t>(bits.byte_size(), arg.b->size);
+            memcpy(bits.data(), arg.b->data, size);
+        };
+
+        //
+        if (Messages::matchOSC("/key/slots", path, indices) && !strcmp(sig, "b"))
+            copyArgToBitSpan(args[0], desc.keyUsed.span());
+        else if (Messages::matchOSC("/sw/last/slots", path, indices) && !strcmp(sig, "b"))
+            copyArgToBitSpan(args[0], desc.keyswitchUsed.span());
+        else if (Messages::matchOSC("/cc/slots", path, indices) && !strcmp(sig, "b"))
+            copyArgToBitSpan(args[0], desc.ccUsed.span());
+        else if (Messages::matchOSC("/key&/label", path, indices) && !strcmp(sig, "s"))
+            desc.keyLabel[indices[0]] = args[0].s;
+        else if (Messages::matchOSC("/sw/last/&/label", path, indices) && !strcmp(sig, "s"))
+            desc.keyswitchLabel[indices[0]] = args[0].s;
+        else if (Messages::matchOSC("/cc&/label", path, indices) && !strcmp(sig, "s"))
+            desc.ccLabel[indices[0]] = args[0].s;
+        else if (Messages::matchOSC("/cc&/default", path, indices) && !strcmp(sig, "f"))
+            desc.ccDefault[indices[0]] = args[0].f;
+
+        src += byteCount;
+        srcSize -= byteCount;
+    }
+
+    return desc;
+}
+
+std::ostream& operator<<(std::ostream& os, const InstrumentDescription& desc)
+{
+    os << "instrument:\n";
+
+    os << "  keys:\n";
+    for (unsigned i = 0; i < 128; ++i) {
+        if (desc.keyUsed.test(i)) {
+            os << "  - number: " << i << "\n";
+            if (!desc.keyLabel[i].empty())
+                os << "    label: " << desc.keyLabel[i].c_str() << "\n";
+        }
+    }
+
+    os << "  keyswitches:\n";
+    for (unsigned i = 0; i < 128; ++i) {
+        if (desc.keyswitchUsed.test(i)) {
+            os << "  - number: " << i << "\n";
+            if (!desc.keyswitchLabel[i].empty())
+                os << "    label: " << desc.keyswitchLabel[i].c_str() << "\n";
+        }
+    }
+
+    os << "  cc:\n";
+    for (unsigned i = 0; i < sfz::config::numCCs; ++i) {
+        if (desc.ccUsed.test(i)) {
+            os << "  - number: " << i << "\n";
+            os << "    default: " << desc.ccDefault[i] << "\n";
+            if (!desc.ccLabel[i].empty())
+                os << "    label: " << desc.ccLabel[i].c_str() << "\n";
+        }
+    }
+
+    return os;
+}

--- a/plugins/common/plugin/InstrumentDescription.cpp
+++ b/plugins/common/plugin/InstrumentDescription.cpp
@@ -98,6 +98,8 @@ std::string getDescriptionBlob(sfizz_synth_t* handle)
     synth.sendMessage(*client, 0, "/num_masters", "", nullptr);
     synth.sendMessage(*client, 0, "/num_curves", "", nullptr);
     synth.sendMessage(*client, 0, "/num_samples", "", nullptr);
+    synth.sendMessage(*client, 0, "/root_path", "", nullptr);
+    synth.sendMessage(*client, 0, "/image", "", nullptr);
     synth.sendMessage(*client, 0, "/key/slots", "", nullptr);
     synth.sendMessage(*client, 0, "/sw/last/slots", "", nullptr);
     synth.sendMessage(*client, 0, "/cc/slots", "", nullptr);
@@ -140,6 +142,10 @@ InstrumentDescription parseDescriptionBlob(absl::string_view blob)
             desc.numCurves = uint32_t(args[0].i);
         else if (Messages::matchOSC("/num_samples", path, indices) && !strcmp(sig, "i"))
             desc.numSamples = uint32_t(args[0].i);
+        else if (Messages::matchOSC("/root_path", path, indices) && !strcmp(sig, "s"))
+            desc.rootPath = args[0].s;
+        else if (Messages::matchOSC("/image", path, indices) && !strcmp(sig, "s"))
+            desc.image = args[0].s;
         else if (Messages::matchOSC("/key/slots", path, indices) && !strcmp(sig, "b"))
             copyArgToBitSpan(args[0], desc.keyUsed.span());
         else if (Messages::matchOSC("/sw/last/slots", path, indices) && !strcmp(sig, "b"))
@@ -171,6 +177,9 @@ std::ostream& operator<<(std::ostream& os, const InstrumentDescription& desc)
     os << "  masters: " << desc.numMasters << "\n";
     os << "  curves: " << desc.numCurves << "\n";
     os << "  samples: " << desc.numSamples << "\n";
+
+    os << "  root_path: " << desc.rootPath << "\n";
+    os << "  image: " << desc.image << "\n";
 
     os << "  keys:\n";
     for (unsigned i = 0; i < 128; ++i) {

--- a/plugins/common/plugin/InstrumentDescription.h
+++ b/plugins/common/plugin/InstrumentDescription.h
@@ -13,7 +13,15 @@
 #include <iosfwd>
 struct sfizz_synth_t;
 
+/**
+ * @brief Description of user-interactible elements of the SFZ instrument
+ */
 struct InstrumentDescription {
+    uint32_t numRegions {};
+    uint32_t numGroups {};
+    uint32_t numMasters {};
+    uint32_t numCurves {};
+    uint32_t numSamples {};
     BitArray<128> keyUsed {};
     BitArray<128> keyswitchUsed {};
     BitArray<sfz::config::numCCs> ccUsed {};
@@ -23,7 +31,21 @@ struct InstrumentDescription {
     std::array<float, sfz::config::numCCs> ccDefault {};
 };
 
+/**
+ * @brief Produce a description of the currently loaded instrument in the synth,
+ *        in the form of a concatenation of OSC messages.
+ *
+ * This form is a message transmissible over binary channels.
+ */
 std::string getDescriptionBlob(sfizz_synth_t* handle);
+
+/**
+ * @brief Extract the information from the OSC blob and rearrange it in a
+ *        structured form.
+ */
 InstrumentDescription parseDescriptionBlob(absl::string_view blob);
 
+/**
+ * @brief Display the description in human-readable format.
+ */
 std::ostream& operator<<(std::ostream& os, const InstrumentDescription& desc);

--- a/plugins/common/plugin/InstrumentDescription.h
+++ b/plugins/common/plugin/InstrumentDescription.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+#include "sfizz/Config.h"
+#include "sfizz/utility/bit_array/BitArray.h"
+#include <absl/strings/string_view.h>
+#include <string>
+#include <array>
+#include <iosfwd>
+struct sfizz_synth_t;
+
+struct InstrumentDescription {
+    BitArray<128> keyUsed {};
+    BitArray<128> keyswitchUsed {};
+    BitArray<sfz::config::numCCs> ccUsed {};
+    std::array<std::string, 128> keyLabel {};
+    std::array<std::string, 128> keyswitchLabel {};
+    std::array<std::string, sfz::config::numCCs> ccLabel {};
+    std::array<float, sfz::config::numCCs> ccDefault {};
+};
+
+std::string getDescriptionBlob(sfizz_synth_t* handle);
+InstrumentDescription parseDescriptionBlob(absl::string_view blob);
+
+std::ostream& operator<<(std::ostream& os, const InstrumentDescription& desc);

--- a/plugins/common/plugin/InstrumentDescription.h
+++ b/plugins/common/plugin/InstrumentDescription.h
@@ -22,6 +22,8 @@ struct InstrumentDescription {
     uint32_t numMasters {};
     uint32_t numCurves {};
     uint32_t numSamples {};
+    std::string rootPath;
+    std::string image;
     BitArray<128> keyUsed {};
     BitArray<128> keyswitchUsed {};
     BitArray<sfz::config::numCCs> ccUsed {};

--- a/plugins/editor/src/editor/EditIds.h
+++ b/plugins/editor/src/editor/EditIds.h
@@ -22,11 +22,19 @@ enum class EditId : int {
     UserFilesDir,
     FallbackFilesDir,
     //
-    Key0,
-    KeyLast = Key0 + 128 - 1,
+    #define KEY_RANGE(Name) Name##0, Name##Last = Name##0 + 128 - 1
+    #define CC_RANGE(Name) Name##0, Name##Last = Name##0 + sfz::config::numCCs - 1
     //
-    Controller0,
-    ControllerLast = Controller0 + sfz::config::numCCs - 1,
+    KEY_RANGE(Key),
+    CC_RANGE(Controller),
+    //
+    KEY_RANGE(KeyUsed),
+    KEY_RANGE(KeyLabel),
+    KEY_RANGE(KeyswitchUsed),
+    KEY_RANGE(KeyswitchLabel),
+    CC_RANGE(ControllerUsed),
+    CC_RANGE(ControllerDefault),
+    CC_RANGE(ControllerLabel),
     //
     UINumCurves,
     UINumMasters,
@@ -35,6 +43,9 @@ enum class EditId : int {
     UINumPreloadedSamples,
     UINumActiveVoices,
     UIActivePanel,
+    //
+    #undef KEY_RANGE
+    #undef CC_RANGE
 };
 
 struct EditRange {
@@ -66,5 +77,12 @@ struct EditRange {
 // defines editIdForCC, ccForEditId, editIdIsCC, etc..
 DEFINE_EDIT_ID_RANGE_HELPERS(cc, CC, Controller)
 DEFINE_EDIT_ID_RANGE_HELPERS(key, Key, Key)
+DEFINE_EDIT_ID_RANGE_HELPERS(keyUsed, KeyUsed, KeyUsed)
+DEFINE_EDIT_ID_RANGE_HELPERS(keyLabel, KeyLabel, KeyLabel)
+DEFINE_EDIT_ID_RANGE_HELPERS(keyswitchUsed, KeyswitchUsed, KeyswitchUsed)
+DEFINE_EDIT_ID_RANGE_HELPERS(keyswitchLabel, KeyswitchLabel, KeyswitchLabel)
+DEFINE_EDIT_ID_RANGE_HELPERS(ccUsed, CCUsed, ControllerUsed)
+DEFINE_EDIT_ID_RANGE_HELPERS(ccDefault, CCDefault, ControllerDefault)
+DEFINE_EDIT_ID_RANGE_HELPERS(ccLabel, CCLabel, ControllerLabel)
 
 #undef DEFINE_EDIT_ID_RANGE_HELPERS

--- a/plugins/editor/src/editor/EditIds.h
+++ b/plugins/editor/src/editor/EditIds.h
@@ -60,18 +60,21 @@ struct EditRange {
 };
 
 #define DEFINE_EDIT_ID_RANGE_HELPERS(type, Type, IdPrefix)          \
-    inline EditId editIdFor##Type(int value)                        \
-    {                                                               \
-        return EditId(int(EditId::IdPrefix##0) + value);            \
-    }                                                               \
-    inline int type##ForEditId(EditId id)                           \
-    {                                                               \
-        return int(id) - int(EditId::IdPrefix##0);                  \
-    }                                                               \
     inline bool editIdIs##Type(EditId id)                           \
     {                                                               \
         return int(id) >= int(EditId::IdPrefix##0) &&               \
             int(id) <= int(EditId::IdPrefix##Last);                 \
+    }                                                               \
+    inline EditId editIdFor##Type(int value)                        \
+    {                                                               \
+        EditId id = EditId(int(EditId::IdPrefix##0) + value);       \
+        assert(editIdIs##Type(id));                                 \
+        return id;                                                  \
+    }                                                               \
+    inline int type##ForEditId(EditId id)                           \
+    {                                                               \
+        assert(editIdIs##Type(id));                                 \
+        return int(id) - int(EditId::IdPrefix##0);                  \
     }
 
 // defines editIdForCC, ccForEditId, editIdIsCC, etc..

--- a/plugins/editor/src/editor/EditIds.h
+++ b/plugins/editor/src/editor/EditIds.h
@@ -48,29 +48,23 @@ struct EditRange {
     static EditRange get(EditId id);
 };
 
-inline EditId editIdForCC(int cc)
-{
-    return EditId(int(EditId::Controller0) + cc);
-}
-inline int ccForEditId(EditId id)
-{
-    return int(id) - int(EditId::Controller0);
-}
-inline bool editIdIsCC(EditId id)
-{
-    return int(id) >= int(EditId::Controller0) &&
-        int(id) <= int(EditId::ControllerLast);
-}
+#define DEFINE_EDIT_ID_RANGE_HELPERS(type, Type, IdPrefix)          \
+    inline EditId editIdFor##Type(int value)                        \
+    {                                                               \
+        return EditId(int(EditId::IdPrefix##0) + value);            \
+    }                                                               \
+    inline int type##ForEditId(EditId id)                           \
+    {                                                               \
+        return int(id) - int(EditId::IdPrefix##0);                  \
+    }                                                               \
+    inline bool editIdIs##Type(EditId id)                           \
+    {                                                               \
+        return int(id) >= int(EditId::IdPrefix##0) &&               \
+            int(id) <= int(EditId::IdPrefix##Last);                 \
+    }
 
-inline EditId editIdForKey(int key)
-{
-    return EditId(int(EditId::Key0) + key);
-}
-inline int keyForEditId(EditId id)
-{
-    return int(id) - int(EditId::Key0);
-}
-inline bool editIdIsKey(EditId id)
-{
-    return int(id) >= int(EditId::Key0) && int(id) <= int(EditId::KeyLast);
-}
+// defines editIdForCC, ccForEditId, editIdIsCC, etc..
+DEFINE_EDIT_ID_RANGE_HELPERS(cc, CC, Controller)
+DEFINE_EDIT_ID_RANGE_HELPERS(key, Key, Key)
+
+#undef DEFINE_EDIT_ID_RANGE_HELPERS

--- a/plugins/editor/src/editor/EditIds.h
+++ b/plugins/editor/src/editor/EditIds.h
@@ -44,6 +44,8 @@ enum class EditId : int {
     UINumActiveVoices,
     UIActivePanel,
     //
+    BackgroundImage,
+    //
     #undef KEY_RANGE
     #undef CC_RANGE
 };

--- a/plugins/editor/src/editor/Editor.cpp
+++ b/plugins/editor/src/editor/Editor.cpp
@@ -200,6 +200,7 @@ struct Editor::Impl : EditorController::Receiver, IControlListener {
     void updateKeyswitchNameLabel();
 
     void updateKeyUsed(unsigned key, bool used);
+    void updateKeyLabel(unsigned key, const char* label);
     void updateKeyswitchUsed(unsigned key, bool used);
     void updateCCUsed(unsigned cc, bool used);
     void updateCCValue(unsigned cc, float value);
@@ -460,6 +461,27 @@ void Editor::Impl::uiReceiveValue(EditId id, const EditValue& v)
             const float value = v.to_float();
             if (SPiano* piano = piano_)
                 piano->setKeyValue(key, value);
+        }
+        else if (editIdIsKeyUsed(id)) {
+            updateKeyUsed(keyUsedForEditId(id), v.to_float() != 0);
+        }
+        else if (editIdIsKeyLabel(id)) {
+            updateKeyLabel(keyLabelForEditId(id), v.to_string().c_str());
+        }
+        else if (editIdIsKeyswitchUsed(id)) {
+            updateKeyswitchUsed(keyswitchUsedForEditId(id), v.to_float() != 0);
+        }
+        else if (editIdIsKeyswitchLabel(id)) {
+            updateSWLastLabel(keyswitchLabelForEditId(id), v.to_string().c_str());
+        }
+        else if (editIdIsCCUsed(id)) {
+            updateCCUsed(ccUsedForEditId(id), v.to_float() != 0);
+        }
+        else if (editIdIsCCDefault(id)) {
+            updateCCDefaultValue(ccDefaultForEditId(id), v.to_float());
+        }
+        else if (editIdIsCCLabel(id)) {
+            updateCCLabel(ccLabelForEditId(id), v.to_string().c_str());
         }
         break;
     }
@@ -1517,6 +1539,13 @@ void Editor::Impl::updateKeyUsed(unsigned key, bool used)
 {
     if (SPiano* piano = piano_)
         piano->setKeyUsed(key, used);
+}
+
+void Editor::Impl::updateKeyLabel(unsigned key, const char* label)
+{
+    // TODO nothing done with this info currently
+    (void)key;
+    (void)label;
 }
 
 void Editor::Impl::updateKeyswitchUsed(unsigned key, bool used)

--- a/plugins/editor/src/editor/Editor.cpp
+++ b/plugins/editor/src/editor/Editor.cpp
@@ -443,6 +443,12 @@ void Editor::Impl::uiReceiveValue(EditId id, const EditValue& v)
             setActivePanel(value);
         }
         break;
+    case EditId::BackgroundImage:
+        {
+            const std::string& value = v.to_string();
+            updateBackgroundImage(value.c_str());
+        }
+        break;
     default:
         if (editIdIsKey(id)) {
             const int key = keyForEditId(id);
@@ -1541,10 +1547,7 @@ void Editor::Impl::updateSWLastLabel(unsigned sw, const char* label)
 
 void Editor::Impl::updateBackgroundImage(const char* filepath)
 {
-    const fs::path sfzFilePath = fs::u8path(currentSfzFile_);
-    const fs::path sfzDirPath = sfzFilePath.parent_path();
-    const fs::path imagePath = sfzDirPath / fs::u8path(filepath);
-    SharedPointer<CBitmap> bitmap = loadAnyFormatImage(imagePath);
+    SharedPointer<CBitmap> bitmap = loadAnyFormatImage(filepath);
 
     if (!bitmap)
         bitmap = owned(new CBitmap("background.png"));

--- a/plugins/editor/src/editor/Editor.cpp
+++ b/plugins/editor/src/editor/Editor.cpp
@@ -554,6 +554,9 @@ void Editor::Impl::uiReceiveMessage(const char* path, const char* sig, const sfi
     else if (Messages::matchOSC("/sw/last/current", path, indices) && !strcmp(sig, "i")) {
         updateSWLastCurrent(args[0].i);
     }
+    else if (Messages::matchOSC("/sw/last/current", path, indices) && !strcmp(sig, "N")) {
+        updateSWLastCurrent(-1);
+    }
     else if (Messages::matchOSC("/sw/last/&/label", path, indices) && !strcmp(sig, "s")) {
         updateSWLastLabel(indices[0], args[0].s);
     }

--- a/plugins/lv2/CMakeLists.txt
+++ b/plugins/lv2/CMakeLists.txt
@@ -20,12 +20,14 @@ source_group("Turtle Files" FILES
 )
 add_library(${LV2PLUGIN_PRJ_NAME} MODULE
     ${PROJECT_NAME}.cpp
+    ${PROJECT_NAME}_lv2_common.cpp
     ${LV2PLUGIN_TTL_SRC_FILES})
 target_link_libraries(${LV2PLUGIN_PRJ_NAME} PRIVATE sfizz::sfizz sfizz::import sfizz::plugins-common)
 
 if(SFIZZ_LV2_UI)
     add_library(${LV2PLUGIN_PRJ_NAME}_ui MODULE
         ${PROJECT_NAME}_ui.cpp
+        ${PROJECT_NAME}_lv2_common.cpp
         vstgui_helpers.h
         vstgui_helpers.cpp)
     target_link_libraries(${LV2PLUGIN_PRJ_NAME}_ui PRIVATE sfizz::editor sfizz::vstgui sfizz::plugins-common)

--- a/plugins/lv2/sfizz.cpp
+++ b/plugins/lv2/sfizz.cpp
@@ -942,6 +942,10 @@ run(LV2_Handle instance, uint32_t sample_count)
     // Render the block
     sfizz_render_block(self->synth, self->output_buffers, 2, (int)sample_count);
 
+    // Request OSC updates
+    sfizz_send_message(self->synth, self->client, 0, "/cc/changed~", "", nullptr);
+    sfizz_send_message(self->synth, self->client, 0, "/sw/last/current", "", nullptr);
+
     spin_mutex_unlock(self->synth_mutex);
 
     if (self->midnam && self->must_update_midnam.exchange(0))

--- a/plugins/lv2/sfizz_lv2.h
+++ b/plugins/lv2/sfizz_lv2.h
@@ -6,6 +6,27 @@
 
 #pragma once
 
+#include <lv2/atom/atom.h>
+#include <lv2/atom/forge.h>
+#include <lv2/atom/util.h>
+#include <lv2/buf-size/buf-size.h>
+#include <lv2/core/lv2.h>
+#include <lv2/core/lv2_util.h>
+#include <lv2/midi/midi.h>
+#include <lv2/options/options.h>
+#include <lv2/parameters/parameters.h>
+#include <lv2/patch/patch.h>
+#include <lv2/state/state.h>
+#include <lv2/urid/urid.h>
+#include <lv2/worker/worker.h>
+#include <lv2/log/logger.h>
+#include <lv2/log/log.h>
+#include <lv2/time/time.h>
+
+#include <ardour/lv2_extensions.h>
+
+#include <stdint.h>
+
 #define MAX_PATH_SIZE 1024
 #define ATOM_TEMP_SIZE 8192
 #define OSC_TEMP_SIZE 8192
@@ -45,3 +66,22 @@ enum
     SFIZZ_NUM_REGIONS = 16,
     SFIZZ_NUM_SAMPLES = 17,
 };
+
+// For use with instance-access
+struct sfizz_plugin_t;
+
+/**
+ * @brief Fetch a copy of the current description, if more recent than what the
+ *        version we already have.
+ *
+ * @param self     The LV2 plugin
+ * @param serial   The optional serial number to compare against
+ * @param desc     The memory zone which receives the copy
+ * @param sizep    The memory zone which receives the size
+ * @param serialp  The memory zone which receives the new serial
+ * @return if serial is not null and its value isn't older, false
+ *         otherwise, true, and the pointer returned in descp must be freed with delete[] after use
+ */
+bool sfizz_lv2_fetch_description(
+    sfizz_plugin_t *self, const int *serial,
+    uint8_t **descp, uint32_t *sizep, int *serialp);

--- a/plugins/lv2/sfizz_lv2_common.cpp
+++ b/plugins/lv2/sfizz_lv2_common.cpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#include "sfizz_lv2.h"
+#include "sfizz_lv2_plugin.h"
+
+bool sfizz_lv2_fetch_description(
+    sfizz_plugin_t *self, const int *serial,
+    uint8_t **descp, uint32_t *sizep, int *serialp)
+{
+    // must be thread-safe
+
+    if (serial && self->sfz_blob_serial == *serial)
+        return false;
+
+    self->sfz_blob_mutex->lock();
+    uint32_t size = self->sfz_blob_size;
+    uint8_t *data = new uint8_t[size];
+    int new_serial = self->sfz_blob_serial;
+    memcpy(data, self->sfz_blob_data, size);
+    self->sfz_blob_mutex->unlock();
+
+    *descp = data;
+    *sizep = size;
+    *serialp = new_serial;
+
+    return true;
+}

--- a/plugins/lv2/sfizz_lv2_plugin.h
+++ b/plugins/lv2/sfizz_lv2_plugin.h
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#pragma once
+
+#include "sfizz_lv2.h"
+#include <spin_mutex.h>
+#include <sfizz.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <atomic>
+#include <mutex>
+
+#define DEFAULT_SCALA_FILE  "Contents/Resources/DefaultScale.scl"
+#define DEFAULT_SFZ_FILE    "Contents/Resources/DefaultInstrument.sfz"
+// This assumes that the longest path is the default sfz file; if not, change it
+#define MAX_BUNDLE_PATH_SIZE (MAX_PATH_SIZE - sizeof(DEFAULT_SFZ_FILE))
+
+struct sfizz_plugin_t
+{
+    // Features
+    LV2_URID_Map *map {};
+    LV2_URID_Unmap *unmap {};
+    LV2_Worker_Schedule *worker {};
+    LV2_Log_Log *log {};
+    LV2_Midnam *midnam {};
+
+    // Ports
+    const LV2_Atom_Sequence *control_port {};
+    LV2_Atom_Sequence *notify_port {};
+    float *output_buffers[2] {};
+    const float *volume_port {};
+    const float *polyphony_port {};
+    const float *oversampling_port {};
+    const float *preload_port {};
+    const float *freewheel_port {};
+    const float *scala_root_key_port {};
+    const float *tuning_frequency_port {};
+    const float *stretch_tuning_port {};
+    float *active_voices_port {};
+    float *num_curves_port {};
+    float *num_masters_port {};
+    float *num_groups_port {};
+    float *num_regions_port {};
+    float *num_samples_port {};
+
+    // Atom forge
+    LV2_Atom_Forge forge {};              ///< Forge for writing atoms in run thread
+    LV2_Atom_Forge forge_secondary {};    ///< Forge for writing into other buffers
+
+    // Logger
+    LV2_Log_Logger logger {};
+
+    // URIs
+    LV2_URID midi_event_uri {};
+    LV2_URID options_interface_uri {};
+    LV2_URID max_block_length_uri {};
+    LV2_URID nominal_block_length_uri {};
+    LV2_URID sample_rate_uri {};
+    LV2_URID atom_object_uri {};
+    LV2_URID atom_blank_uri {};
+    LV2_URID atom_float_uri {};
+    LV2_URID atom_double_uri {};
+    LV2_URID atom_int_uri {};
+    LV2_URID atom_long_uri {};
+    LV2_URID atom_urid_uri {};
+    LV2_URID atom_path_uri {};
+    LV2_URID patch_set_uri {};
+    LV2_URID patch_get_uri {};
+    LV2_URID patch_put_uri {};
+    LV2_URID patch_property_uri {};
+    LV2_URID patch_value_uri {};
+    LV2_URID patch_body_uri {};
+    LV2_URID state_changed_uri {};
+    LV2_URID sfizz_sfz_file_uri {};
+    LV2_URID sfizz_scala_file_uri {};
+    LV2_URID sfizz_num_voices_uri {};
+    LV2_URID sfizz_preload_size_uri {};
+    LV2_URID sfizz_oversampling_uri {};
+    LV2_URID sfizz_log_status_uri {};
+    LV2_URID sfizz_check_modification_uri {};
+    LV2_URID sfizz_active_voices_uri {};
+    LV2_URID sfizz_osc_blob_uri {};
+    LV2_URID time_position_uri {};
+    LV2_URID time_bar_uri {};
+    LV2_URID time_bar_beat_uri {};
+    LV2_URID time_beat_unit_uri {};
+    LV2_URID time_beats_per_bar_uri {};
+    LV2_URID time_beats_per_minute_uri {};
+    LV2_URID time_speed_uri {};
+
+    // Sfizz related data
+    sfizz_synth_t *synth {};
+    sfizz_client_t *client {};
+    spin_mutex_t *synth_mutex {};
+    bool expect_nominal_block_length {};
+    char sfz_file_path[MAX_PATH_SIZE] {};
+    char scala_file_path[MAX_PATH_SIZE] {};
+    int num_voices {};
+    unsigned int preload_size {};
+    sfizz_oversampling_factor_t oversampling {};
+    float stretch_tuning {};
+    volatile bool check_modification {};
+    int max_block_size {};
+    int sample_counter {};
+    float sample_rate {};
+    std::atomic<int> must_update_midnam {};
+
+    // Current instrument description
+    std::mutex *sfz_blob_mutex {};
+    volatile int sfz_blob_serial {};
+    const uint8_t *volatile sfz_blob_data {};
+    volatile uint32_t sfz_blob_size {};
+
+    // Timing data
+    int bar {};
+    double bar_beat {};
+    int beats_per_bar {};
+    int beat_unit {};
+    double bpm_tempo {};
+    double speed {};
+
+    // Paths
+    char bundle_path[MAX_BUNDLE_PATH_SIZE] {};
+
+    // OSC
+    uint8_t osc_temp[OSC_TEMP_SIZE] {};
+};

--- a/plugins/lv2/sfizz_ui.cpp
+++ b/plugins/lv2/sfizz_ui.cpp
@@ -46,6 +46,7 @@
 #include <lv2/patch/patch.h>
 #include <lv2/urid/urid.h>
 #include <lv2/instance-access/instance-access.h>
+#include <ghc/fs_std.hpp>
 #include <string>
 #include <memory>
 #include <cstring>
@@ -378,6 +379,10 @@ sfizz_ui_update_description(sfizz_ui_t *self, const InstrumentDescription& desc)
     self->uiReceiveValue(EditId::UINumGroups, desc.numGroups);
     self->uiReceiveValue(EditId::UINumRegions, desc.numRegions);
     self->uiReceiveValue(EditId::UINumPreloadedSamples, desc.numSamples);
+
+    const fs::path rootPath = fs::u8path(desc.rootPath);
+    const fs::path imagePath = rootPath / fs::u8path(desc.image);
+    self->uiReceiveValue(EditId::BackgroundImage, imagePath.u8string());
 
     for (unsigned key = 0; key < 128; ++key) {
         bool keyUsed = desc.keyUsed.test(key);

--- a/plugins/lv2/sfizz_ui.ttl.in
+++ b/plugins/lv2/sfizz_ui.ttl.in
@@ -11,4 +11,5 @@
     lv2:optionalFeature ui:parent ;
     lv2:optionalFeature ui:touch ;
     lv2:requiredFeature urid:map ;
-    lv2:requiredFeature urid:unmap .
+    lv2:requiredFeature urid:unmap ;
+    lv2:requiredFeature <http://lv2plug.in/ns/ext/instance-access> .

--- a/plugins/vst/SfizzVstController.h
+++ b/plugins/vst/SfizzVstController.h
@@ -48,6 +48,7 @@ protected:
     Steinberg::IPtr<OSCUpdate> oscUpdate_;
     Steinberg::IPtr<NoteUpdate> noteUpdate_;
     Steinberg::IPtr<SfzUpdate> sfzUpdate_;
+    Steinberg::IPtr<SfzDescriptionUpdate> sfzDescriptionUpdate_;
     Steinberg::IPtr<ScalaUpdate> scalaUpdate_;
     Steinberg::IPtr<ProcessorStateUpdate> processorStateUpdate_;
     Steinberg::IPtr<PlayStateUpdate> playStateUpdate_;

--- a/plugins/vst/SfizzVstController.h
+++ b/plugins/vst/SfizzVstController.h
@@ -47,8 +47,8 @@ public:
 protected:
     Steinberg::IPtr<OSCUpdate> oscUpdate_;
     Steinberg::IPtr<NoteUpdate> noteUpdate_;
-    Steinberg::IPtr<FilePathUpdate> sfzPathUpdate_;
-    Steinberg::IPtr<FilePathUpdate> scalaPathUpdate_;
+    Steinberg::IPtr<SfzUpdate> sfzUpdate_;
+    Steinberg::IPtr<ScalaUpdate> scalaUpdate_;
     Steinberg::IPtr<ProcessorStateUpdate> processorStateUpdate_;
     Steinberg::IPtr<PlayStateUpdate> playStateUpdate_;
     Vst::ParamID midiMapping_[Vst::kCountCtrlNumber] {};

--- a/plugins/vst/SfizzVstEditor.cpp
+++ b/plugins/vst/SfizzVstEditor.cpp
@@ -206,20 +206,20 @@ void PLUGIN_API SfizzVstEditor::update(FUnknown* changedUnknown, int32 message)
         for (unsigned key = 0; key < 128; ++key) {
             bool keyUsed = desc.keyUsed.test(key);
             bool keyswitchUsed = desc.keyswitchUsed.test(key);
-            uiReceiveValue(editIdForKeyUsed(key), float(keyUsed));
-            uiReceiveValue(editIdForKeyswitchUsed(key), float(keyswitchUsed));
+            uiReceiveValue(editIdForKeyUsed(int(key)), float(keyUsed));
+            uiReceiveValue(editIdForKeyswitchUsed(int(key)), float(keyswitchUsed));
             if (keyUsed)
-                uiReceiveValue(editIdForKeyLabel(key), desc.keyLabel[key]);
+                uiReceiveValue(editIdForKeyLabel(int(key)), desc.keyLabel[key]);
             if (keyswitchUsed)
-                uiReceiveValue(editIdForKeyswitchLabel(key), desc.keyswitchLabel[key]);
+                uiReceiveValue(editIdForKeyswitchLabel(int(key)), desc.keyswitchLabel[key]);
         }
 
         for (unsigned cc = 0; cc < sfz::config::numCCs; ++cc) {
             bool ccUsed = desc.ccUsed.test(cc);
-            uiReceiveValue(editIdForCCUsed(cc), float(ccUsed));
+            uiReceiveValue(editIdForCCUsed(int(cc)), float(ccUsed));
             if (ccUsed) {
-                uiReceiveValue(editIdForCCDefault(cc), desc.ccDefault[cc]);
-                uiReceiveValue(editIdForCCLabel(cc), desc.ccLabel[cc]);
+                uiReceiveValue(editIdForCCDefault(int(cc)), desc.ccDefault[cc]);
+                uiReceiveValue(editIdForCCLabel(int(cc)), desc.ccLabel[cc]);
             }
         }
     }

--- a/plugins/vst/SfizzVstEditor.cpp
+++ b/plugins/vst/SfizzVstEditor.cpp
@@ -188,17 +188,14 @@ void PLUGIN_API SfizzVstEditor::update(FUnknown* changedUnknown, int32 message)
         }
     }
 
-    if (FilePathUpdate* update = FCast<FilePathUpdate>(changedUnknown)) {
+    if (SfzUpdate* update = FCast<SfzUpdate>(changedUnknown)) {
         const std::string path = update->getPath();
-        switch (update->getType()) {
-        case kFilePathUpdateSfz:
-            uiReceiveValue(EditId::SfzFile, path);
-            break;
-        case kFilePathUpdateScala:
-            uiReceiveValue(EditId::ScalaFile, path);
-            break;
-        }
-        return;
+        uiReceiveValue(EditId::SfzFile, path);
+    }
+
+    if (ScalaUpdate* update = FCast<ScalaUpdate>(changedUnknown)) {
+        const std::string path = update->getPath();
+        uiReceiveValue(EditId::ScalaFile, path);
     }
 
     if (ProcessorStateUpdate* update = FCast<ProcessorStateUpdate>(changedUnknown)) {

--- a/plugins/vst/SfizzVstEditor.cpp
+++ b/plugins/vst/SfizzVstEditor.cpp
@@ -244,11 +244,6 @@ void PLUGIN_API SfizzVstEditor::update(FUnknown* changedUnknown, int32 message)
 
     if (PlayStateUpdate* update = FCast<PlayStateUpdate>(changedUnknown)) {
         const SfizzPlayState playState = update->getState();
-        uiReceiveValue(EditId::UINumCurves, playState.curves);
-        uiReceiveValue(EditId::UINumMasters, playState.masters);
-        uiReceiveValue(EditId::UINumGroups, playState.groups);
-        uiReceiveValue(EditId::UINumRegions, playState.regions);
-        uiReceiveValue(EditId::UINumPreloadedSamples, playState.preloadedSamples);
         uiReceiveValue(EditId::UINumActiveVoices, playState.activeVoices);
         return;
     }

--- a/plugins/vst/SfizzVstEditor.cpp
+++ b/plugins/vst/SfizzVstEditor.cpp
@@ -196,7 +196,32 @@ void PLUGIN_API SfizzVstEditor::update(FUnknown* changedUnknown, int32 message)
 
     if (SfzDescriptionUpdate* update = FCast<SfzDescriptionUpdate>(changedUnknown)) {
         const InstrumentDescription desc = parseDescriptionBlob(update->getDescription());
-        // TODO(jpc) instrument description
+
+        uiReceiveValue(EditId::UINumCurves, desc.numCurves);
+        uiReceiveValue(EditId::UINumMasters, desc.numMasters);
+        uiReceiveValue(EditId::UINumGroups, desc.numGroups);
+        uiReceiveValue(EditId::UINumRegions, desc.numRegions);
+        uiReceiveValue(EditId::UINumPreloadedSamples, desc.numSamples);
+
+        for (unsigned key = 0; key < 128; ++key) {
+            bool keyUsed = desc.keyUsed.test(key);
+            bool keyswitchUsed = desc.keyswitchUsed.test(key);
+            uiReceiveValue(editIdForKeyUsed(key), float(keyUsed));
+            uiReceiveValue(editIdForKeyswitchUsed(key), float(keyswitchUsed));
+            if (keyUsed)
+                uiReceiveValue(editIdForKeyLabel(key), desc.keyLabel[key]);
+            if (keyswitchUsed)
+                uiReceiveValue(editIdForKeyswitchLabel(key), desc.keyswitchLabel[key]);
+        }
+
+        for (unsigned cc = 0; cc < sfz::config::numCCs; ++cc) {
+            bool ccUsed = desc.ccUsed.test(cc);
+            uiReceiveValue(editIdForCCUsed(cc), float(ccUsed));
+            if (ccUsed) {
+                uiReceiveValue(editIdForCCDefault(cc), desc.ccDefault[cc]);
+                uiReceiveValue(editIdForCCLabel(cc), desc.ccLabel[cc]);
+            }
+        }
     }
 
     if (ScalaUpdate* update = FCast<ScalaUpdate>(changedUnknown)) {

--- a/plugins/vst/SfizzVstEditor.cpp
+++ b/plugins/vst/SfizzVstEditor.cpp
@@ -11,6 +11,7 @@
 #include "SfizzFileScan.h"
 #include "editor/Editor.h"
 #include "editor/EditIds.h"
+#include "plugin/InstrumentDescription.h"
 #include "IdleUpdateHandler.h"
 #if !defined(__APPLE__) && !defined(_WIN32)
 #include "X11RunLoop.h"
@@ -191,6 +192,11 @@ void PLUGIN_API SfizzVstEditor::update(FUnknown* changedUnknown, int32 message)
     if (SfzUpdate* update = FCast<SfzUpdate>(changedUnknown)) {
         const std::string path = update->getPath();
         uiReceiveValue(EditId::SfzFile, path);
+    }
+
+    if (SfzDescriptionUpdate* update = FCast<SfzDescriptionUpdate>(changedUnknown)) {
+        const InstrumentDescription desc = parseDescriptionBlob(update->getDescription());
+        // TODO(jpc) instrument description
     }
 
     if (ScalaUpdate* update = FCast<ScalaUpdate>(changedUnknown)) {

--- a/plugins/vst/SfizzVstEditor.cpp
+++ b/plugins/vst/SfizzVstEditor.cpp
@@ -16,6 +16,7 @@
 #if !defined(__APPLE__) && !defined(_WIN32)
 #include "X11RunLoop.h"
 #endif
+#include <ghc/fs_std.hpp>
 
 using namespace VSTGUI;
 
@@ -202,6 +203,10 @@ void PLUGIN_API SfizzVstEditor::update(FUnknown* changedUnknown, int32 message)
         uiReceiveValue(EditId::UINumGroups, desc.numGroups);
         uiReceiveValue(EditId::UINumRegions, desc.numRegions);
         uiReceiveValue(EditId::UINumPreloadedSamples, desc.numSamples);
+
+        const fs::path rootPath = fs::u8path(desc.rootPath);
+        const fs::path imagePath = rootPath / fs::u8path(desc.image);
+        uiReceiveValue(EditId::BackgroundImage, imagePath.u8string());
 
         for (unsigned key = 0; key < 128; ++key) {
             bool keyUsed = desc.keyUsed.test(key);

--- a/plugins/vst/SfizzVstProcessor.cpp
+++ b/plugins/vst/SfizzVstProcessor.cpp
@@ -295,11 +295,6 @@ tresult PLUGIN_API SfizzVstProcessor::process(Vst::ProcessData& data)
     if (_playStateChangeCounter > _playStateChangePeriod) {
         _playStateChangeCounter %= _playStateChangePeriod;
         SfizzPlayState playState {};
-        playState.curves = synth.getNumCurves();
-        playState.masters = synth.getNumMasters();
-        playState.groups = synth.getNumGroups();
-        playState.regions = synth.getNumRegions();
-        playState.preloadedSamples = synth.getNumPreloadedSamples();
         playState.activeVoices = synth.getNumActiveVoices();
         if (writeWorkerMessage(kMsgIdNotifyPlayState, &playState, sizeof(playState)))
             _semaToWorker.post();

--- a/plugins/vst/SfizzVstProcessor.cpp
+++ b/plugins/vst/SfizzVstProcessor.cpp
@@ -286,6 +286,11 @@ tresult PLUGIN_API SfizzVstProcessor::process(Vst::ProcessData& data)
 
     synth.renderBlock(outputs, numFrames, numChannels);
 
+    // Request OSC updates
+    sfz::Client& client = *_client;
+    synth.sendMessage(client, 0, "/cc/changed~", "", nullptr);
+    synth.sendMessage(client, 0, "/sw/last/current", "", nullptr);
+
     _playStateChangeCounter += numFrames;
     if (_playStateChangeCounter > _playStateChangePeriod) {
         _playStateChangeCounter %= _playStateChangePeriod;

--- a/plugins/vst/SfizzVstProcessor.h
+++ b/plugins/vst/SfizzVstProcessor.h
@@ -26,6 +26,8 @@ public:
     tresult PLUGIN_API initialize(FUnknown* context) override;
     tresult PLUGIN_API setBusArrangements(Vst::SpeakerArrangement* inputs, int32 numIns, Vst::SpeakerArrangement* outputs, int32 numOuts) override;
 
+    tresult PLUGIN_API connect(IConnectionPoint* other) override;
+
     tresult PLUGIN_API setState(IBStream* stream) override;
     tresult PLUGIN_API getState(IBStream* stream) override;
     void syncStateToSynth();
@@ -49,6 +51,7 @@ public:
 private:
     // synth state. acquire processMutex before accessing
     std::unique_ptr<sfz::Sfizz> _synth;
+    Steinberg::IPtr<Vst::IMessage> _loadedSfzMessage;
     bool _isActive = false;
     SfizzVstState _state;
     float _currentStretchedTuning = 0;
@@ -59,7 +62,7 @@ private:
     void receiveMessage(int delay, const char* path, const char* sig, const sfizz_arg_t* args);
 
     // misc
-    static void loadSfzFileOrDefault(sfz::Sfizz& synth, const std::string& filePath);
+    void loadSfzFileOrDefault(const std::string& filePath);
 
     // note event tracking
     std::array<float, 128> _noteEventsCurrentCycle; // 0: off, >0: on, <0: no change

--- a/plugins/vst/SfizzVstProcessor.h
+++ b/plugins/vst/SfizzVstProcessor.h
@@ -75,10 +75,6 @@ private:
     Ring_Buffer _fifoMessageFromUi;
     SpinMutex _processMutex;
 
-    // state notification periodic timer
-    uint32 _playStateChangeCounter = 0;
-    uint32 _playStateChangePeriod = 0;
-
     // time info
     int _timeSigNumerator = 0;
     int _timeSigDenominator = 0;
@@ -98,7 +94,7 @@ private:
 
     // worker
     void doBackgroundWork();
-    void doBackgroundIdle();
+    void doBackgroundIdle(size_t idleCounter);
     void startBackgroundWork();
     void stopBackgroundWork();
     // writer

--- a/plugins/vst/SfizzVstState.h
+++ b/plugins/vst/SfizzVstState.h
@@ -31,10 +31,5 @@ public:
 };
 
 struct SfizzPlayState {
-    uint32 curves;
-    uint32 masters;
-    uint32 groups;
-    uint32 regions;
-    uint32 preloadedSamples;
     uint32 activeVoices;
 };

--- a/plugins/vst/SfizzVstUpdates.h
+++ b/plugins/vst/SfizzVstUpdates.h
@@ -67,21 +67,42 @@ private:
 };
 
 /**
- * @brief Update which notifies a change of file path pseudo-parameter
- * The message ID is used to indicate which path it is.
+ * @brief Update which notifies a change of SFZ file.
  */
-class FilePathUpdate : public Steinberg::FObject {
+class SfzUpdate : public Steinberg::FObject {
 public:
-    explicit FilePathUpdate(int32 type)
-        : type_(type)
+    void setPath(std::string newPath, std::string newDescription)
     {
+        std::lock_guard<std::mutex> lock(mutex_);
+        path_ = std::move(newPath);
+        description_ = std::move(newDescription);
     }
 
-    int32 getType() const noexcept
+    std::string getPath() const
     {
-        return type_;
+        std::lock_guard<std::mutex> lock(mutex_);
+        return path_;
     }
 
+    std::string getDescription() const
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return description_;
+    }
+
+    OBJ_METHODS(SfzUpdate, FObject)
+
+private:
+    std::string path_;
+    std::string description_;
+    mutable std::mutex mutex_;
+};
+
+/**
+ * @brief Update which notifies a change of scala file.
+ */
+class ScalaUpdate : public Steinberg::FObject {
+public:
     void setPath(std::string newPath)
     {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -94,17 +115,11 @@ public:
         return path_;
     }
 
-    OBJ_METHODS(FilePathUpdate, FObject)
+    OBJ_METHODS(ScalaUpdate, FObject)
 
 private:
-    int32 type_ {};
     std::string path_;
     mutable std::mutex mutex_;
-};
-
-enum {
-    kFilePathUpdateSfz,
-    kFilePathUpdateScala,
 };
 
 /**

--- a/plugins/vst/SfizzVstUpdates.h
+++ b/plugins/vst/SfizzVstUpdates.h
@@ -71,11 +71,10 @@ private:
  */
 class SfzUpdate : public Steinberg::FObject {
 public:
-    void setPath(std::string newPath, std::string newDescription)
+    void setPath(std::string newPath)
     {
         std::lock_guard<std::mutex> lock(mutex_);
         path_ = std::move(newPath);
-        description_ = std::move(newDescription);
     }
 
     std::string getPath() const
@@ -84,16 +83,33 @@ public:
         return path_;
     }
 
+    OBJ_METHODS(SfzUpdate, FObject)
+
+private:
+    std::string path_;
+    mutable std::mutex mutex_;
+};
+
+/**
+ * @brief Update which notifies a change of SFZ description.
+ */
+class SfzDescriptionUpdate : public Steinberg::FObject {
+public:
+    void setDescription(std::string newDescription)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        description_ = std::move(newDescription);
+    }
+
     std::string getDescription() const
     {
         std::lock_guard<std::mutex> lock(mutex_);
         return description_;
     }
 
-    OBJ_METHODS(SfzUpdate, FObject)
+    OBJ_METHODS(SfzDescriptionUpdate, FObject)
 
 private:
-    std::string path_;
     std::string description_;
     mutable std::mutex mutex_;
 };

--- a/scripts/run_clang_tidy.sh
+++ b/scripts/run_clang_tidy.sh
@@ -30,6 +30,6 @@ clang-tidy \
   -- -Iexternal/abseil-cpp -Iexternal/jsl/include -Iexternal/filesystem/include -Iexternal/atomic_queue/include -Iexternal/threadpool -Isrc/external/hiir -Isrc/external/pugixml/src \
      -Iexternal/st_audiofile/src -Iexternal/st_audiofile/thirdparty/dr_libs \
       -Isrc/sfizz -Isrc -Isrc/sfizz/utility/bit_array -Isrc/sfizz/utility/spin_mutex -Isrc/external/spline -Isrc/external/cpuid/src -Iexternal/simde \
-      -Iplugins/vst -Iplugins/vst/external/VST_SDK/VST3_SDK -Iplugins/editor/external/vstgui4 -Iplugins/vst/external/ring_buffer \
+      -Iplugins/common -Iplugins/vst -Iplugins/vst/external/VST_SDK/VST3_SDK -Iplugins/editor/external/vstgui4 -Iplugins/vst/external/ring_buffer \
       -Iplugins/editor/src \
       -DNDEBUG -std=c++17

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -249,7 +249,6 @@ void Synth::Impl::clear()
     numGroups_ = 0;
     numMasters_ = 0;
     currentSwitch_ = absl::nullopt;
-    currentSwitchChanged_ = true;
     defaultPath_ = "";
     image_ = "";
     resources_.midiState.reset();
@@ -791,8 +790,6 @@ void Synth::Impl::finalizeSfzLoad()
                 swLastSlots_.set(key);
         }
     }
-    // resend current keyswitch
-    currentSwitchChanged_ = true;
 }
 
 bool Synth::loadScalaFile(const fs::path& path)
@@ -1018,26 +1015,9 @@ void Synth::renderBlock(AudioSpan<float> buffer) noexcept
     // Advance the clock to the end of cycle
     bc.endCycle();
 
-    // Send the set of changed CCs
-    Client broadcaster = impl.getBroadcaster();
-    const BitArray<config::numCCs>& changedCCs = impl.changedCCsThisCycle_;
-    const int finalFrameNumber = int(numFrames - 1);
-    if (broadcaster.canReceive()) {
-            sfizz_blob_t blob { changedCCs.data(), static_cast<uint32_t>(changedCCs.byte_size()) };
-            broadcaster.receive<'b'>(finalFrameNumber, "/cc/changed", &blob);
-    }
+    // Update sets of changed CCs
     impl.changedCCsLastCycle_ = impl.changedCCsThisCycle_;
     impl.changedCCsThisCycle_.clear();
-    // Send the changed keyswitch
-    if (impl.currentSwitchChanged_) {
-        if (broadcaster.canReceive()) {
-            int32_t value = -1;
-            if (impl.currentSwitch_)
-                value = *impl.currentSwitch_;
-            broadcaster.receive<'i'>(finalFrameNumber, "/sw/last/current", value);
-        }
-        impl.currentSwitchChanged_ = false;
-    }
 
     { // Clear events and advance midi time
         ScopedTiming logger { impl.dispatchDuration_, ScopedTiming::Operation::addToDuration };
@@ -1137,7 +1117,6 @@ void Synth::Impl::noteOnDispatch(int delay, int noteNumber, float velocity) noex
                 layer->keySwitched_ = false;
         }
         currentSwitch_ = noteNumber;
-        currentSwitchChanged_ = true;
     }
 
     for (Layer* layer : lastKeyswitchLists_[noteNumber])

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -246,6 +246,7 @@ void Synth::Impl::clear()
     effectBuses_[0]->setSampleRate(sampleRate_);
     effectBuses_[0]->clearInputs(samplesPerBlock_);
     resources_.clear();
+    rootPath_.clear();
     numGroups_ = 0;
     numMasters_ = 0;
     currentSwitch_ = absl::nullopt;
@@ -547,7 +548,11 @@ bool Synth::loadSfzString(const fs::path& path, absl::string_view text)
 
 void Synth::Impl::finalizeSfzLoad()
 {
-    resources_.filePool.setRootDirectory(parser_.originalDirectory());
+    const fs::path& rootDirectory = parser_.originalDirectory();
+    resources_.filePool.setRootDirectory(rootDirectory);
+
+    // a string representation used for OSC purposes
+    rootPath_ = rootDirectory.u8string();
 
     size_t currentRegionIndex = 0;
     size_t currentRegionCount = layers_.size();

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -258,6 +258,7 @@ void Synth::Impl::clear()
     clearCCLabels();
     currentUsedCCs_.clear();
     changedCCsThisCycle_.clear();
+    changedCCsLastCycle_.clear();
     clearKeyLabels();
     keySlots_.clear();
     swLastSlots_.clear();
@@ -1025,6 +1026,7 @@ void Synth::renderBlock(AudioSpan<float> buffer) noexcept
             sfizz_blob_t blob { changedCCs.data(), static_cast<uint32_t>(changedCCs.byte_size()) };
             broadcaster.receive<'b'>(finalFrameNumber, "/cc/changed", &blob);
     }
+    impl.changedCCsLastCycle_ = impl.changedCCsThisCycle_;
     impl.changedCCsThisCycle_.clear();
     // Send the changed keyswitch
     if (impl.currentSwitchChanged_) {

--- a/src/sfizz/SynthMessaging.cpp
+++ b/src/sfizz/SynthMessaging.cpp
@@ -45,7 +45,7 @@ void sfz::Synth::dispatchMessage(Client& client, int delay, const char* path, co
             client.receive<'b'>(delay, path, &blob);
         } break;
 
-        MATCH("/key%d/label", "") {
+        MATCH("/key&/label", "") {
             if (indices[0] >= 128)
                 break;
             const std::string* label = impl.getKeyLabel(indices[0]);

--- a/src/sfizz/SynthMessaging.cpp
+++ b/src/sfizz/SynthMessaging.cpp
@@ -39,6 +39,28 @@ void sfz::Synth::dispatchMessage(Client& client, int delay, const char* path, co
 
         //----------------------------------------------------------------------
 
+        MATCH("/num_regions", "") {
+            client.receive<'i'>(delay, path, int(impl.layers_.size()));
+        } break;
+
+        MATCH("/num_groups", "") {
+            client.receive<'i'>(delay, path, impl.numGroups_);
+        } break;
+
+        MATCH("/num_masters", "") {
+            client.receive<'i'>(delay, path, impl.numMasters_);
+        } break;
+
+        MATCH("/num_curves", "") {
+            client.receive<'i'>(delay, path, int(impl.resources_.curves.getNumCurves()));
+        } break;
+
+        MATCH("/num_samples", "") {
+            client.receive<'i'>(delay, path, int(impl.resources_.filePool.getNumPreloadedSamples()));
+        } break;
+
+        //----------------------------------------------------------------------
+
         MATCH("/key/slots", "") {
             const BitArray<128>& keys = impl.keySlots_;
             sfizz_blob_t blob { keys.data(), static_cast<uint32_t>(keys.byte_size()) };

--- a/src/sfizz/SynthMessaging.cpp
+++ b/src/sfizz/SynthMessaging.cpp
@@ -87,10 +87,10 @@ void sfz::Synth::dispatchMessage(Client& client, int delay, const char* path, co
         } break;
 
         MATCH("/sw/last/current", "") {
-            int32_t value = -1;
             if (impl.currentSwitch_)
-                value = *impl.currentSwitch_;
-            client.receive<'i'>(delay, path, value);
+                client.receive<'i'>(delay, path, *impl.currentSwitch_);
+            else
+                client.receive<'N'>(delay, path, {});
         } break;
 
         MATCH("/sw/last/&/label", "") {

--- a/src/sfizz/SynthMessaging.cpp
+++ b/src/sfizz/SynthMessaging.cpp
@@ -134,6 +134,18 @@ void sfz::Synth::dispatchMessage(Client& client, int delay, const char* path, co
             client.receive<'s'>(delay, path, label ? label->c_str() : "");
         } break;
 
+        MATCH("/cc/changed", "") {
+            const BitArray<config::numCCs>& changedCCs = impl.changedCCsThisCycle_;
+            sfizz_blob_t blob { changedCCs.data(), static_cast<uint32_t>(changedCCs.byte_size()) };
+            client.receive<'b'>(delay, path, &blob);
+        } break;
+
+        MATCH("/cc/changed~", "") {
+            const BitArray<config::numCCs>& changedCCs = impl.changedCCsLastCycle_;
+            sfizz_blob_t blob { changedCCs.data(), static_cast<uint32_t>(changedCCs.byte_size()) };
+            client.receive<'b'>(delay, path, &blob);
+        } break;
+
         //----------------------------------------------------------------------
 
         MATCH("/mem/buffers", "") {

--- a/src/sfizz/SynthMessaging.cpp
+++ b/src/sfizz/SynthMessaging.cpp
@@ -76,9 +76,15 @@ void sfz::Synth::dispatchMessage(Client& client, int delay, const char* path, co
 
         //----------------------------------------------------------------------
 
+        MATCH("/root_path", "") {
+            client.receive<'s'>(delay, path, impl.rootPath_.c_str());
+        } break;
+
         MATCH("/image", "") {
             client.receive<'s'>(delay, path, impl.image_.c_str());
         } break;
+
+        //----------------------------------------------------------------------
 
         MATCH("/sw/last/slots", "") {
             const BitArray<128>& switches = impl.swLastSlots_;

--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -240,7 +240,6 @@ struct Synth::Impl final: public Parser::Listener {
 
     // Set as sw_default if present in the file
     absl::optional<uint8_t> currentSwitch_;
-    bool currentSwitchChanged_ = true;
     std::vector<std::string> unknownOpcodes_;
     using RegionViewVector = std::vector<Region*>;
     using LayerViewVector = std::vector<Layer*>;

--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -315,6 +315,7 @@ struct Synth::Impl final: public Parser::Listener {
     std::array<float, config::numCCs> defaultCCValues_;
     BitArray<config::numCCs> currentUsedCCs_;
     BitArray<config::numCCs> changedCCsThisCycle_;
+    BitArray<config::numCCs> changedCCsLastCycle_;
 
     // Messaging
     sfizz_receive_t* broadcastReceiver = nullptr;

--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -278,6 +278,9 @@ struct Synth::Impl final: public Parser::Listener {
     // Singletons passed as references to the voices
     Resources resources_;
 
+    // Root path
+    std::string rootPath_;
+
     // Control opcodes
     std::string defaultPath_ { "" };
     std::string image_ { "" };


### PR DESCRIPTION
This work communicates all static info of the current SFZ file to plugin editors, in a single large message.
The message is serialized as a sequence of OSC replies.
The helpers allow to work easily with this message blob and display content.

Note: received but not handled, this will be in next work

Benefits
- does not need to be communicated over the OSC, so this info can be updated while plugin is not running
- makes the FIFO less busy

Note(LV2): this work enables instance-access;
the editor will check in the idle callback that a serial number of the sfz loader matches the latest check, and if not, it will pull an updated description of SFZ.
Some reorganization of LV2 is needed, because UI must compile a function which accesses into `sfizz_plugin_t`.