### PR TITLE
Make a variable SFIZZ_NUM_CCS available to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ option_ex (SFIZZ_USE_SYSTEM_SIMDE  "Use SIMDe libraries preinstalled on system" 
 option_ex (SFIZZ_STATIC_DEPENDENCIES "Link dependencies statically" OFF)
 option_ex (SFIZZ_RELEASE_ASSERTS   "Forced assertions in release builds" OFF)
 
+# The fixed number of controller parameters
+set(SFIZZ_NUM_CCS 512)
+
 include (SfizzConfig)
 include (SfizzDeps)
 include (SfizzFaust)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -300,6 +300,14 @@ if(SFIZZ_RELEASE_ASSERTS)
 endif()
 sfizz_enable_fast_math(sfizz_internal)
 
+# Check that sfizz and cmake-side definitions are matching
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/sfizz_match_definitions.cpp" "
+#include \"Config.h\"
+static_assert(sfz::config::numCCs == ${SFIZZ_NUM_CCS}, \"SFIZZ_NUM_CCS did not match\");
+")
+add_library(sfizz_match_definitions STATIC "${CMAKE_CURRENT_BINARY_DIR}/sfizz_match_definitions.cpp")
+target_link_libraries(sfizz_match_definitions PRIVATE sfizz::internal)
+
 # Sfizz static library
 add_library(sfizz_static STATIC sfizz/sfizz_wrapper.cpp sfizz/sfizz.cpp sfizz/sfizz_private.hpp)
 add_library(sfizz::static ALIAS sfizz_static)


### PR DESCRIPTION
This allows cmake to have the number of CCs available to sfizz as a variable.
This would serve to generate the TTL for LV2 which will have all the 512 automatable parameters for each CC.
