### PR TITLE
Fix inability to save the user directory

### DIFF
--- a/plugins/vst/SfizzSettings.cpp
+++ b/plugins/vst/SfizzSettings.cpp
@@ -123,7 +123,8 @@ static const fs::path getSettingsPath()
     dirPath /= "SFZTools";
     dirPath /= "sfizz";
     std::error_code ec;
-    if (!fs::create_directories(dirPath, ec))
+    fs::create_directories(dirPath, ec);
+    if (ec)
         return {};
     return dirPath / "settings.xml";
 }


### PR DESCRIPTION
Fix misuse of the function `fs::create_directories`.
It returns false if directory already exists.