### PR TITLE
lv2: Add option to enable plugin-side CC automation

### DIFF
--- a/cmake/LV2Config.cmake
+++ b/cmake/LV2Config.cmake
@@ -1,3 +1,6 @@
+# This option is for MIDI CC support in absence of host midi:binding support
+option(SFIZZ_LV2_PSA "Enable plugin-side MIDI automations" OFF)
+
 # Configuration for this plugin
 # TODO: generate version from git
 set(LV2PLUGIN_VERSION_MINOR   6)
@@ -61,7 +64,7 @@ sfizz:cc${_i}
   rdfs:label \"Controller ${_i}\" ;
   rdfs:range atom:Float")
 
-        if(_i LESS 128)
+        if(_i LESS 128 AND NOT SFIZZ_LV2_PSA)
             math(EXPR _digit1 "${_i}>>4")
             math(EXPR _digit2 "${_i}&15")
             string(SUBSTRING "0123456789ABCDEF" "${_digit1}" 1 _digit1)

--- a/plugins/lv2/CMakeLists.txt
+++ b/plugins/lv2/CMakeLists.txt
@@ -33,6 +33,11 @@ if(SFIZZ_LV2_UI)
     target_link_libraries(${LV2PLUGIN_PRJ_NAME}_ui PRIVATE sfizz::editor sfizz::vstgui sfizz::plugins-common)
 endif()
 
+if(SFIZZ_LV2_PSA)
+    target_compile_definitions(${LV2PLUGIN_PRJ_NAME} PRIVATE "SFIZZ_LV2_PSA=1")
+    target_compile_definitions(${LV2PLUGIN_PRJ_NAME}_ui PRIVATE "SFIZZ_LV2_PSA=1")
+endif()
+
 # Explicitely strip all symbols on Linux but lv2_descriptor()
 # MacOS linker does not support this apparently https://bugs.webkit.org/show_bug.cgi?id=144555
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")


### PR DESCRIPTION
Adds cmake option `SFIZZ_LV2_PSA`, with default to OFF, which allows MIDI CC to automate the parameters.
Offers a compatibility option with the current LV2 hosts.