### PR TITLE
Editor host info

### DIFF
--- a/plugins/editor/src/editor/DlgAbout.cpp
+++ b/plugins/editor/src/editor/DlgAbout.cpp
@@ -136,6 +136,11 @@ SAboutDialog::SAboutDialog(const CRect& bounds)
     aboutView->setViewSize(aboutBounds);
 }
 
+void SAboutDialog::setPluginFormat(const std::string& pluginFormat)
+{
+    // TODO
+}
+
 CMouseEventResult SAboutDialog::onMouseDown(CPoint& where, const CButtonState& buttons)
 {
     CMouseEventResult result = CViewContainer::onMouseDown(where, buttons);

--- a/plugins/editor/src/editor/DlgAbout.cpp
+++ b/plugins/editor/src/editor/DlgAbout.cpp
@@ -141,6 +141,11 @@ void SAboutDialog::setPluginFormat(const std::string& pluginFormat)
     // TODO
 }
 
+void SAboutDialog::setPluginHost(const std::string& pluginHost)
+{
+    // TODO
+}
+
 CMouseEventResult SAboutDialog::onMouseDown(CPoint& where, const CButtonState& buttons)
 {
     CMouseEventResult result = CViewContainer::onMouseDown(where, buttons);

--- a/plugins/editor/src/editor/DlgAbout.h
+++ b/plugins/editor/src/editor/DlgAbout.h
@@ -27,6 +27,7 @@ public:
     explicit SAboutDialog(const CRect& bounds);
 
     void setPluginFormat(const std::string& pluginFormat);
+    void setPluginHost(const std::string& pluginHost);
 
 protected:
     CMouseEventResult onMouseDown(CPoint& where, const CButtonState& buttons) override;

--- a/plugins/editor/src/editor/DlgAbout.h
+++ b/plugins/editor/src/editor/DlgAbout.h
@@ -9,6 +9,7 @@
 #include "vstgui/lib/cviewcontainer.h"
 #include "vstgui/vstgui.h"
 #include "utility/vstgui_after.h"
+#include <string>
 
 using namespace VSTGUI;
 
@@ -24,6 +25,8 @@ class SAboutDialog : public CViewContainer, public IControlListener {
 
 public:
     explicit SAboutDialog(const CRect& bounds);
+
+    void setPluginFormat(const std::string& pluginFormat);
 
 protected:
     CMouseEventResult onMouseDown(CPoint& where, const CButtonState& buttons) override;

--- a/plugins/editor/src/editor/EditIds.h
+++ b/plugins/editor/src/editor/EditIds.h
@@ -47,6 +47,7 @@ enum class EditId : int {
     BackgroundImage,
     //
     PluginFormat,
+    PluginHost,
     //
     #undef KEY_RANGE
     #undef CC_RANGE

--- a/plugins/editor/src/editor/EditIds.h
+++ b/plugins/editor/src/editor/EditIds.h
@@ -46,6 +46,8 @@ enum class EditId : int {
     //
     BackgroundImage,
     //
+    PluginFormat,
+    //
     #undef KEY_RANGE
     #undef CC_RANGE
 };

--- a/plugins/editor/src/editor/Editor.cpp
+++ b/plugins/editor/src/editor/Editor.cpp
@@ -403,6 +403,9 @@ void Editor::Impl::uiReceiveValue(EditId id, const EditValue& v)
             fallbackFilesDir_ = v.to_string();
             break;
         }
+    case EditId::PluginFormat:
+        aboutDialog_->setPluginFormat(v.to_string());
+        break;
     case EditId::UINumCurves:
         {
             const int value = static_cast<int>(v.to_float());

--- a/plugins/editor/src/editor/Editor.cpp
+++ b/plugins/editor/src/editor/Editor.cpp
@@ -406,6 +406,9 @@ void Editor::Impl::uiReceiveValue(EditId id, const EditValue& v)
     case EditId::PluginFormat:
         aboutDialog_->setPluginFormat(v.to_string());
         break;
+    case EditId::PluginHost:
+        aboutDialog_->setPluginHost(v.to_string());
+        break;
     case EditId::UINumCurves:
         {
             const int value = static_cast<int>(v.to_float());

--- a/plugins/lv2/sfizz_ui.cpp
+++ b/plugins/lv2/sfizz_ui.cpp
@@ -256,6 +256,9 @@ instantiate(const LV2UI_Descriptor *descriptor,
     self->editor.reset(editor);
     editor->open(*uiFrame);
 
+    // let the editor know about plugin format
+    self->uiReceiveValue(EditId::PluginFormat, std::string("LV2"));
+
     // user files dir is not relevant to LV2 (not yet?)
     // LV2 has its own path management mechanism
     self->uiReceiveValue(EditId::CanEditUserFilesDir, 0);

--- a/plugins/vst/SfizzVstEditor.cpp
+++ b/plugins/vst/SfizzVstEditor.cpp
@@ -97,6 +97,9 @@ bool PLUGIN_API SfizzVstEditor::open(void* parent, const VSTGUI::PlatformType& p
     for (FObject* update : continuousUpdates_)
         update->deferUpdate();
 
+    // let the editor know about plugin format
+    uiReceiveValue(EditId::PluginFormat, std::string("VST3"));
+
     absl::optional<fs::path> userFilesDir = SfizzPaths::getSfzConfigDefaultPath();
     uiReceiveValue(EditId::CanEditUserFilesDir, 1);
     uiReceiveValue(EditId::UserFilesDir, userFilesDir.value_or(fs::path()).u8string());

--- a/plugins/vst/SfizzVstEditor.cpp
+++ b/plugins/vst/SfizzVstEditor.cpp
@@ -100,6 +100,12 @@ bool PLUGIN_API SfizzVstEditor::open(void* parent, const VSTGUI::PlatformType& p
     // let the editor know about plugin format
     uiReceiveValue(EditId::PluginFormat, std::string("VST3"));
 
+    if (FUnknownPtr<Vst::IHostApplication> app { controller->getHostContext() }) {
+        Vst::String128 name;
+        app->getName(name);
+        uiReceiveValue(EditId::PluginHost, std::string(Steinberg::String(name).text8()));
+    }
+
     absl::optional<fs::path> userFilesDir = SfizzPaths::getSfzConfigDefaultPath();
     uiReceiveValue(EditId::CanEditUserFilesDir, 1);
     uiReceiveValue(EditId::UserFilesDir, userFilesDir.value_or(fs::path()).u8string());


### PR DESCRIPTION
Provides the host name and plugin format to the editor, when available.
Note that AudioUnit will still indicate VST3 for format (because of wrapping)