### PR TITLE
Fix Atom port corruption in LV2

### DIFF
--- a/plugins/lv2/sfizz.cpp
+++ b/plugins/lv2/sfizz.cpp
@@ -330,7 +330,8 @@ sfizz_lv2_receive_message(void* data, int delay, const char* path, const char* s
         lv2_atom_forge_frame_time(forge, 0) &&
         lv2_atom_forge_atom(forge, osc_size, self->sfizz_osc_blob_uri) &&
         lv2_atom_forge_raw(forge, osc_temp, osc_size);
-    lv2_atom_forge_pad(forge, osc_size);
+    if (write_ok)
+        lv2_atom_forge_pad(forge, osc_size);
 
     (void)write_ok;
 }

--- a/plugins/lv2/sfizz.ttl.in
+++ b/plugins/lv2/sfizz.ttl.in
@@ -99,7 +99,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "control" ;
     lv2:name "Control",
       "Contrôle"@fr ;
-    rsz:minimumSize 65536 ;
+    rsz:minimumSize 524288 ;
   ] , [
     a lv2:OutputPort, atom:AtomPort ;
     atom:bufferType atom:Sequence ;
@@ -108,7 +108,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "notify" ;
     lv2:name "Notify",
       "Notification"@fr ;
-    rsz:minimumSize 65536 ;
+    rsz:minimumSize 524288 ;
   ] , [
     a lv2:OutputPort, atom:AtomPort ;
     atom:bufferType atom:Sequence ;
@@ -118,7 +118,7 @@ midnam:update a lv2:Feature .
     lv2:symbol "automate" ;
     lv2:name "Automate",
       "Automatisation"@fr ;
-    rsz:minimumSize 65536 ;
+    rsz:minimumSize 524288 ;
   ] , [
     a lv2:AudioPort, lv2:OutputPort ;
     lv2:index 3 ;


### PR DESCRIPTION
Protects against corruption in case of overflowing the port buffer