### PR TITLE
Make C++ standard the same for lib, plugin and editor

### DIFF
--- a/cmake/SfizzConfig.cmake
+++ b/cmake/SfizzConfig.cmake
@@ -14,6 +14,14 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 
+# Set C++ compatibility level
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC" AND CMAKE_CXX_STANDARD LESS 17)
+    set(CMAKE_CXX_STANDARD 17)
+elseif((SFIZZ_LV2_UI OR SFIZZ_VST OR SFIZZ_AU) AND CMAKE_CXX_STANDARD LESS 14)
+    # if the UI is part of the build, make it 14
+    set(CMAKE_CXX_STANDARD 14)
+endif()
+
 # Process sources as UTF-8
 if(MSVC)
     add_compile_options("/utf-8")
@@ -57,7 +65,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         endif()
     endif()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    set(CMAKE_CXX_STANDARD 17)
     add_compile_options(/Zc:__cplusplus)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()

--- a/plugins/editor/cmake/Vstgui.cmake
+++ b/plugins/editor/cmake/Vstgui.cmake
@@ -207,10 +207,6 @@ if(${CMAKE_BUILD_TYPE} MATCHES "Release")
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    # higher C++ requirement on Windows
-    if(NOT CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 14)
-        set_property(TARGET sfizz_vstgui PROPERTY CXX_STANDARD 14)
-    endif()
     # Windows 10 RS2 DDI for custom fonts
     target_compile_definitions(sfizz_vstgui PRIVATE "NTDDI_VERSION=0x0A000003")
     # disable custom fonts if dwrite3 API is unavailable in MinGW

--- a/plugins/vst/cmake/Vst3.cmake
+++ b/plugins/vst/cmake/Vst3.cmake
@@ -36,9 +36,6 @@ function(plugin_add_vst3sdk NAME)
             "${VST3SDK_BASEDIR}/public.sdk/source/common/threadchecker_win32.cpp"
             "${VST3SDK_BASEDIR}/public.sdk/source/vst/vstgui_win32_bundle_support.cpp"
             "${VST3SDK_BASEDIR}/public.sdk/source/main/dllmain.cpp")
-        if(NOT CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 14)
-            set_property(TARGET "${NAME}" PROPERTY CXX_STANDARD 14)
-        endif()
     elseif(APPLE)
         target_sources("${NAME}" PRIVATE
             "${VST3SDK_BASEDIR}/public.sdk/source/main/macmain.cpp")


### PR DESCRIPTION
Set the C++ standard at top level and once only, such that it eliminates the perils of mismatching between various parts of code.