### PR TITLE
Devirtualize OrderedEventProcessor

### DIFF
--- a/plugins/vst/CMakeLists.txt
+++ b/plugins/vst/CMakeLists.txt
@@ -36,7 +36,7 @@ add_library(sfizz-vst3-core STATIC EXCLUDE_FROM_ALL
     SfizzVstUpdates.cpp
     SfizzVstIDs.h
     OrderedEventProcessor.h
-    OrderedEventProcessor.cpp
+    OrderedEventProcessor.hpp
     IdleUpdateHandler.h
     X11RunLoop.h
     X11RunLoop.cpp)

--- a/plugins/vst/OrderedEventProcessor.h
+++ b/plugins/vst/OrderedEventProcessor.h
@@ -12,16 +12,13 @@
 
 using namespace Steinberg;
 
+template <class R>
 class OrderedEventProcessor {
 public:
     virtual ~OrderedEventProcessor() {}
 
     void initializeEventProcessor(const Vst::ProcessSetup& setup, int32 paramCount, int32 subdivSize = 128);
     void processUnorderedEvents(int32 numSamples, Vst::IParameterChanges* pcs, Vst::IEventList* evs);
-
-protected:
-    virtual void playOrderedParameter(int32 sampleOffset, Vst::ParamID id, Vst::ParamValue value) = 0;
-    virtual void playOrderedEvent(const Vst::Event& event) = 0;
 
 private:
     void startProcessing(Vst::IEventList* evs, Vst::IParameterChanges* pcs);
@@ -64,3 +61,5 @@ private:
     bool haveCurrentEvent_ = false;
     Vst::Event currentEvent_ {};
 };
+
+#include "OrderedEventProcessor.hpp"

--- a/plugins/vst/SfizzVstProcessor.h
+++ b/plugins/vst/SfizzVstProcessor.h
@@ -20,7 +20,7 @@
 using namespace Steinberg;
 
 class SfizzVstProcessor : public Vst::AudioEffect,
-                          public OrderedEventProcessor {
+                          public OrderedEventProcessor<SfizzVstProcessor> {
 public:
     SfizzVstProcessor();
     ~SfizzVstProcessor();
@@ -39,8 +39,8 @@ public:
     tresult PLUGIN_API process(Vst::ProcessData& data) override;
 
     // OrderedEventProcessor
-    void playOrderedParameter(int32 sampleOffset, Vst::ParamID id, Vst::ParamValue value) override;
-    void playOrderedEvent(const Vst::Event& event) override;
+    void playOrderedParameter(int32 sampleOffset, Vst::ParamID id, Vst::ParamValue value);
+    void playOrderedEvent(const Vst::Event& event);
 
     void processMessagesFromUi();
     static int convertVelocityFromFloat(float x);


### PR DESCRIPTION
Gets rid of the virtual call occurring once every parameter point