### PR TITLE
Copy editor resources when changed

### DIFF
--- a/plugins/editor/CMakeLists.txt
+++ b/plugins/editor/CMakeLists.txt
@@ -23,12 +23,20 @@ set(EDITOR_RESOURCES
     Themes/Default/theme.xml
     PARENT_SCOPE)
 
-function(copy_editor_resources SOURCE_DIR DESTINATION_DIR)
+function(copy_editor_resources TARGET SOURCE_DIR DESTINATION_DIR)
+    set(_deps)
     foreach(res ${EDITOR_RESOURCES})
         get_filename_component(_dir "${res}" DIRECTORY)
         file(MAKE_DIRECTORY "${DESTINATION_DIR}/${_dir}")
-        file(COPY "${SOURCE_DIR}/${res}" DESTINATION "${DESTINATION_DIR}/${_dir}")
+        add_custom_command(
+            OUTPUT "${DESTINATION_DIR}/${res}"
+            COMMAND "${CMAKE_COMMAND}" "-E" "copy"
+                    "${SOURCE_DIR}/${res}" "${DESTINATION_DIR}/${res}"
+            DEPENDS "${SOURCE_DIR}/${res}")
+        list(APPEND _deps "${DESTINATION_DIR}/${res}")
     endforeach()
+    add_custom_target("${TARGET}_editor_resources" DEPENDS ${_deps})
+    add_dependencies("${TARGET}" "${TARGET}_editor_resources")
 endfunction()
 
 set(UI_FILES layout/main.fl layout/about.fl)

--- a/plugins/lv2/CMakeLists.txt
+++ b/plugins/lv2/CMakeLists.txt
@@ -106,6 +106,7 @@ if(SFIZZ_LV2_UI)
     execute_process(
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/Contents/Resources")
     copy_editor_resources(
+        ${LV2PLUGIN_PRJ_NAME}_ui
         "${CMAKE_CURRENT_SOURCE_DIR}/../editor/resources"
         "${PROJECT_BINARY_DIR}/Contents/Resources")
 endif()

--- a/plugins/vst/CMakeLists.txt
+++ b/plugins/vst/CMakeLists.txt
@@ -91,6 +91,7 @@ if(SFIZZ_VST)
     execute_process(
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/Resources")
     copy_editor_resources(
+        ${VSTPLUGIN_PRJ_NAME}
         "${CMAKE_CURRENT_SOURCE_DIR}/../editor/resources"
         "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/Resources")
     if(WIN32)
@@ -228,6 +229,7 @@ elseif(SFIZZ_AU)
     execute_process(
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources")
     copy_editor_resources(
+        ${AUPLUGIN_PRJ_NAME}
         "${CMAKE_CURRENT_SOURCE_DIR}/../editor/resources"
         "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/Resources")
     set_target_properties(${AUPLUGIN_PRJ_NAME} PROPERTIES
@@ -334,6 +336,7 @@ if(SFIZZ_VST2)
     execute_process(
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${PROJECT_BINARY_DIR}/${VST2PLUGIN_BUNDLE_NAME}/Contents/Resources")
     copy_editor_resources(
+        ${VST2PLUGIN_PRJ_NAME}
         "${CMAKE_CURRENT_SOURCE_DIR}/../editor/resources"
         "${PROJECT_BINARY_DIR}/${VST2PLUGIN_BUNDLE_NAME}/Contents/Resources")
     set_target_properties(${VST2PLUGIN_PRJ_NAME} PROPERTIES


### PR DESCRIPTION
Update build rules such that resources are copied into bundles after they are modified.