### PR TITLE
Use a color pair for key/switch, giving switch priority

### DIFF
--- a/plugins/editor/src/editor/GUIPiano.cpp
+++ b/plugins/editor/src/editor/GUIPiano.cpp
@@ -33,7 +33,6 @@ struct SPiano::Impl {
 
     float keyUsedHue_ = 0.55;
     float keySwitchHue_ = 0.0;
-    float keyUsedAndSwitchHue_ = 0.85;
     float whiteKeyChroma_ = 0.9;
     float blackKeyChroma_ = 0.75;
     float whiteKeyLuma_ = 0.9;
@@ -126,16 +125,16 @@ void SPiano::setKeyValue(unsigned key, float value)
     invalid();
 }
 
-int SPiano::getKeyRole(unsigned key)
+SPiano::KeyRole SPiano::getKeyRole(unsigned key)
 {
     Impl& impl = *impl_;
-    int role = 0;
+    KeyRole role = KeyRole::Unused;
 
     if (key < 128) {
-        if (impl.keyUsed_.test(key))
-            role |= KeyRole::Note;
         if (impl.keyswitchUsed_.test(key))
-            role |= KeyRole::Switch;
+            role = KeyRole::Switch;
+        else if (impl.keyUsed_.test(key))
+            role = KeyRole::Note;
     }
 
     return role;
@@ -189,12 +188,6 @@ void SPiano::draw(CDrawContext* dc)
                     goto whiteKeyDefault;
                 hcy.h = impl.keyUsedHue_;
                 break;
-            case KeyRole::Note|KeyRole::Switch:
-                if (!allKeysUsed) {
-                    hcy.h = impl.keyUsedAndSwitchHue_;
-                    break;
-                }
-                // fall through
             case KeyRole::Switch:
                 hcy.h = impl.keySwitchHue_;
                 break;
@@ -235,12 +228,6 @@ void SPiano::draw(CDrawContext* dc)
                     goto blackKeyDefault;
                 hcy.h = impl.keyUsedHue_;
                 break;
-            case KeyRole::Note|KeyRole::Switch:
-                if (!allKeysUsed) {
-                    hcy.h = impl.keyUsedAndSwitchHue_;
-                    break;
-                }
-                // fall through
             case KeyRole::Switch:
                 hcy.h = impl.keySwitchHue_;
                 break;

--- a/plugins/editor/src/editor/GUIPiano.h
+++ b/plugins/editor/src/editor/GUIPiano.h
@@ -29,13 +29,13 @@ public:
     void setKeyswitchUsed(unsigned key, bool used);
     void setKeyValue(unsigned key, float value);
 
-    enum KeyRole : int {
+    enum class KeyRole : int {
         Unused = 0,
         Note   = 1 << 0,
         Switch = 1 << 1,
     };
 
-    int getKeyRole(unsigned key);
+    KeyRole getKeyRole(unsigned key);
 
     std::function<void(unsigned, float)> onKeyPressed;
     std::function<void(unsigned, float)> onKeyReleased;


### PR DESCRIPTION
As suggested previously, avoid using a 3rd color for VK keys which are both note and switch.
Give priority to switch.