### PR TITLE
Prevent the indices from overflowing

### DIFF
--- a/src/sfizz/SIMDHelpers.h
+++ b/src/sfizz/SIMDHelpers.h
@@ -641,8 +641,10 @@ namespace _internals {
     template <class T>
     void snippetSFZInterpolationCast(const T*& floatJump, int*& jump, T*& coeff)
     {
-        *jump = static_cast<int>(*floatJump);
-        *coeff = *floatJump - static_cast<float>(*jump);
+        constexpr float maxJump { 1 << 24 };
+        const float limitedJump = min(maxJump, *floatJump);
+        *jump = static_cast<int>(limitedJump);
+        *coeff = limitedJump - static_cast<float>(*jump);
         incrementAll(floatJump, coeff, jump);
     }
 }


### PR DESCRIPTION
This prevents the crash in case the pitch is modulated in extreme ways.