### PR TITLE
Validation with pluginval

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,6 +189,15 @@ jobs:
       run: cmake --build . --config "${Env:BUILD_TYPE}" -j 2
     - name: Test
       run: ${{runner.workspace}}/build/tests/Release/sfizz_tests
+    - name: Install pluginval
+      run: |
+        Invoke-WebRequest https://github.com/Tracktion/pluginval/releases/download/latest_release/pluginval_Windows.zip -OutFile pluginval.zip
+        Expand-Archive pluginval.zip -DestinationPath pluginval
+        echo "$(Get-Location)\pluginval" | Out-File -FilePath ${Env:GITHUB_PATH} -Encoding utf8 -Append
+        pluginval\pluginval --version
+    - name: Validate VST3
+      working-directory: ${{runner.workspace}}/build
+      run: pluginval --validate-in-process --validate sfizz.vst3
     - name: Create installer
       working-directory: ${{runner.workspace}}/build
       run: iscc /O"." /F"${Env:install_name}" /dARCH="${Env:platform}" innosetup.iss


### PR DESCRIPTION
Adds plugin validation in the CI process. Only on Windows for not
- Win64 (only 32 bit binary available)
- No Linux: curl ABI problem in binaries
- No macOS: hangs on AudioUnit