### PR TITLE
Ability for OpcodeSpec to process number values

### DIFF
--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -33,6 +33,7 @@
 #include "SfzHelpers.h"
 #include "LFOCommon.h"
 #include "MathHelpers.h"
+#include "utility/Macros.h"
 
 
 namespace sfz
@@ -67,6 +68,9 @@ struct OpcodeSpec
     T defaultInputValue;
     Range<T> bounds;
     int flags;
+
+    using Intermediate = typename std::conditional<
+        std::is_integral<T>::value, int64_t, T>::type;
 
     template <class U>
     using IsNormalizable = std::integral_constant<

--- a/src/sfizz/Opcode.h
+++ b/src/sfizz/Opcode.h
@@ -113,6 +113,14 @@ struct Opcode {
     template <class T>
     T read(OpcodeSpec<T> spec) const { return readOptional(spec).value_or(spec); }
 
+    template <class T> using Intermediate = typename OpcodeSpec<T>::Intermediate;
+
+    template <class T>
+    absl::optional<T> transformOptional(OpcodeSpec<T> spec, Intermediate<T> value) const;
+
+    template <class T>
+    T transform(OpcodeSpec<T> spec, Intermediate<T> value) const { return transformOptional(spec, value).value_or(spec); }
+
 private:
     static OpcodeCategory identifyCategory(absl::string_view name);
     LEAK_DETECTOR(Opcode);


### PR DESCRIPTION
This extends `OpcodeSpec` with an ability to work on numbers, in addition to string values.
This will let region OSC apply on these values the desired range-reduction and normalization, by the same rules as the opcode parser would.