### PR TITLE
Use better variables for the pkg-config file

### DIFF
--- a/scripts/sfizz.pc.in
+++ b/scripts/sfizz.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@


### PR DESCRIPTION
The previous version created problems when setting manually CMAKE_INSTALL_LIBDIR on configure, e.g. for OBS/Debian packages.
The `libdir` value ended up as `libdir=${exec_prefix}//usr/lib` in this case, leading pkg-config to complain (obviously).