### PR TITLE
Thread-safety for receiving parameters

### DIFF
--- a/plugins/vst/cmake/Vst3.cmake
+++ b/plugins/vst/cmake/Vst3.cmake
@@ -35,6 +35,8 @@ if(WIN32)
     target_sources(vst3sdk PRIVATE
         "${VST3SDK_BASEDIR}/public.sdk/source/common/threadchecker_win32.cpp")
 elseif(APPLE)
+    target_sources(vst3sdk PRIVATE
+        "${VST3SDK_BASEDIR}/public.sdk/source/common/threadchecker_mac.mm")
 else()
     target_sources(vst3sdk PRIVATE
         "${VST3SDK_BASEDIR}/public.sdk/source/common/threadchecker_linux.cpp")


### PR DESCRIPTION
This implements a thread-safety measure in the editor, because the Juce-based Carla host sends us the parameter updates in the wrong thread.
This regards the parameters changes of the level meters, performed by the DSP.
If this workaround is not implemented, this messes with the VSTGUI data, most likely the tracking of update rectangles, creating memory corruption.