### PR TITLE
VST thread safety+

### DIFF
--- a/plugins/vst/SfizzVstProcessor.h
+++ b/plugins/vst/SfizzVstProcessor.h
@@ -6,6 +6,7 @@
 
 #pragma once
 #include "SfizzVstState.h"
+#include "SfizzVstUpdates.h"
 #include "OrderedEventProcessor.h"
 #include "plugin/RMSFollower.h"
 #include "sfizz/RTSemaphore.h"
@@ -27,6 +28,7 @@ public:
     ~SfizzVstProcessor();
 
     tresult PLUGIN_API initialize(FUnknown* context) override;
+    tresult PLUGIN_API terminate() override;
     tresult PLUGIN_API setBusArrangements(Vst::SpeakerArrangement* inputs, int32 numIns, Vst::SpeakerArrangement* outputs, int32 numOuts) override;
 
     tresult PLUGIN_API connect(IConnectionPoint* other) override;
@@ -56,8 +58,6 @@ public:
 private:
     // synth state. acquire processMutex before accessing
     std::unique_ptr<sfz::Sfizz> _synth;
-    Steinberg::IPtr<Vst::IMessage> _loadedSfzMessage;
-    Steinberg::IPtr<Vst::IMessage> _automateMessage;
     bool _isActive = false;
     SfizzVstState _state;
     float _currentStretchedTuning = 0;
@@ -70,6 +70,12 @@ private:
     bool _editorIsOpen = false;
 
     // updates
+    IPtr<QueuedUpdates> _queuedMessages;
+    IPtr<PlayStateUpdate> _playStateUpdate;
+    IPtr<SfzUpdate> _sfzUpdate;
+    IPtr<SfzDescriptionUpdate> _sfzDescriptionUpdate;
+    IPtr<ScalaUpdate> _scalaUpdate;
+    IPtr<AutomationUpdate> _automationUpdate;
     bool processUpdate(FUnknown* changedUnknown, int32 message);
 
     // client

--- a/plugins/vst/SfizzVstUpdates.hpp
+++ b/plugins/vst/SfizzVstUpdates.hpp
@@ -10,7 +10,7 @@
 template <class T>
 IPtr<Vst::IMessage> IConvertibleToMessage<T>::convertToMessage(Vst::ComponentBase* sender) const
 {
-    IPtr<Vst::IMessage> message = owned(sender->allocateMessage());
+    IPtr<Vst::IMessage> message = Steinberg::owned(sender->allocateMessage());
     if (!message)
         return nullptr;
     message->setMessageID(static_cast<const T*>(this)->isA());
@@ -20,13 +20,22 @@ IPtr<Vst::IMessage> IConvertibleToMessage<T>::convertToMessage(Vst::ComponentBas
 }
 
 template <class T>
-IPtr<T> IConvertibleToMessage<T>::convertFromMessage(Vst::IMessage& message)
+IPtr<T> IConvertibleToMessage<T>::createFromMessage(Vst::IMessage& message)
 {
     IPtr<T> object;
     if (!strcmp(T::getFClassID(), message.getMessageID())) {
-        object = owned(new T);
+        object = Steinberg::owned(new T);
         if (!object->loadFromAttributes(message.getAttributes()))
             object = nullptr;
     }
     return object;
+}
+
+template <class T>
+bool IConvertibleToMessage<T>::convertFromMessage(Vst::IMessage& message)
+{
+    bool success = false;
+    if (!strcmp(T::getFClassID(), message.getMessageID()))
+        success = loadFromAttributes(message.getAttributes());
+    return success;
 }


### PR DESCRIPTION
This work permits to communicate DSP->Controller forcing it to use the controller thread, which was not the case in Reaper previously.
The message processing is expected to become thread-safe, taking advantage of work from the previous PR.
It's also expected to fix the standalone.

Notes
- [x] fixme, stuck notes on the VK