### PR TITLE
catch possible exceptions in std::regex constructor

### DIFF
--- a/plugins/editor/src/editor/NativeHelpers.cpp
+++ b/plugins/editor/src/editor/NativeHelpers.cpp
@@ -305,14 +305,18 @@ std::string getProcessorName()
     std::string name;
     std::string line;
     std::ifstream in("/proc/cpuinfo", std::ios::binary);
-    std::regex re("^model name\\s*:\\s*(.*)");
+    try {
+        std::regex re("^model name\\s*:\\s*(.*)");
 
-    line.reserve(256);
+        line.reserve(256);
 
-    while (name.empty() && std::getline(in, line) && !line.empty()) {
-        std::smatch match;
-        if (std::regex_match(line, match, re))
-            name = match[1];
+        while (name.empty() && std::getline(in, line) && !line.empty()) {
+            std::smatch match;
+            if (std::regex_match(line, match, re))
+                name = match[1];
+        }
+    } catch (const std::exception& e) {
+        fprintf(stderr, "[sfizz] can't get processor name: %s\n", e.what());
     }
 
     if (name.empty())


### PR DESCRIPTION
Hi,

I've tried to load `sfizz.vst3` in Pd (with https://github.com/Spacechild1/vstplugin). It works fine with the Pd version shipped with Debian, but when I try with my self compiled Pd, the following line throws a `bad_cast` exception: https://github.com/sfztools/sfizz/blob/87f3a2b2249351ae97b40cc36904bec868eac36f/plugins/editor/src/editor/NativeHelpers.cpp#L308
This is very strange and likely caused by a libc bug. See also https://gcc.gnu.org/bugzilla//show_bug.cgi?id=82366

An easy solution is to simply wrap that code section in a try-block and catch any exception.

---

Generally, you might want to make sure that C++ exceptions never cross the plugin boundary!