### PR TITLE
Don't publish the linux tarball on releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -429,9 +429,9 @@ jobs:
       - name: Set install name
         run: |
           echo "install_ref=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@v2
-        with:
-          name: Linux tarball
+      # - uses: actions/download-artifact@v2
+      #   with:
+      #     name: Linux tarball
       - uses: actions/download-artifact@v2
         with:
           name: MOD devices tarball


### PR DESCRIPTION
If accepted I will also:
- Remove the Linux tarball from the 1.0.0 release
- Add a link to OBS in the release notes