### PR TITLE
Fix group cutting behavior with CC triggered samples (such as sustain pedals)

### DIFF
--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -1648,7 +1648,9 @@ bool Voice::checkOffGroup(const Region* other, int delay, int noteNumber) noexce
     if (impl.released())
         return false;
 
-    if (impl.triggerEvent_.type == TriggerEventType::NoteOn
+    if (
+        (impl.triggerEvent_.type == TriggerEventType::NoteOn
+            ||  impl.triggerEvent_.type == TriggerEventType::CC)
         && region->offBy && *region->offBy == other->group
         && (region->group != other->group || noteNumber != impl.triggerEvent_.number)) {
         off(delay);

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -1648,8 +1648,7 @@ bool Voice::checkOffGroup(const Region* other, int delay, int noteNumber) noexce
     if (impl.released())
         return false;
 
-    if (
-        (impl.triggerEvent_.type == TriggerEventType::NoteOn
+    if ((impl.triggerEvent_.type == TriggerEventType::NoteOn
             ||  impl.triggerEvent_.type == TriggerEventType::CC)
         && region->offBy && *region->offBy == other->group
         && (region->group != other->group || noteNumber != impl.triggerEvent_.number)) {

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -1693,6 +1693,23 @@ TEST_CASE("[Synth] Off by a CC event")
     REQUIRE( playingSamples(synth) == std::vector<std::string> { "*sine" });
 }
 
+TEST_CASE("[Synth] CC triggered off by a CC event")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
+
+    synth.loadSfzString(fs::current_path(), R"(
+        <region> group=1 off_by=2 sample=*saw hikey=-1 on_locc64=126 on_hicc64=127
+        <region> group=2 sample=*triangle hikey=-1 on_locc64=0 on_hicc64=1
+    )");
+    synth.cc(0, 64, 127);
+    synth.renderBlock(buffer);
+    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*saw" });
+    synth.cc(0, 64, 0);
+    synth.renderBlock(buffer);
+    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*triangle" });
+}
+
 TEST_CASE("[Synth] Off by a note-off event")
 {
     sfz::Synth synth;


### PR DESCRIPTION
While trying out the [Salamander Grand Piano](http://freepats.zenvoid.org/Piano/acoustic-grand-piano.html), I noticed that the sustain pedal sample was not stopped upon releasing the pedal. The SFZ file does include an opcode for cutting the activation sample:
```xml
//======================
//pedalAction

<group> group=1 hikey=-1 lokey=-1 on_locc64=126 on_hicc64=127 off_by=2 volume=-20

<region> sample=samples/pedalD1.flac lorand=0 hirand=0.5
<region> sample=samples/pedalD2.flac lorand=0.5 hirand=1

<group> group=2 hikey=-1 lokey=-1 on_locc64=0 on_hicc64=1 volume=-19

<region> sample=samples/pedalU1.flac lorand=0 hirand=0.5
<region> sample=samples/pedalU2.flac lorand=0.5 hirand=1
```

This commit fixes this problem.