### PR TITLE
Store files to load and their offset and defer loading

### DIFF
--- a/src/sfizz/Layer.h
+++ b/src/sfizz/Layer.h
@@ -88,7 +88,7 @@ public:
      * @return true if the region should trigger on this event
      * @return false
      */
-    bool registerCC(int ccNumber, float ccValue) noexcept;
+    bool registerCC(int ccNumber, float ccValue, bool dontTrigger = false) noexcept;
     /**
      * @brief Register a new pitch wheel event.
      *

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -581,6 +581,8 @@ void Synth::Impl::finalizeSfzLoad()
     size_t currentRegionIndex = 0;
     size_t currentRegionCount = layers_.size();
 
+    absl::flat_hash_map<sfz::FileId, int64_t> filesToLoad;
+
     auto removeCurrentRegion = [this, &currentRegionIndex, &currentRegionCount]() {
         const Region& region = layers_[currentRegionIndex]->getRegion();
         DBG("Removing the region with sample " << *region.sampleId);
@@ -679,10 +681,8 @@ void Synth::Impl::finalizeSfzLoad()
                 return Default::offsetMod.bounds.clamp(sumOffsetCC);
             }();
 
-            if (!filePool.preloadFile(*region.sampleId, maxOffset)) {
-                removeCurrentRegion();
-                continue;
-            }
+            auto& toLoad = filesToLoad[*region.sampleId];
+            toLoad = max(toLoad, maxOffset);
         }
         else if (!region.isGenerator()) {
             if (!wavePool.createFileWave(filePool, std::string(region.sampleId->filename()))) {
@@ -763,6 +763,11 @@ void Synth::Impl::finalizeSfzLoad()
 
         ++currentRegionIndex;
     }
+
+    for (const auto& toLoad: filesToLoad) {
+        filePool.preloadFile(toLoad.first, toLoad.second);
+    }
+
     if (currentRegionCount < layers_.size()) {
         DBG("Removing " << (layers_.size() - currentRegionCount)
             << " out of " << layers_.size() << " regions");

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -726,7 +726,7 @@ void Synth::Impl::finalizeSfzLoad()
         // Defaults
         MidiState& midiState = resources_.getMidiState();
         for (int cc = 0; cc < config::numCCs; cc++) {
-            layer.registerCC(cc, midiState.getCCValue(cc));
+            layer.registerCC(cc, midiState.getCCValue(cc), true);
         }
 
 
@@ -1951,7 +1951,7 @@ void Synth::Impl::resetAllControllers(int delay) noexcept
     for (const LayerPtr& layerPtr : layers_) {
         Layer& layer = *layerPtr;
         for (int cc = 0; cc < config::numCCs; ++cc)
-            layer.registerCC(cc, defaultCCValues_[cc]);
+            layer.registerCC(cc, defaultCCValues_[cc], true);
     }
 }
 


### PR DESCRIPTION
Closes: #912

Better behavior when using a file multiple times with different offsets. This does not solve the high memory usage for monolithic libraries which will basically load the full sample in memory; for this I'll track another issue.

I'll keep adding to this PR to try and debug what's going on with this library: it showed other issues (volume is high and polyphony too).