### PR TITLE
Preserve source permissions

### DIFF
--- a/plugins/lv2/CMakeLists.txt
+++ b/plugins/lv2/CMakeLists.txt
@@ -117,7 +117,8 @@ endif()
 # Installation
 if(NOT MSVC)
     install(DIRECTORY ${PROJECT_BINARY_DIR} DESTINATION ${LV2PLUGIN_INSTALL_DIR}
-        COMPONENT "lv2")
+        COMPONENT "lv2"
+        USE_SOURCE_PERMISSIONS)
     bundle_dylibs(lv2
         "${LV2PLUGIN_INSTALL_DIR}/${PROJECT_NAME}.lv2/Contents/Binary/sfizz.so"
         COMPONENT "lv2")

--- a/plugins/puredata/CMakeLists.txt
+++ b/plugins/puredata/CMakeLists.txt
@@ -49,7 +49,8 @@ copy_puredata_resources(sfizz_puredata
 # Installation
 if(NOT MSVC)
     install(DIRECTORY "${PUREDATA_BINARY_DIR}" DESTINATION "${PDPLUGIN_INSTALL_DIR}"
-        COMPONENT "puredata")
+        COMPONENT "puredata"
+        USE_SOURCE_PERMISSIONS)
     bundle_dylibs(puredata
         "${PDPLUGIN_INSTALL_DIR}/sfizz/sfizz${PUREDATA_SUFFIX}"
         COMPONENT "puredata")

--- a/plugins/vst/CMakeLists.txt
+++ b/plugins/vst/CMakeLists.txt
@@ -136,7 +136,8 @@ if(SFIZZ_VST)
     if(NOT MSVC)
         install(DIRECTORY "${PROJECT_BINARY_DIR}/${VSTPLUGIN_BUNDLE_NAME}"
             DESTINATION "${VSTPLUGIN_INSTALL_DIR}"
-            COMPONENT "vst")
+            COMPONENT "vst"
+            USE_SOURCE_PERMISSIONS)
         bundle_dylibs(vst
             "${VSTPLUGIN_INSTALL_DIR}/${VSTPLUGIN_BUNDLE_NAME}/Contents/MacOS/sfizz"
             COMPONENT "vst")
@@ -284,7 +285,8 @@ elseif(SFIZZ_AU)
     if(AUPLUGIN_INSTALL_DIR)
         install(DIRECTORY "${PROJECT_BINARY_DIR}/${AUPLUGIN_BUNDLE_NAME}"
             DESTINATION "${AUPLUGIN_INSTALL_DIR}"
-            COMPONENT "au")
+            COMPONENT "au"
+            USE_SOURCE_PERMISSIONS)
         bundle_dylibs(au
             "${AUPLUGIN_INSTALL_DIR}/${AUPLUGIN_BUNDLE_NAME}/Contents/MacOS/sfizz"
             COMPONENT "au")
@@ -355,7 +357,8 @@ if(SFIZZ_VST2)
     if(VST2PLUGIN_INSTALL_DIR)
         install(DIRECTORY "${PROJECT_BINARY_DIR}/${VST2PLUGIN_BUNDLE_NAME}"
             DESTINATION "${VST2PLUGIN_INSTALL_DIR}"
-            COMPONENT "vst2")
+            COMPONENT "vst2"
+            USE_SOURCE_PERMISSIONS)
         if(APPLE)
             bundle_dylibs(vst2
                 "${VST2PLUGIN_INSTALL_DIR}/${VST2PLUGIN_BUNDLE_NAME}/Contents/Binary/sfizz.${CMAKE_SHARED_MODULE_SUFFIX}"


### PR DESCRIPTION
Preserve source permissions to allow fedora packaging tools to auto strip so files.