### PR TITLE
Fix build with Apple clang & C++17 (bessel functions not defined)

### DIFF
--- a/src/sfizz/MathHelpers.h
+++ b/src/sfizz/MathHelpers.h
@@ -26,7 +26,7 @@
 #include <simde/x86/sse.h>
 #endif
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && defined(__cpp_lib_math_special_functions)
 static double i0(double x) { return std::cyl_bessel_i(0.0, x); }
 #else
 // external Bessel function from cephes


### PR DESCRIPTION
The cyl_bessel_i function isn't defined if you're building with clang, but MathHelpers assumes it is as long as you're using C++17. So we need to add a check for that feature.

I tested this on an Intel Mac. CMake identifies the compiler as "AppleClang 12.0.5.12050022."

I added
```
SET(CMAKE_CXX_STANDARD 17)
SET(CMAKE_CXX_STANDARD_REQUIRED ON)
```
to the root CMakeLists.txt, and I ran
```
cmake -DCMAKE_BUILD_TYPE=Release .
make -j$(sysctl -n hw.ncpu)
```