### PR TITLE
Have the DS importer generate the correct loop mode

### DIFF
--- a/src/sfizz/import/foreign_instruments/DecentSampler.cpp
+++ b/src/sfizz/import/foreign_instruments/DecentSampler.cpp
@@ -202,7 +202,7 @@ void DecentSamplerInstrumentImporter::emitRegionalOpcodes(std::ostream& os, pugi
             break;
         case hash("loopEnabled"):
             os << "loop_mode="
-               << ((xmlOpcode.value == "true") ? "loop_continuous" : "one_shot") << "\n";
+               << ((xmlOpcode.value == "true") ? "loop_continuous" : "no_loop") << "\n";
             break;
         case hash("attack"):
             convertToReal("ampeg_attack");


### PR DESCRIPTION
This is expected to fix the long releases which don't account for the key-off.