### PR TITLE
Fix the VST thread synchronization on activate/deactivate

### DIFF
--- a/plugins/vst/SfizzVstProcessor.cpp
+++ b/plugins/vst/SfizzVstProcessor.cpp
@@ -740,8 +740,13 @@ void SfizzVstProcessor::doBackgroundWork()
     for (;;) {
         bool isNotified = _semaToWorker.timed_wait(kBackgroundIdleInterval.count());
 
-        if (!_workRunning)
+        if (!_workRunning) {
+            // if the quit signal is sent, the semaphore is also signaled
+            // make sure the count is kept consistent
+            if (!isNotified)
+                _semaToWorker.wait();
             break;
+        }
 
         const char* id = nullptr;
         RTMessagePtr msg;


### PR DESCRIPTION
This fixes a race condition happening in Reaper.
It may occur when clicking Play on a freshly loaded project.
It's rare in normal circumstances, but frequent under valgrind.