### PR TITLE
Set the macOS compability back to 10.9

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -193,7 +193,8 @@ set(SFIZZ_SOURCES
     sfizz/effects/impl/ResonantStringAVX.cpp
     sfizz/effects/impl/ResonantArray.cpp
     sfizz/effects/impl/ResonantArraySSE.cpp
-    sfizz/effects/impl/ResonantArrayAVX.cpp)
+    sfizz/effects/impl/ResonantArrayAVX.cpp
+    sfizz/utility/c++17/AlignedMemorySupport.cpp)
 
 include(SfizzSIMDSourceFiles)
 sfizz_add_simd_sources(SFIZZ_SOURCES ".")
@@ -302,6 +303,9 @@ if(SFIZZ_USE_SNDFILE)
 endif()
 if(SFIZZ_RELEASE_ASSERTS)
     target_compile_definitions(sfizz_internal PUBLIC "SFIZZ_ENABLE_RELEASE_ASSERT=1")
+endif()
+if(SFIZZ_IMPLEMENT_CXX17_ALIGNED_NEW_SUPPORT)
+    target_compile_definitions(sfizz_internal PRIVATE "SFIZZ_IMPLEMENT_CXX17_ALIGNED_NEW_SUPPORT=1")
 endif()
 sfizz_enable_fast_math(sfizz_internal)
 

--- a/src/sfizz/utility/c++17/AlignedMemorySupport.cpp
+++ b/src/sfizz/utility/c++17/AlignedMemorySupport.cpp
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+#if defined(SFIZZ_IMPLEMENT_CXX17_ALIGNED_NEW_SUPPORT)
+#include <new>
+#if defined(_WIN32)
+#   include <malloc.h>
+#else
+#   include <stdlib.h>
+#endif
+
+void* operator new(std::size_t count, std::align_val_t al, const std::nothrow_t&) noexcept
+{
+    void *ptr;
+#if defined(_WIN32)
+    ptr = ::_aligned_malloc(count, static_cast<std::size_t>(al));
+#else
+    if (::posix_memalign(&ptr, static_cast<std::size_t>(al), count) != 0)
+        ptr = nullptr;
+#endif
+    return ptr;
+}
+
+void operator delete(void* ptr, std::align_val_t, const std::nothrow_t&) noexcept
+{
+#if defined(_WIN32)
+    ::_aligned_free(ptr);
+#else
+    ::free(ptr);
+#endif
+}
+
+//------------------------------------------------------------------------------
+
+void* operator new(std::size_t count, std::align_val_t al)
+{
+    void *ptr = operator new(count, al, std::nothrow);
+    if (!ptr)
+        throw std::bad_alloc();
+    return ptr;
+}
+
+void operator delete(void* ptr, std::align_val_t al) noexcept
+{
+    operator delete(ptr, al, std::nothrow);
+}
+
+//------------------------------------------------------------------------------
+
+void* operator new[](std::size_t count, std::align_val_t al)
+{
+    return operator new(count, al);
+}
+
+void* operator new[](std::size_t count, std::align_val_t al, const std::nothrow_t& tag) noexcept
+{
+    return operator new(count, al, tag);
+}
+
+void operator delete[](void* ptr, std::align_val_t al) noexcept
+{
+    operator delete(ptr, al);
+}
+
+void operator delete[](void* ptr, std::align_val_t al, const std::nothrow_t& tag) noexcept
+{
+    operator delete(ptr, al, tag);
+}
+
+
+#endif // defined(SFIZZ_IMPLEMENT_CXX17_ALIGNED_NEW_SUPPORT)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,10 @@ set(SFIZZ_TEST_SOURCES
 
 add_executable(sfizz_tests ${SFIZZ_TEST_SOURCES})
 target_link_libraries(sfizz_tests PRIVATE sfizz::internal sfizz::static sfizz::spin_mutex sfizz::jsl sfizz::filesystem)
+if(APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS "10.12")
+    # workaround for incomplete C++17 runtime on macOS
+    target_compile_definitions(sfizz_tests PRIVATE "CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS")
+endif()
 sfizz_enable_lto_if_needed(sfizz_tests)
 sfizz_enable_fast_math(sfizz_tests)
 catch_discover_tests(sfizz_tests)


### PR DESCRIPTION
fixes #988

This finds whether new/delete aligned operators are missing, and if so implements them.
Also fixed catch2 under the incomplete macOS c++17 runtime.

Somewhat tested, but not inside the target environment (10.9 <= macOS <10.12)
