### PR TITLE
When using GCC 8, explicitely link stdc++fs

### DIFF
--- a/cmake/SfizzDeps.cmake
+++ b/cmake/SfizzDeps.cmake
@@ -246,6 +246,12 @@ else()
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/fs_std_impl.cpp" "#include <ghc/fs_std_impl.hpp>")
     add_library(sfizz_filesystem_impl STATIC "${CMAKE_CURRENT_BINARY_DIR}/fs_std_impl.cpp")
     target_include_directories(sfizz_filesystem_impl PUBLIC "external/filesystem/include")
+    # Add the needed linker option for GCC 8
+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU"
+        AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0
+        AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+        target_link_libraries(sfizz_filesystem_impl PUBLIC stdc++fs)
+    endif()
     #
     add_library(sfizz_filesystem INTERFACE)
     target_compile_definitions(sfizz_filesystem INTERFACE "GHC_FILESYSTEM_FWD")


### PR DESCRIPTION
Compilation otherwise fails on raspberry pi which is still using Debian 10/GCC 8 as a default compiler. Worse, the plugins compile but fail to load.