### PR TITLE
Update the filters' code ...

### DIFF
--- a/src/sfizz/dsp/filters/sfz_filters.dsp
+++ b/src/sfizz/dsp/filters/sfz_filters.dsp
@@ -100,12 +100,16 @@ sfzEqPeak = fm.rbjPeakingEqSmooth(smoothCoefs,cutoff,pkShGain,Q) with {
 
 // the SFZ low-shelf with EQ controls
 sfzEqLshelf = fm.rbjLowShelfSmooth(smoothCoefs,cutoff,pkShGain,Q) with {
-  Q = sfzGetQFromSlope(slope);
+//  Q = sfzGetQFromSlope(slope);
+  Q = 1./(2.*ma.sinh(0.5*log(2)*bandwidth*w0/sin(w0)));
+  w0 = 2*ma.PI*cutoff/ma.SR;
 };
 
 // the SFZ high-shelf with EQ controls
 sfzEqHshelf = fm.rbjHighShelfSmooth(smoothCoefs,cutoff,pkShGain,Q) with {
-  Q = sfzGetQFromSlope(slope);
+//  Q = sfzGetQFromSlope(slope);
+  Q = 1./(2.*ma.sinh(0.5*log(2)*bandwidth*w0/sin(w0)));
+  w0 = 2*ma.PI*cutoff/ma.SR;
 };
 
 //==============================================================================

--- a/src/sfizz/gen/filters/sfz2chApf1p.hxx
+++ b/src/sfizz/gen/filters/sfz2chApf1p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chApf1p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -66,7 +66,7 @@ class faust2chApf1p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -120,14 +120,14 @@ class faust2chApf1p : public sfzFilterDsp {
 		FAUSTFLOAT* output1 = outputs[1];
 		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (((fConst2 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0)))) + -1.0) * (1.0 - fSlow0));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow1);
 			fRec0[0] = (fTemp0 - (fRec1[0] * fRec0[1]));
-			output0[i] = FAUSTFLOAT((fRec0[1] + (fRec1[0] * fRec0[0])));
+			output0[i0] = FAUSTFLOAT((fRec0[1] + (fRec1[0] * fRec0[0])));
 			fRec2[0] = (fTemp1 - (fRec1[0] * fRec2[1]));
-			output1[i] = FAUSTFLOAT((fRec2[1] + (fRec1[0] * fRec2[0])));
+			output1[i0] = FAUSTFLOAT((fRec2[1] + (fRec1[0] * fRec2[0])));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];

--- a/src/sfizz/gen/filters/sfz2chBpf1p.hxx
+++ b/src/sfizz/gen/filters/sfz2chBpf1p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chBpf1p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -68,7 +68,7 @@ class faust2chBpf1p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (1.0 / fConst0);
 		//[End:instanceConstants]
@@ -128,19 +128,19 @@ class faust2chBpf1p : public sfzFilterDsp {
 		FAUSTFLOAT* output1 = outputs[1];
 		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0))))))) * (1.0 - fSlow0));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow1);
 			fRec1[0] = (fTemp0 + (fRec2[0] * fRec1[1]));
 			double fTemp2 = (1.0 - fRec2[0]);
 			fRec0[0] = ((fRec1[0] * fTemp2) + (fRec2[0] * fRec0[1]));
 			double fTemp3 = (fRec2[0] + 1.0);
 			double fTemp4 = (0.0 - (0.5 * fTemp3));
-			output0[i] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp3)) + (fRec0[1] * fTemp4)));
+			output0[i0] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp3)) + (fRec0[1] * fTemp4)));
 			fRec4[0] = (fTemp1 + (fRec2[0] * fRec4[1]));
 			fRec3[0] = ((fRec4[0] * fTemp2) + (fRec2[0] * fRec3[1]));
-			output1[i] = FAUSTFLOAT(((0.5 * (fRec3[0] * fTemp3)) + (fTemp4 * fRec3[1])));
+			output1[i0] = FAUSTFLOAT(((0.5 * (fRec3[0] * fTemp3)) + (fTemp4 * fRec3[1])));
 			fRec2[1] = fRec2[0];
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];

--- a/src/sfizz/gen/filters/sfz2chBpf2p.hxx
+++ b/src/sfizz/gen/filters/sfz2chBpf2p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chBpf2p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fRec2[2];
 	double fVec0[2];
@@ -79,7 +79,7 @@ class faust2chBpf2p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -180,9 +180,9 @@ class faust2chBpf2p : public sfzFilterDsp {
 		double fSlow9 = ((0.0 - fSlow6) * fSlow7);
 		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
 		double fSlow11 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = (fSlow0 * fRec2[1]);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow8);
@@ -193,13 +193,13 @@ class faust2chBpf2p : public sfzFilterDsp {
 			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow11);
 			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec3[0] = (fTemp1 * fRec2[0]);
 			fVec4[0] = (fTemp1 * fRec4[0]);
 			fVec5[0] = (fVec4[1] - (fRec5[0] * fRec7[1]));
 			fRec8[0] = ((fVec3[1] + ((fTemp1 * fRec3[0]) + fVec5[1])) - (fRec6[0] * fRec8[1]));
 			fRec7[0] = fRec8[0];
-			output1[i] = FAUSTFLOAT(fRec7[0]);
+			output1[i0] = FAUSTFLOAT(fRec7[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfz2chBpf2pSv.hxx
+++ b/src/sfizz/gen/filters/sfz2chBpf2pSv.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chBpf2pSv : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -71,7 +71,7 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
 		//[End:instanceConstants]
@@ -140,9 +140,9 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0))))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * std::min<double>(60.0, std::max<double>(-60.0, double(fVslider0))))));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow2);
 			double fTemp2 = (fSlow3 + fRec3[0]);
 			fRec4[0] = ((fSlow0 * fRec4[1]) + (fSlow1 / ((fRec3[0] * fTemp2) + 1.0)));
@@ -155,7 +155,7 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 			fRec1[0] = (fRec1[1] + (2.0 * (fRec3[0] * fTemp6)));
 			double fTemp7 = (fRec2[1] + (2.0 * fTemp5));
 			fRec2[0] = fTemp7;
-			output0[i] = FAUSTFLOAT(fRec0);
+			output0[i0] = FAUSTFLOAT(fRec0);
 			double fTemp8 = (fTemp1 - (fRec7[1] + (fRec5[0] * fRec8[1])));
 			double fTemp9 = (fTemp3 * fTemp8);
 			double fTemp10 = (fRec8[1] + fTemp9);
@@ -163,7 +163,7 @@ class faust2chBpf2pSv : public sfzFilterDsp {
 			fRec7[0] = (fRec7[1] + (2.0 * (fRec3[0] * fTemp10)));
 			double fTemp11 = (fRec8[1] + (2.0 * fTemp9));
 			fRec8[0] = fTemp11;
-			output1[i] = FAUSTFLOAT(fRec6);
+			output1[i0] = FAUSTFLOAT(fRec6);
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
 			fRec5[1] = fRec5[0];

--- a/src/sfizz/gen/filters/sfz2chBpf4p.hxx
+++ b/src/sfizz/gen/filters/sfz2chBpf4p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chBpf4p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -89,7 +89,7 @@ class faust2chBpf4p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -220,9 +220,9 @@ class faust2chBpf4p : public sfzFilterDsp {
 		double fSlow9 = (fSlow6 * fSlow7);
 		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
 		double fSlow11 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
 			fRec5[0] = (fSlow0 * fRec5[1]);
 			fVec0[0] = (fTemp0 * fRec5[0]);
@@ -238,7 +238,7 @@ class faust2chBpf4p : public sfzFilterDsp {
 			fVec5[0] = (fRec5[0] * fRec3[0]);
 			fRec1[0] = (((fVec4[1] + fVec5[1]) + (fRec6[0] * fRec3[0])) - (fRec8[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec6[0] = (fTemp1 * fRec5[0]);
 			fVec7[0] = (fTemp1 * fRec2[0]);
 			fVec8[0] = (fVec7[1] - (fRec7[0] * fRec11[1]));
@@ -249,7 +249,7 @@ class faust2chBpf4p : public sfzFilterDsp {
 			fVec11[0] = (fRec5[0] * fRec11[0]);
 			fRec10[0] = (((fVec10[1] + fVec11[1]) + (fRec6[0] * fRec11[0])) - (fRec8[0] * fRec10[1]));
 			fRec9[0] = fRec10[0];
-			output1[i] = FAUSTFLOAT(fRec9[0]);
+			output1[i0] = FAUSTFLOAT(fRec9[0]);
 			fRec2[1] = fRec2[0];
 			fRec5[1] = fRec5[0];
 			fVec0[1] = fVec0[0];

--- a/src/sfizz/gen/filters/sfz2chBpf6p.hxx
+++ b/src/sfizz/gen/filters/sfz2chBpf6p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chBpf6p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -99,7 +99,7 @@ class faust2chBpf6p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -260,9 +260,9 @@ class faust2chBpf6p : public sfzFilterDsp {
 		double fSlow9 = (fSlow6 * fSlow7);
 		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
 		double fSlow11 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
 			fRec7[0] = (fSlow0 * fRec7[1]);
 			fVec0[0] = (fTemp0 * fRec7[0]);
@@ -283,7 +283,7 @@ class faust2chBpf6p : public sfzFilterDsp {
 			fVec8[0] = (fRec7[0] * fRec3[0]);
 			fRec1[0] = (((fVec7[1] + fVec8[1]) + (fRec8[0] * fRec3[0])) - (fRec10[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec9[0] = (fTemp1 * fRec7[0]);
 			fVec10[0] = (fTemp1 * fRec2[0]);
 			fVec11[0] = (fVec10[1] - (fRec9[0] * fRec15[1]));
@@ -299,7 +299,7 @@ class faust2chBpf6p : public sfzFilterDsp {
 			fVec17[0] = (fRec7[0] * fRec13[0]);
 			fRec12[0] = (((fVec16[1] + fVec17[1]) + (fRec8[0] * fRec13[0])) - (fRec10[0] * fRec12[1]));
 			fRec11[0] = fRec12[0];
-			output1[i] = FAUSTFLOAT(fRec11[0]);
+			output1[i0] = FAUSTFLOAT(fRec11[0]);
 			fRec2[1] = fRec2[0];
 			fRec7[1] = fRec7[0];
 			fVec0[1] = fVec0[0];

--- a/src/sfizz/gen/filters/sfz2chBrf1p.hxx
+++ b/src/sfizz/gen/filters/sfz2chBrf1p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chBrf1p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -68,7 +68,7 @@ class faust2chBrf1p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -128,16 +128,16 @@ class faust2chBrf1p : public sfzFilterDsp {
 		FAUSTFLOAT* output1 = outputs[1];
 		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (((fConst2 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0)))) + -1.0) * (1.0 - fSlow0));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow1);
 			fRec1[0] = (fTemp0 - (fRec2[0] * fRec1[1]));
 			fRec0[0] = (fRec1[1] + (fRec2[0] * (fRec1[0] - fRec0[1])));
-			output0[i] = FAUSTFLOAT((fTemp0 + (fRec0[1] + (fRec2[0] * fRec0[0]))));
+			output0[i0] = FAUSTFLOAT((fTemp0 + (fRec0[1] + (fRec2[0] * fRec0[0]))));
 			fRec4[0] = (fTemp1 - (fRec2[0] * fRec4[1]));
 			fRec3[0] = (fRec4[1] + (fRec2[0] * (fRec4[0] - fRec3[1])));
-			output1[i] = FAUSTFLOAT((fTemp1 + (fRec3[1] + (fRec2[0] * fRec3[0]))));
+			output1[i0] = FAUSTFLOAT((fTemp1 + (fRec3[1] + (fRec2[0] * fRec3[0]))));
 			fRec2[1] = fRec2[0];
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];

--- a/src/sfizz/gen/filters/sfz2chBrf2p.hxx
+++ b/src/sfizz/gen/filters/sfz2chBrf2p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chBrf2p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -77,7 +77,7 @@ class faust2chBrf2p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -168,9 +168,9 @@ class faust2chBrf2p : public sfzFilterDsp {
 		double fSlow5 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow3) * fSlow4);
 		double fSlow6 = ((1.0 / fSlow3) * fSlow4);
 		double fSlow7 = (((1.0 - fSlow2) / fSlow3) * fSlow4);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow5);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow6);
@@ -180,14 +180,14 @@ class faust2chBrf2p : public sfzFilterDsp {
 			fVec2[0] = (fVec1[1] - (fRec4[0] * fRec0[1]));
 			fRec1[0] = ((fVec0[1] + (fTemp2 + fVec2[1])) - (fRec2[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec3[0] = (fTemp1 * fRec2[0]);
 			double fTemp3 = (fTemp1 * fRec3[0]);
 			fVec4[0] = fTemp3;
 			fVec5[0] = (fVec4[1] - (fRec4[0] * fRec5[1]));
 			fRec6[0] = ((fVec3[1] + (fTemp3 + fVec5[1])) - (fRec2[0] * fRec6[1]));
 			fRec5[0] = fRec6[0];
-			output1[i] = FAUSTFLOAT(fRec5[0]);
+			output1[i0] = FAUSTFLOAT(fRec5[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfz2chBrf2pSv.hxx
+++ b/src/sfizz/gen/filters/sfz2chBrf2pSv.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chBrf2pSv : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -71,7 +71,7 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
 		//[End:instanceConstants]
@@ -140,9 +140,9 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0))))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * std::min<double>(60.0, std::max<double>(-60.0, double(fVslider0))))));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow2);
 			double fTemp2 = (fSlow3 + fRec5[0]);
 			fRec4[0] = ((fSlow0 * fRec4[1]) + (fSlow1 / ((fRec5[0] * fTemp2) + 1.0)));
@@ -156,7 +156,7 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 			double fTemp7 = (fRec3[1] + fTemp5);
 			fRec2[0] = (fRec2[1] + (2.0 * (fRec5[0] * fTemp7)));
 			fRec3[0] = fTemp6;
-			output0[i] = FAUSTFLOAT((fRec1 + fRec0));
+			output0[i0] = FAUSTFLOAT((fRec1 + fRec0));
 			double fTemp8 = (fTemp1 - (fRec9[1] + (fRec6[0] * fRec10[1])));
 			double fRec7 = (fRec4[0] * fTemp8);
 			double fTemp9 = (fTemp4 * fTemp8);
@@ -165,7 +165,7 @@ class faust2chBrf2pSv : public sfzFilterDsp {
 			double fTemp11 = (fRec10[1] + fTemp9);
 			fRec9[0] = (fRec9[1] + (2.0 * (fRec5[0] * fTemp11)));
 			fRec10[0] = fTemp10;
-			output1[i] = FAUSTFLOAT((fRec8 + fRec7));
+			output1[i0] = FAUSTFLOAT((fRec8 + fRec7));
 			fRec5[1] = fRec5[0];
 			fRec4[1] = fRec4[0];
 			fRec6[1] = fRec6[0];

--- a/src/sfizz/gen/filters/sfz2chEqHshelf.hxx
+++ b/src/sfizz/gen/filters/sfz2chEqHshelf.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -17,13 +17,12 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 #define FAUSTFLOAT float
 #endif 
 
+/* link with : "" */
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
-static double faust2chEqHshelf_faustpower2_f(double value) {
-	return (value * value);
-}
 
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chEqHshelf
@@ -43,11 +42,11 @@ class faust2chEqHshelf : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fVslider0;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
+	double fConst3;
 	FAUSTFLOAT fVslider1;
 	double fRec2[2];
 	double fVec0[2];
@@ -83,9 +82,10 @@ class faust2chEqHshelf : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
+		fConst3 = (2.1775860903036022 / fConst0);
 		//[End:instanceConstants]
 	}
 	
@@ -175,42 +175,40 @@ class faust2chEqHshelf : public sfzFilterDsp {
 		FAUSTFLOAT* output1 = outputs[1];
 		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = std::pow(10.0, (0.025000000000000001 * std::min<double>(60.0, std::max<double>(-120.0, double(fVslider0)))));
-		double fSlow2 = (fConst2 * std::max<double>(0.0, std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0)))));
-		double fSlow3 = std::cos(fSlow2);
-		double fSlow4 = ((fSlow1 + 1.0) * fSlow3);
-		double fSlow5 = (faust2chEqHshelf_faustpower2_f(fSlow1) + 1.0);
-		double fSlow6 = (fSlow1 + -1.0);
-		double fSlow7 = faust2chEqHshelf_faustpower2_f(fSlow6);
-		double fSlow8 = ((std::sqrt(fSlow1) * std::sin(fSlow2)) / std::max<double>(0.001, (1.0 / std::sqrt((((fSlow1 + (1.0 / fSlow1)) * ((1.0 / std::min<double>(((fSlow5 / fSlow7) + -0.01), std::max<double>(0.01, ((double(fVslider1) * fSlow5) / fSlow7)))) + -1.0)) + 2.0)))));
-		double fSlow9 = (fSlow6 * fSlow3);
-		double fSlow10 = ((fSlow1 + fSlow8) + (1.0 - fSlow9));
-		double fSlow11 = (1.0 - fSlow0);
-		double fSlow12 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow1 + fSlow4) + -1.0)) / fSlow10) * fSlow11);
-		double fSlow13 = (fSlow9 + fSlow8);
-		double fSlow14 = (((fSlow1 * ((fSlow1 + fSlow13) + 1.0)) / fSlow10) * fSlow11);
-		double fSlow15 = (((fSlow1 * ((fSlow1 + fSlow9) + (1.0 - fSlow8))) / fSlow10) * fSlow11);
-		double fSlow16 = (((fSlow1 + (1.0 - fSlow13)) / fSlow10) * fSlow11);
-		double fSlow17 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow10)) * fSlow11);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow12);
+		double fSlow2 = std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0)));
+		double fSlow3 = (fConst2 * std::max<double>(0.0, fSlow2));
+		double fSlow4 = std::cos(fSlow3);
+		double fSlow5 = ((fSlow1 + 1.0) * fSlow4);
+		double fSlow6 = ((std::sqrt(fSlow1) * std::sin(fSlow3)) / std::max<double>(0.001, (0.5 / double(sinh(double((fConst3 * ((fSlow2 * std::min<double>(12.0, std::max<double>(0.01, double(fVslider1)))) / std::sin((fConst2 * fSlow2))))))))));
+		double fSlow7 = ((fSlow1 + -1.0) * fSlow4);
+		double fSlow8 = ((fSlow1 + fSlow6) + (1.0 - fSlow7));
+		double fSlow9 = (1.0 - fSlow0);
+		double fSlow10 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow1 + fSlow5) + -1.0)) / fSlow8) * fSlow9);
+		double fSlow11 = (fSlow7 + fSlow6);
+		double fSlow12 = (((fSlow1 * ((fSlow1 + fSlow11) + 1.0)) / fSlow8) * fSlow9);
+		double fSlow13 = (((fSlow1 * ((fSlow1 + fSlow7) + (1.0 - fSlow6))) / fSlow8) * fSlow9);
+		double fSlow14 = (((fSlow1 + (1.0 - fSlow11)) / fSlow8) * fSlow9);
+		double fSlow15 = ((2.0 * ((fSlow1 + (-1.0 - fSlow5)) / fSlow8)) * fSlow9);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow10);
 			fVec0[0] = (fTemp0 * fRec2[0]);
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow14);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow15);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
 			fVec1[0] = (fTemp0 * fRec4[0]);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow16);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow14);
 			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
-			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow17);
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow15);
 			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec3[0] = (fTemp1 * fRec2[0]);
 			fVec4[0] = (fTemp1 * fRec4[0]);
 			fVec5[0] = (fVec4[1] - (fRec5[0] * fRec7[1]));
 			fRec8[0] = ((fVec3[1] + ((fTemp1 * fRec3[0]) + fVec5[1])) - (fRec6[0] * fRec8[1]));
 			fRec7[0] = fRec8[0];
-			output1[i] = FAUSTFLOAT(fRec7[0]);
+			output1[i0] = FAUSTFLOAT(fRec7[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfz2chEqLshelf.hxx
+++ b/src/sfizz/gen/filters/sfz2chEqLshelf.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -17,13 +17,12 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 #define FAUSTFLOAT float
 #endif 
 
+/* link with : "" */
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
-static double faust2chEqLshelf_faustpower2_f(double value) {
-	return (value * value);
-}
 
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faust2chEqLshelf
@@ -43,11 +42,11 @@ class faust2chEqLshelf : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fVslider0;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
+	double fConst3;
 	FAUSTFLOAT fVslider1;
 	double fRec2[2];
 	double fVec0[2];
@@ -83,9 +82,10 @@ class faust2chEqLshelf : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
+		fConst3 = (2.1775860903036022 / fConst0);
 		//[End:instanceConstants]
 	}
 	
@@ -175,42 +175,40 @@ class faust2chEqLshelf : public sfzFilterDsp {
 		FAUSTFLOAT* output1 = outputs[1];
 		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = std::pow(10.0, (0.025000000000000001 * std::min<double>(60.0, std::max<double>(-120.0, double(fVslider0)))));
-		double fSlow2 = (fConst2 * std::max<double>(0.0, std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0)))));
-		double fSlow3 = std::cos(fSlow2);
-		double fSlow4 = ((fSlow1 + 1.0) * fSlow3);
-		double fSlow5 = (fSlow1 + -1.0);
-		double fSlow6 = (fSlow5 * fSlow3);
-		double fSlow7 = (faust2chEqLshelf_faustpower2_f(fSlow1) + 1.0);
-		double fSlow8 = faust2chEqLshelf_faustpower2_f(fSlow5);
-		double fSlow9 = ((std::sqrt(fSlow1) * std::sin(fSlow2)) / std::max<double>(0.001, (1.0 / std::sqrt((((fSlow1 + (1.0 / fSlow1)) * ((1.0 / std::min<double>(((fSlow7 / fSlow8) + -0.01), std::max<double>(0.01, ((double(fVslider1) * fSlow7) / fSlow8)))) + -1.0)) + 2.0)))));
-		double fSlow10 = (fSlow6 + fSlow9);
-		double fSlow11 = ((fSlow1 + fSlow10) + 1.0);
-		double fSlow12 = (1.0 - fSlow0);
-		double fSlow13 = ((2.0 * ((fSlow1 * (fSlow1 + (-1.0 - fSlow4))) / fSlow11)) * fSlow12);
-		double fSlow14 = (((fSlow1 * ((fSlow1 + fSlow9) + (1.0 - fSlow6))) / fSlow11) * fSlow12);
-		double fSlow15 = (((fSlow1 * (fSlow1 + (1.0 - fSlow10))) / fSlow11) * fSlow12);
-		double fSlow16 = ((((fSlow1 + fSlow6) + (1.0 - fSlow9)) / fSlow11) * fSlow12);
-		double fSlow17 = (((0.0 - (2.0 * ((fSlow1 + fSlow4) + -1.0))) / fSlow11) * fSlow12);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow13);
+		double fSlow2 = std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0)));
+		double fSlow3 = (fConst2 * std::max<double>(0.0, fSlow2));
+		double fSlow4 = std::cos(fSlow3);
+		double fSlow5 = ((fSlow1 + 1.0) * fSlow4);
+		double fSlow6 = ((fSlow1 + -1.0) * fSlow4);
+		double fSlow7 = ((std::sqrt(fSlow1) * std::sin(fSlow3)) / std::max<double>(0.001, (0.5 / double(sinh(double((fConst3 * ((fSlow2 * std::min<double>(12.0, std::max<double>(0.01, double(fVslider1)))) / std::sin((fConst2 * fSlow2))))))))));
+		double fSlow8 = (fSlow6 + fSlow7);
+		double fSlow9 = ((fSlow1 + fSlow8) + 1.0);
+		double fSlow10 = (1.0 - fSlow0);
+		double fSlow11 = ((2.0 * ((fSlow1 * (fSlow1 + (-1.0 - fSlow5))) / fSlow9)) * fSlow10);
+		double fSlow12 = (((fSlow1 * ((fSlow1 + fSlow7) + (1.0 - fSlow6))) / fSlow9) * fSlow10);
+		double fSlow13 = (((fSlow1 * (fSlow1 + (1.0 - fSlow8))) / fSlow9) * fSlow10);
+		double fSlow14 = ((((fSlow1 + fSlow6) + (1.0 - fSlow7)) / fSlow9) * fSlow10);
+		double fSlow15 = (((0.0 - (2.0 * ((fSlow1 + fSlow5) + -1.0))) / fSlow9) * fSlow10);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow11);
 			fVec0[0] = (fTemp0 * fRec2[0]);
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow14);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow15);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
 			fVec1[0] = (fTemp0 * fRec4[0]);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow16);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow14);
 			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
-			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow17);
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow15);
 			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec3[0] = (fTemp1 * fRec2[0]);
 			fVec4[0] = (fTemp1 * fRec4[0]);
 			fVec5[0] = (fVec4[1] - (fRec5[0] * fRec7[1]));
 			fRec8[0] = ((fVec3[1] + ((fTemp1 * fRec3[0]) + fVec5[1])) - (fRec6[0] * fRec8[1]));
 			fRec7[0] = fRec8[0];
-			output1[i] = FAUSTFLOAT(fRec7[0]);
+			output1[i0] = FAUSTFLOAT(fRec7[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfz2chEqPeak.hxx
+++ b/src/sfizz/gen/filters/sfz2chEqPeak.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -20,6 +20,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 /* link with : "" */
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -41,7 +42,6 @@ class faust2chEqPeak : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -81,7 +81,7 @@ class faust2chEqPeak : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		fConst3 = (2.1775860903036022 / fConst0);
@@ -183,9 +183,9 @@ class faust2chEqPeak : public sfzFilterDsp {
 		double fSlow11 = (((fSlow10 + 1.0) / fSlow7) * fSlow8);
 		double fSlow12 = (((1.0 - fSlow10) / fSlow7) * fSlow8);
 		double fSlow13 = (((1.0 - fSlow6) / fSlow7) * fSlow8);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow9);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
@@ -195,13 +195,13 @@ class faust2chEqPeak : public sfzFilterDsp {
 			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
 			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec2[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec3[0] = (fTemp1 * fRec2[0]);
 			fVec4[0] = (fTemp1 * fRec4[0]);
 			fVec5[0] = (fVec4[1] - (fRec5[0] * fRec6[1]));
 			fRec7[0] = ((fVec3[1] + ((fTemp1 * fRec3[0]) + fVec5[1])) - (fRec2[0] * fRec7[1]));
 			fRec6[0] = fRec7[0];
-			output1[i] = FAUSTFLOAT(fRec6[0]);
+			output1[i0] = FAUSTFLOAT(fRec6[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfz2chHpf1p.hxx
+++ b/src/sfizz/gen/filters/sfz2chHpf1p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chHpf1p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -66,7 +66,7 @@ class faust2chHpf1p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (1.0 / fConst0);
 		//[End:instanceConstants]
@@ -120,16 +120,16 @@ class faust2chHpf1p : public sfzFilterDsp {
 		FAUSTFLOAT* output1 = outputs[1];
 		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0))))))) * (1.0 - fSlow0));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow1);
 			fRec0[0] = (fTemp0 + (fRec1[0] * fRec0[1]));
 			double fTemp2 = (fRec1[0] + 1.0);
 			double fTemp3 = (0.0 - (0.5 * fTemp2));
-			output0[i] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp2)) + (fRec0[1] * fTemp3)));
+			output0[i0] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp2)) + (fRec0[1] * fTemp3)));
 			fRec2[0] = (fTemp1 + (fRec1[0] * fRec2[1]));
-			output1[i] = FAUSTFLOAT(((0.5 * (fRec2[0] * fTemp2)) + (fTemp3 * fRec2[1])));
+			output1[i0] = FAUSTFLOAT(((0.5 * (fRec2[0] * fTemp2)) + (fTemp3 * fRec2[1])));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];

--- a/src/sfizz/gen/filters/sfz2chHpf2p.hxx
+++ b/src/sfizz/gen/filters/sfz2chHpf2p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chHpf2p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -78,7 +78,7 @@ class faust2chHpf2p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -174,9 +174,9 @@ class faust2chHpf2p : public sfzFilterDsp {
 		double fSlow7 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
 		double fSlow9 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow7);
@@ -187,14 +187,14 @@ class faust2chHpf2p : public sfzFilterDsp {
 			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow9);
 			fRec1[0] = ((fVec0[1] + (fTemp2 + fVec2[1])) - (fRec5[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec3[0] = (fTemp1 * fRec2[0]);
 			double fTemp3 = (fTemp1 * fRec3[0]);
 			fVec4[0] = fTemp3;
 			fVec5[0] = (fVec4[1] - (fRec4[0] * fRec6[1]));
 			fRec7[0] = ((fVec3[1] + (fTemp3 + fVec5[1])) - (fRec5[0] * fRec7[1]));
 			fRec6[0] = fRec7[0];
-			output1[i] = FAUSTFLOAT(fRec6[0]);
+			output1[i0] = FAUSTFLOAT(fRec6[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfz2chHpf2pSv.hxx
+++ b/src/sfizz/gen/filters/sfz2chHpf2pSv.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chHpf2pSv : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -71,7 +71,7 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
 		//[End:instanceConstants]
@@ -140,9 +140,9 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0))))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * std::min<double>(60.0, std::max<double>(-60.0, double(fVslider0))))));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow2);
 			double fTemp2 = (fSlow3 + fRec4[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + (fSlow1 / ((fRec4[0] * fTemp2) + 1.0)));
@@ -155,7 +155,7 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 			fRec1[0] = (fRec1[1] + (2.0 * (fRec4[0] * fTemp6)));
 			double fTemp7 = (fRec2[1] + (2.0 * fTemp5));
 			fRec2[0] = fTemp7;
-			output0[i] = FAUSTFLOAT(fRec0);
+			output0[i0] = FAUSTFLOAT(fRec0);
 			double fTemp8 = (fTemp1 - (fRec7[1] + (fRec5[0] * fRec8[1])));
 			double fRec6 = (fRec3[0] * fTemp8);
 			double fTemp9 = (fTemp4 * fTemp8);
@@ -163,7 +163,7 @@ class faust2chHpf2pSv : public sfzFilterDsp {
 			fRec7[0] = (fRec7[1] + (2.0 * (fRec4[0] * fTemp10)));
 			double fTemp11 = (fRec8[1] + (2.0 * fTemp9));
 			fRec8[0] = fTemp11;
-			output1[i] = FAUSTFLOAT(fRec6);
+			output1[i0] = FAUSTFLOAT(fRec6);
 			fRec4[1] = fRec4[0];
 			fRec3[1] = fRec3[0];
 			fRec5[1] = fRec5[0];

--- a/src/sfizz/gen/filters/sfz2chHpf4p.hxx
+++ b/src/sfizz/gen/filters/sfz2chHpf4p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chHpf4p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -88,7 +88,7 @@ class faust2chHpf4p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -214,9 +214,9 @@ class faust2chHpf4p : public sfzFilterDsp {
 		double fSlow7 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
 		double fSlow9 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow7);
@@ -233,7 +233,7 @@ class faust2chHpf4p : public sfzFilterDsp {
 			fVec5[0] = (fVec4[1] - (fRec6[0] * fRec0[1]));
 			fRec1[0] = ((fVec3[1] + (fTemp3 + fVec5[1])) - (fRec7[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec6[0] = (fTemp1 * fRec2[0]);
 			double fTemp4 = (fTemp1 * fRec5[0]);
 			fVec7[0] = fTemp4;
@@ -246,7 +246,7 @@ class faust2chHpf4p : public sfzFilterDsp {
 			fVec11[0] = (fVec10[1] - (fRec6[0] * fRec8[1]));
 			fRec9[0] = ((fVec9[1] + (fTemp5 + fVec11[1])) - (fRec7[0] * fRec9[1]));
 			fRec8[0] = fRec9[0];
-			output1[i] = FAUSTFLOAT(fRec8[0]);
+			output1[i0] = FAUSTFLOAT(fRec8[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec5[1] = fRec5[0];

--- a/src/sfizz/gen/filters/sfz2chHpf6p.hxx
+++ b/src/sfizz/gen/filters/sfz2chHpf6p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chHpf6p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -98,7 +98,7 @@ class faust2chHpf6p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -254,9 +254,9 @@ class faust2chHpf6p : public sfzFilterDsp {
 		double fSlow7 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
 		double fSlow9 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec7[0] = ((fSlow0 * fRec7[1]) + fSlow7);
@@ -279,7 +279,7 @@ class faust2chHpf6p : public sfzFilterDsp {
 			fVec8[0] = (fVec7[1] - (fRec8[0] * fRec0[1]));
 			fRec1[0] = ((fVec6[1] + (fTemp4 + fVec8[1])) - (fRec9[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec9[0] = (fTemp1 * fRec2[0]);
 			double fTemp5 = (fTemp1 * fRec7[0]);
 			fVec10[0] = fTemp5;
@@ -298,7 +298,7 @@ class faust2chHpf6p : public sfzFilterDsp {
 			fVec17[0] = (fVec16[1] - (fRec8[0] * fRec10[1]));
 			fRec11[0] = ((fVec15[1] + (fTemp7 + fVec17[1])) - (fRec9[0] * fRec11[1]));
 			fRec10[0] = fRec11[0];
-			output1[i] = FAUSTFLOAT(fRec10[0]);
+			output1[i0] = FAUSTFLOAT(fRec10[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec7[1] = fRec7[0];

--- a/src/sfizz/gen/filters/sfz2chHsh.hxx
+++ b/src/sfizz/gen/filters/sfz2chHsh.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chHsh : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fVslider0;
 	double fConst2;
@@ -80,7 +80,7 @@ class faust2chHsh : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -185,9 +185,9 @@ class faust2chHsh : public sfzFilterDsp {
 		double fSlow12 = (((fSlow1 * ((fSlow1 + fSlow6) + (1.0 - fSlow5))) / fSlow7) * fSlow8);
 		double fSlow13 = (((fSlow1 + (1.0 - fSlow10)) / fSlow7) * fSlow8);
 		double fSlow14 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow7)) * fSlow8);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow9);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
@@ -198,13 +198,13 @@ class faust2chHsh : public sfzFilterDsp {
 			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow14);
 			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec3[0] = (fTemp1 * fRec2[0]);
 			fVec4[0] = (fTemp1 * fRec4[0]);
 			fVec5[0] = (fVec4[1] - (fRec5[0] * fRec7[1]));
 			fRec8[0] = ((fVec3[1] + ((fTemp1 * fRec3[0]) + fVec5[1])) - (fRec6[0] * fRec8[1]));
 			fRec7[0] = fRec8[0];
-			output1[i] = FAUSTFLOAT(fRec7[0]);
+			output1[i0] = FAUSTFLOAT(fRec7[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfz2chLpf1p.hxx
+++ b/src/sfizz/gen/filters/sfz2chLpf1p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chLpf1p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -66,7 +66,7 @@ class faust2chLpf1p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (1.0 / fConst0);
 		//[End:instanceConstants]
@@ -120,15 +120,15 @@ class faust2chLpf1p : public sfzFilterDsp {
 		FAUSTFLOAT* output1 = outputs[1];
 		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0))))))) * (1.0 - fSlow0));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow1);
 			fRec0[0] = (fTemp0 + (fRec1[0] * fRec0[1]));
 			double fTemp2 = (1.0 - fRec1[0]);
-			output0[i] = FAUSTFLOAT((fRec0[0] * fTemp2));
+			output0[i0] = FAUSTFLOAT((fRec0[0] * fTemp2));
 			fRec2[0] = (fTemp1 + (fRec1[0] * fRec2[1]));
-			output1[i] = FAUSTFLOAT((fRec2[0] * fTemp2));
+			output1[i0] = FAUSTFLOAT((fRec2[0] * fTemp2));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
 			fRec2[1] = fRec2[0];

--- a/src/sfizz/gen/filters/sfz2chLpf2p.hxx
+++ b/src/sfizz/gen/filters/sfz2chLpf2p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chLpf2p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fHslider0;
 	FAUSTFLOAT fVslider0;
@@ -78,7 +78,7 @@ class faust2chLpf2p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = (6.2831853071795862 / fConst0);
 		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 		//[End:instanceConstants]
@@ -175,9 +175,9 @@ class faust2chLpf2p : public sfzFilterDsp {
 		double fSlow8 = ((0.5 * fSlow4) * fSlow6);
 		double fSlow9 = (((1.0 - fSlow2) / fSlow3) * fSlow6);
 		double fSlow10 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = (fSlow7 + (fSlow5 * fRec2[1]));
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow5 * fRec3[1]) + fSlow8);
@@ -188,14 +188,14 @@ class faust2chLpf2p : public sfzFilterDsp {
 			fRec5[0] = ((fSlow5 * fRec5[1]) + fSlow10);
 			fRec1[0] = ((fVec0[1] + (fTemp2 + fVec2[1])) - (fRec5[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec3[0] = (fTemp1 * fRec2[0]);
 			double fTemp3 = (fTemp1 * fRec3[0]);
 			fVec4[0] = fTemp3;
 			fVec5[0] = (fVec4[1] - (fRec4[0] * fRec6[1]));
 			fRec7[0] = ((fVec3[1] + (fTemp3 + fVec5[1])) - (fRec5[0] * fRec7[1]));
 			fRec6[0] = fRec7[0];
-			output1[i] = FAUSTFLOAT(fRec6[0]);
+			output1[i0] = FAUSTFLOAT(fRec6[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfz2chLpf2pSv.hxx
+++ b/src/sfizz/gen/filters/sfz2chLpf2pSv.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chLpf2pSv : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -71,7 +71,7 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
 		//[End:instanceConstants]
@@ -140,9 +140,9 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0))))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * std::min<double>(60.0, std::max<double>(-60.0, double(fVslider0))))));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow2);
 			double fTemp2 = (fSlow3 + fRec3[0]);
 			fRec4[0] = ((fSlow0 * fRec4[1]) + (fSlow1 / ((fRec3[0] * fTemp2) + 1.0)));
@@ -155,7 +155,7 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 			double fTemp7 = (fRec2[1] + fTemp5);
 			fRec1[0] = (fRec1[1] + (2.0 * (fRec3[0] * fTemp7)));
 			fRec2[0] = fTemp6;
-			output0[i] = FAUSTFLOAT(fRec0);
+			output0[i0] = FAUSTFLOAT(fRec0);
 			double fTemp8 = (fTemp1 - (fRec7[1] + (fRec5[0] * fRec8[1])));
 			double fTemp9 = (fTemp3 * fTemp8);
 			double fTemp10 = (fRec8[1] + (2.0 * fTemp9));
@@ -163,7 +163,7 @@ class faust2chLpf2pSv : public sfzFilterDsp {
 			double fTemp11 = (fRec8[1] + fTemp9);
 			fRec7[0] = (fRec7[1] + (2.0 * (fRec3[0] * fTemp11)));
 			fRec8[0] = fTemp10;
-			output1[i] = FAUSTFLOAT(fRec6);
+			output1[i0] = FAUSTFLOAT(fRec6);
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
 			fRec5[1] = fRec5[0];

--- a/src/sfizz/gen/filters/sfz2chLpf4p.hxx
+++ b/src/sfizz/gen/filters/sfz2chLpf4p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chLpf4p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fHslider0;
 	FAUSTFLOAT fVslider0;
@@ -88,7 +88,7 @@ class faust2chLpf4p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = (6.2831853071795862 / fConst0);
 		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 		//[End:instanceConstants]
@@ -215,9 +215,9 @@ class faust2chLpf4p : public sfzFilterDsp {
 		double fSlow8 = ((0.5 * fSlow4) * fSlow6);
 		double fSlow9 = (((1.0 - fSlow2) / fSlow3) * fSlow6);
 		double fSlow10 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = (fSlow7 + (fSlow5 * fRec2[1]));
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec5[0] = ((fSlow5 * fRec5[1]) + fSlow8);
@@ -234,7 +234,7 @@ class faust2chLpf4p : public sfzFilterDsp {
 			fVec5[0] = (fVec4[1] - (fRec6[0] * fRec0[1]));
 			fRec1[0] = ((fVec3[1] + (fTemp3 + fVec5[1])) - (fRec7[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec6[0] = (fTemp1 * fRec2[0]);
 			double fTemp4 = (fTemp1 * fRec5[0]);
 			fVec7[0] = fTemp4;
@@ -247,7 +247,7 @@ class faust2chLpf4p : public sfzFilterDsp {
 			fVec11[0] = (fVec10[1] - (fRec6[0] * fRec8[1]));
 			fRec9[0] = ((fVec9[1] + (fTemp5 + fVec11[1])) - (fRec7[0] * fRec9[1]));
 			fRec8[0] = fRec9[0];
-			output1[i] = FAUSTFLOAT(fRec8[0]);
+			output1[i0] = FAUSTFLOAT(fRec8[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec5[1] = fRec5[0];

--- a/src/sfizz/gen/filters/sfz2chLpf6p.hxx
+++ b/src/sfizz/gen/filters/sfz2chLpf6p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chLpf6p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fHslider0;
 	FAUSTFLOAT fVslider0;
@@ -98,7 +98,7 @@ class faust2chLpf6p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = (6.2831853071795862 / fConst0);
 		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 		//[End:instanceConstants]
@@ -255,9 +255,9 @@ class faust2chLpf6p : public sfzFilterDsp {
 		double fSlow8 = ((0.5 * fSlow4) * fSlow6);
 		double fSlow9 = (((1.0 - fSlow2) / fSlow3) * fSlow6);
 		double fSlow10 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = (fSlow7 + (fSlow5 * fRec2[1]));
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec7[0] = ((fSlow5 * fRec7[1]) + fSlow8);
@@ -280,7 +280,7 @@ class faust2chLpf6p : public sfzFilterDsp {
 			fVec8[0] = (fVec7[1] - (fRec8[0] * fRec0[1]));
 			fRec1[0] = ((fVec6[1] + (fTemp4 + fVec8[1])) - (fRec9[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec9[0] = (fTemp1 * fRec2[0]);
 			double fTemp5 = (fTemp1 * fRec7[0]);
 			fVec10[0] = fTemp5;
@@ -299,7 +299,7 @@ class faust2chLpf6p : public sfzFilterDsp {
 			fVec17[0] = (fVec16[1] - (fRec8[0] * fRec10[1]));
 			fRec11[0] = ((fVec15[1] + (fTemp7 + fVec17[1])) - (fRec9[0] * fRec11[1]));
 			fRec10[0] = fRec11[0];
-			output1[i] = FAUSTFLOAT(fRec10[0]);
+			output1[i0] = FAUSTFLOAT(fRec10[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec7[1] = fRec7[0];

--- a/src/sfizz/gen/filters/sfz2chLsh.hxx
+++ b/src/sfizz/gen/filters/sfz2chLsh.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chLsh : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fVslider0;
 	double fConst2;
@@ -80,7 +80,7 @@ class faust2chLsh : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -185,9 +185,9 @@ class faust2chLsh : public sfzFilterDsp {
 		double fSlow12 = (((fSlow1 * (fSlow1 + (1.0 - fSlow7))) / fSlow8) * fSlow9);
 		double fSlow13 = ((((fSlow1 + fSlow5) + (1.0 - fSlow6)) / fSlow8) * fSlow9);
 		double fSlow14 = (((0.0 - (2.0 * ((fSlow1 + fSlow4) + -1.0))) / fSlow8) * fSlow9);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow10);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
@@ -198,13 +198,13 @@ class faust2chLsh : public sfzFilterDsp {
 			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow14);
 			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec3[0] = (fTemp1 * fRec2[0]);
 			fVec4[0] = (fTemp1 * fRec4[0]);
 			fVec5[0] = (fVec4[1] - (fRec5[0] * fRec7[1]));
 			fRec8[0] = ((fVec3[1] + ((fTemp1 * fRec3[0]) + fVec5[1])) - (fRec6[0] * fRec8[1]));
 			fRec7[0] = fRec8[0];
-			output1[i] = FAUSTFLOAT(fRec7[0]);
+			output1[i0] = FAUSTFLOAT(fRec7[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfz2chPeq.hxx
+++ b/src/sfizz/gen/filters/sfz2chPeq.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faust2chPeq : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -79,7 +79,7 @@ class faust2chPeq : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -179,9 +179,9 @@ class faust2chPeq : public sfzFilterDsp {
 		double fSlow10 = (((fSlow9 + 1.0) / fSlow6) * fSlow7);
 		double fSlow11 = (((1.0 - fSlow9) / fSlow6) * fSlow7);
 		double fSlow12 = (((1.0 - fSlow5) / fSlow6) * fSlow7);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow10);
@@ -191,13 +191,13 @@ class faust2chPeq : public sfzFilterDsp {
 			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
 			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec2[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fVec3[0] = (fTemp1 * fRec2[0]);
 			fVec4[0] = (fTemp1 * fRec4[0]);
 			fVec5[0] = (fVec4[1] - (fRec5[0] * fRec6[1]));
 			fRec7[0] = ((fVec3[1] + ((fTemp1 * fRec3[0]) + fVec5[1])) - (fRec2[0] * fRec7[1]));
 			fRec6[0] = fRec7[0];
-			output1[i] = FAUSTFLOAT(fRec6[0]);
+			output1[i0] = FAUSTFLOAT(fRec6[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfz2chPink.hxx
+++ b/src/sfizz/gen/filters/sfz2chPink.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 
 
 #ifndef FAUSTCLASS 
@@ -105,13 +106,13 @@ class faust2chPink : public sfzFilterDsp {
 		FAUSTFLOAT const* input1 = inputs[1];
 		FAUSTFLOAT* output0 = outputs[0];
 		FAUSTFLOAT* output1 = outputs[1];
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			double fTemp1 = double(input1[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			double fTemp1 = double(input1[i0]);
 			fRec0[0] = ((fTemp0 + ((2.4949560019999999 * fRec0[1]) + (0.52218940000000003 * fRec0[3]))) - (2.0172658750000001 * fRec0[2]));
-			output0[i] = FAUSTFLOAT((((0.049922034999999997 * fRec0[0]) + (0.050612698999999997 * fRec0[2])) - ((0.095993537000000004 * fRec0[1]) + (0.0044087859999999996 * fRec0[3]))));
+			output0[i0] = FAUSTFLOAT((((0.049922034999999997 * fRec0[0]) + (0.050612698999999997 * fRec0[2])) - ((0.095993537000000004 * fRec0[1]) + (0.0044087859999999996 * fRec0[3]))));
 			fRec1[0] = ((fTemp1 + ((2.4949560019999999 * fRec1[1]) + (0.52218940000000003 * fRec1[3]))) - (2.0172658750000001 * fRec1[2]));
-			output1[i] = FAUSTFLOAT((((0.049922034999999997 * fRec1[0]) + (0.050612698999999997 * fRec1[2])) - ((0.095993537000000004 * fRec1[1]) + (0.0044087859999999996 * fRec1[3]))));
+			output1[i0] = FAUSTFLOAT((((0.049922034999999997 * fRec1[0]) + (0.050612698999999997 * fRec1[2])) - ((0.095993537000000004 * fRec1[1]) + (0.0044087859999999996 * fRec1[3]))));
 			for (int j0 = 3; (j0 > 0); j0 = (j0 - 1)) {
 				fRec0[j0] = fRec0[(j0 - 1)];
 			}

--- a/src/sfizz/gen/filters/sfzApf1p.hxx
+++ b/src/sfizz/gen/filters/sfzApf1p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustApf1p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -65,7 +65,7 @@ class faustApf1p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -114,11 +114,11 @@ class faustApf1p : public sfzFilterDsp {
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (((fConst2 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0)))) + -1.0) * (1.0 - fSlow0));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow1);
 			fRec0[0] = (fTemp0 - (fRec1[0] * fRec0[1]));
-			output0[i] = FAUSTFLOAT((fRec0[1] + (fRec1[0] * fRec0[0])));
+			output0[i0] = FAUSTFLOAT((fRec0[1] + (fRec1[0] * fRec0[0])));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
 		}

--- a/src/sfizz/gen/filters/sfzBpf1p.hxx
+++ b/src/sfizz/gen/filters/sfzBpf1p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustBpf1p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -66,7 +66,7 @@ class faustBpf1p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (1.0 / fConst0);
 		//[End:instanceConstants]
@@ -118,13 +118,13 @@ class faustBpf1p : public sfzFilterDsp {
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0))))))) * (1.0 - fSlow0));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow1);
 			fRec1[0] = (fTemp0 + (fRec2[0] * fRec1[1]));
 			fRec0[0] = ((fRec1[0] * (1.0 - fRec2[0])) + (fRec2[0] * fRec0[1]));
 			double fTemp1 = (fRec2[0] + 1.0);
-			output0[i] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp1)) + (fRec0[1] * (0.0 - (0.5 * fTemp1)))));
+			output0[i0] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp1)) + (fRec0[1] * (0.0 - (0.5 * fTemp1)))));
 			fRec2[1] = fRec2[0];
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];

--- a/src/sfizz/gen/filters/sfzBpf2p.hxx
+++ b/src/sfizz/gen/filters/sfzBpf2p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustBpf2p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fRec2[2];
 	double fVec0[2];
@@ -74,7 +74,7 @@ class faustBpf2p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -158,8 +158,8 @@ class faustBpf2p : public sfzFilterDsp {
 		double fSlow9 = ((0.0 - fSlow6) * fSlow7);
 		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
 		double fSlow11 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = (fSlow0 * fRec2[1]);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow8);
@@ -170,7 +170,7 @@ class faustBpf2p : public sfzFilterDsp {
 			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow11);
 			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfzBpf2pSv.hxx
+++ b/src/sfizz/gen/filters/sfzBpf2pSv.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustBpf2pSv : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -69,7 +69,7 @@ class faustBpf2pSv : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
 		//[End:instanceConstants]
@@ -130,8 +130,8 @@ class faustBpf2pSv : public sfzFilterDsp {
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0))))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * std::min<double>(60.0, std::max<double>(-60.0, double(fVslider0))))));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow2);
 			double fTemp1 = (fSlow3 + fRec3[0]);
 			fRec4[0] = ((fSlow0 * fRec4[1]) + (fSlow1 / ((fRec3[0] * fTemp1) + 1.0)));
@@ -143,7 +143,7 @@ class faustBpf2pSv : public sfzFilterDsp {
 			fRec1[0] = (fRec1[1] + (2.0 * (fRec3[0] * fTemp4)));
 			double fTemp5 = (fRec2[1] + (2.0 * fTemp3));
 			fRec2[0] = fTemp5;
-			output0[i] = FAUSTFLOAT(fRec0);
+			output0[i0] = FAUSTFLOAT(fRec0);
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
 			fRec5[1] = fRec5[0];

--- a/src/sfizz/gen/filters/sfzBpf4p.hxx
+++ b/src/sfizz/gen/filters/sfzBpf4p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustBpf4p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -79,7 +79,7 @@ class faustBpf4p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -178,8 +178,8 @@ class faustBpf4p : public sfzFilterDsp {
 		double fSlow9 = (fSlow6 * fSlow7);
 		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
 		double fSlow11 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
 			fRec5[0] = (fSlow0 * fRec5[1]);
 			fVec0[0] = (fTemp0 * fRec5[0]);
@@ -195,7 +195,7 @@ class faustBpf4p : public sfzFilterDsp {
 			fVec5[0] = (fRec5[0] * fRec3[0]);
 			fRec1[0] = (((fVec4[1] + fVec5[1]) + (fRec6[0] * fRec3[0])) - (fRec8[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fRec5[1] = fRec5[0];
 			fVec0[1] = fVec0[0];

--- a/src/sfizz/gen/filters/sfzBpf6p.hxx
+++ b/src/sfizz/gen/filters/sfzBpf6p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustBpf6p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -84,7 +84,7 @@ class faustBpf6p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -198,8 +198,8 @@ class faustBpf6p : public sfzFilterDsp {
 		double fSlow9 = (fSlow6 * fSlow7);
 		double fSlow10 = (((1.0 - fSlow4) / fSlow5) * fSlow7);
 		double fSlow11 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow5) * fSlow7);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
 			fRec7[0] = (fSlow0 * fRec7[1]);
 			fVec0[0] = (fTemp0 * fRec7[0]);
@@ -220,7 +220,7 @@ class faustBpf6p : public sfzFilterDsp {
 			fVec8[0] = (fRec7[0] * fRec3[0]);
 			fRec1[0] = (((fVec7[1] + fVec8[1]) + (fRec8[0] * fRec3[0])) - (fRec10[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fRec7[1] = fRec7[0];
 			fVec0[1] = fVec0[0];

--- a/src/sfizz/gen/filters/sfzBrf1p.hxx
+++ b/src/sfizz/gen/filters/sfzBrf1p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustBrf1p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -66,7 +66,7 @@ class faustBrf1p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -118,12 +118,12 @@ class faustBrf1p : public sfzFilterDsp {
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (((fConst2 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0)))) + -1.0) * (1.0 - fSlow0));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow1);
 			fRec1[0] = (fTemp0 - (fRec2[0] * fRec1[1]));
 			fRec0[0] = (fRec1[1] + (fRec2[0] * (fRec1[0] - fRec0[1])));
-			output0[i] = FAUSTFLOAT((fTemp0 + (fRec0[1] + (fRec2[0] * fRec0[0]))));
+			output0[i0] = FAUSTFLOAT((fTemp0 + (fRec0[1] + (fRec2[0] * fRec0[0]))));
 			fRec2[1] = fRec2[0];
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];

--- a/src/sfizz/gen/filters/sfzBrf2p.hxx
+++ b/src/sfizz/gen/filters/sfzBrf2p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustBrf2p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -72,7 +72,7 @@ class faustBrf2p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -146,8 +146,8 @@ class faustBrf2p : public sfzFilterDsp {
 		double fSlow5 = (((0.0 - (2.0 * std::cos(fSlow1))) / fSlow3) * fSlow4);
 		double fSlow6 = ((1.0 / fSlow3) * fSlow4);
 		double fSlow7 = (((1.0 - fSlow2) / fSlow3) * fSlow4);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow5);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow6);
@@ -157,7 +157,7 @@ class faustBrf2p : public sfzFilterDsp {
 			fVec2[0] = (fVec1[1] - (fRec4[0] * fRec0[1]));
 			fRec1[0] = ((fVec0[1] + (fTemp1 + fVec2[1])) - (fRec2[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfzBrf2pSv.hxx
+++ b/src/sfizz/gen/filters/sfzBrf2pSv.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustBrf2pSv : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -69,7 +69,7 @@ class faustBrf2pSv : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
 		//[End:instanceConstants]
@@ -130,8 +130,8 @@ class faustBrf2pSv : public sfzFilterDsp {
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0))))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * std::min<double>(60.0, std::max<double>(-60.0, double(fVslider0))))));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow2);
 			double fTemp1 = (fSlow3 + fRec5[0]);
 			fRec4[0] = ((fSlow0 * fRec4[1]) + (fSlow1 / ((fRec5[0] * fTemp1) + 1.0)));
@@ -144,7 +144,7 @@ class faustBrf2pSv : public sfzFilterDsp {
 			double fTemp5 = (fRec3[1] + fTemp3);
 			fRec2[0] = (fRec2[1] + (2.0 * (fRec5[0] * fTemp5)));
 			fRec3[0] = fTemp4;
-			output0[i] = FAUSTFLOAT((fRec1 + fRec0));
+			output0[i0] = FAUSTFLOAT((fRec1 + fRec0));
 			fRec5[1] = fRec5[0];
 			fRec4[1] = fRec4[0];
 			fRec6[1] = fRec6[0];

--- a/src/sfizz/gen/filters/sfzEqHshelf.hxx
+++ b/src/sfizz/gen/filters/sfzEqHshelf.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -17,13 +17,12 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 #define FAUSTFLOAT float
 #endif 
 
+/* link with : "" */
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
-static double faustEqHshelf_faustpower2_f(double value) {
-	return (value * value);
-}
 
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustEqHshelf
@@ -43,11 +42,11 @@ class faustEqHshelf : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fVslider0;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
+	double fConst3;
 	FAUSTFLOAT fVslider1;
 	double fRec2[2];
 	double fVec0[2];
@@ -78,9 +77,10 @@ class faustEqHshelf : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
+		fConst3 = (2.1775860903036022 / fConst0);
 		//[End:instanceConstants]
 	}
 	
@@ -153,35 +153,33 @@ class faustEqHshelf : public sfzFilterDsp {
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = std::pow(10.0, (0.025000000000000001 * std::min<double>(60.0, std::max<double>(-120.0, double(fVslider0)))));
-		double fSlow2 = (fConst2 * std::max<double>(0.0, std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0)))));
-		double fSlow3 = std::cos(fSlow2);
-		double fSlow4 = ((fSlow1 + 1.0) * fSlow3);
-		double fSlow5 = (faustEqHshelf_faustpower2_f(fSlow1) + 1.0);
-		double fSlow6 = (fSlow1 + -1.0);
-		double fSlow7 = faustEqHshelf_faustpower2_f(fSlow6);
-		double fSlow8 = ((std::sqrt(fSlow1) * std::sin(fSlow2)) / std::max<double>(0.001, (1.0 / std::sqrt((((fSlow1 + (1.0 / fSlow1)) * ((1.0 / std::min<double>(((fSlow5 / fSlow7) + -0.01), std::max<double>(0.01, ((double(fVslider1) * fSlow5) / fSlow7)))) + -1.0)) + 2.0)))));
-		double fSlow9 = (fSlow6 * fSlow3);
-		double fSlow10 = ((fSlow1 + fSlow8) + (1.0 - fSlow9));
-		double fSlow11 = (1.0 - fSlow0);
-		double fSlow12 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow1 + fSlow4) + -1.0)) / fSlow10) * fSlow11);
-		double fSlow13 = (fSlow9 + fSlow8);
-		double fSlow14 = (((fSlow1 * ((fSlow1 + fSlow13) + 1.0)) / fSlow10) * fSlow11);
-		double fSlow15 = (((fSlow1 * ((fSlow1 + fSlow9) + (1.0 - fSlow8))) / fSlow10) * fSlow11);
-		double fSlow16 = (((fSlow1 + (1.0 - fSlow13)) / fSlow10) * fSlow11);
-		double fSlow17 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow10)) * fSlow11);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow12);
+		double fSlow2 = std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0)));
+		double fSlow3 = (fConst2 * std::max<double>(0.0, fSlow2));
+		double fSlow4 = std::cos(fSlow3);
+		double fSlow5 = ((fSlow1 + 1.0) * fSlow4);
+		double fSlow6 = ((std::sqrt(fSlow1) * std::sin(fSlow3)) / std::max<double>(0.001, (0.5 / double(sinh(double((fConst3 * ((fSlow2 * std::min<double>(12.0, std::max<double>(0.01, double(fVslider1)))) / std::sin((fConst2 * fSlow2))))))))));
+		double fSlow7 = ((fSlow1 + -1.0) * fSlow4);
+		double fSlow8 = ((fSlow1 + fSlow6) + (1.0 - fSlow7));
+		double fSlow9 = (1.0 - fSlow0);
+		double fSlow10 = ((((0.0 - (2.0 * fSlow1)) * ((fSlow1 + fSlow5) + -1.0)) / fSlow8) * fSlow9);
+		double fSlow11 = (fSlow7 + fSlow6);
+		double fSlow12 = (((fSlow1 * ((fSlow1 + fSlow11) + 1.0)) / fSlow8) * fSlow9);
+		double fSlow13 = (((fSlow1 * ((fSlow1 + fSlow7) + (1.0 - fSlow6))) / fSlow8) * fSlow9);
+		double fSlow14 = (((fSlow1 + (1.0 - fSlow11)) / fSlow8) * fSlow9);
+		double fSlow15 = ((2.0 * ((fSlow1 + (-1.0 - fSlow5)) / fSlow8)) * fSlow9);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow10);
 			fVec0[0] = (fTemp0 * fRec2[0]);
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow14);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow15);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
 			fVec1[0] = (fTemp0 * fRec4[0]);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow16);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow14);
 			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
-			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow17);
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow15);
 			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfzEqLshelf.hxx
+++ b/src/sfizz/gen/filters/sfzEqLshelf.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -17,13 +17,12 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 #define FAUSTFLOAT float
 #endif 
 
+/* link with : "" */
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
-static double faustEqLshelf_faustpower2_f(double value) {
-	return (value * value);
-}
 
 #ifndef FAUSTCLASS 
 #define FAUSTCLASS faustEqLshelf
@@ -43,11 +42,11 @@ class faustEqLshelf : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fVslider0;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
+	double fConst3;
 	FAUSTFLOAT fVslider1;
 	double fRec2[2];
 	double fVec0[2];
@@ -78,9 +77,10 @@ class faustEqLshelf : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
+		fConst3 = (2.1775860903036022 / fConst0);
 		//[End:instanceConstants]
 	}
 	
@@ -153,35 +153,33 @@ class faustEqLshelf : public sfzFilterDsp {
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = std::pow(10.0, (0.025000000000000001 * std::min<double>(60.0, std::max<double>(-120.0, double(fVslider0)))));
-		double fSlow2 = (fConst2 * std::max<double>(0.0, std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0)))));
-		double fSlow3 = std::cos(fSlow2);
-		double fSlow4 = ((fSlow1 + 1.0) * fSlow3);
-		double fSlow5 = (fSlow1 + -1.0);
-		double fSlow6 = (fSlow5 * fSlow3);
-		double fSlow7 = (faustEqLshelf_faustpower2_f(fSlow1) + 1.0);
-		double fSlow8 = faustEqLshelf_faustpower2_f(fSlow5);
-		double fSlow9 = ((std::sqrt(fSlow1) * std::sin(fSlow2)) / std::max<double>(0.001, (1.0 / std::sqrt((((fSlow1 + (1.0 / fSlow1)) * ((1.0 / std::min<double>(((fSlow7 / fSlow8) + -0.01), std::max<double>(0.01, ((double(fVslider1) * fSlow7) / fSlow8)))) + -1.0)) + 2.0)))));
-		double fSlow10 = (fSlow6 + fSlow9);
-		double fSlow11 = ((fSlow1 + fSlow10) + 1.0);
-		double fSlow12 = (1.0 - fSlow0);
-		double fSlow13 = ((2.0 * ((fSlow1 * (fSlow1 + (-1.0 - fSlow4))) / fSlow11)) * fSlow12);
-		double fSlow14 = (((fSlow1 * ((fSlow1 + fSlow9) + (1.0 - fSlow6))) / fSlow11) * fSlow12);
-		double fSlow15 = (((fSlow1 * (fSlow1 + (1.0 - fSlow10))) / fSlow11) * fSlow12);
-		double fSlow16 = ((((fSlow1 + fSlow6) + (1.0 - fSlow9)) / fSlow11) * fSlow12);
-		double fSlow17 = (((0.0 - (2.0 * ((fSlow1 + fSlow4) + -1.0))) / fSlow11) * fSlow12);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
-			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow13);
+		double fSlow2 = std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0)));
+		double fSlow3 = (fConst2 * std::max<double>(0.0, fSlow2));
+		double fSlow4 = std::cos(fSlow3);
+		double fSlow5 = ((fSlow1 + 1.0) * fSlow4);
+		double fSlow6 = ((fSlow1 + -1.0) * fSlow4);
+		double fSlow7 = ((std::sqrt(fSlow1) * std::sin(fSlow3)) / std::max<double>(0.001, (0.5 / double(sinh(double((fConst3 * ((fSlow2 * std::min<double>(12.0, std::max<double>(0.01, double(fVslider1)))) / std::sin((fConst2 * fSlow2))))))))));
+		double fSlow8 = (fSlow6 + fSlow7);
+		double fSlow9 = ((fSlow1 + fSlow8) + 1.0);
+		double fSlow10 = (1.0 - fSlow0);
+		double fSlow11 = ((2.0 * ((fSlow1 * (fSlow1 + (-1.0 - fSlow5))) / fSlow9)) * fSlow10);
+		double fSlow12 = (((fSlow1 * ((fSlow1 + fSlow7) + (1.0 - fSlow6))) / fSlow9) * fSlow10);
+		double fSlow13 = (((fSlow1 * (fSlow1 + (1.0 - fSlow8))) / fSlow9) * fSlow10);
+		double fSlow14 = ((((fSlow1 + fSlow6) + (1.0 - fSlow7)) / fSlow9) * fSlow10);
+		double fSlow15 = (((0.0 - (2.0 * ((fSlow1 + fSlow5) + -1.0))) / fSlow9) * fSlow10);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
+			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow11);
 			fVec0[0] = (fTemp0 * fRec2[0]);
-			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow14);
-			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow15);
+			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow12);
+			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow13);
 			fVec1[0] = (fTemp0 * fRec4[0]);
-			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow16);
+			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow14);
 			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
-			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow17);
+			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow15);
 			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfzEqPeak.hxx
+++ b/src/sfizz/gen/filters/sfzEqPeak.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -20,6 +20,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 /* link with : "" */
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -41,7 +42,6 @@ class faustEqPeak : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -76,7 +76,7 @@ class faustEqPeak : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		fConst3 = (2.1775860903036022 / fConst0);
@@ -161,8 +161,8 @@ class faustEqPeak : public sfzFilterDsp {
 		double fSlow11 = (((fSlow10 + 1.0) / fSlow7) * fSlow8);
 		double fSlow12 = (((1.0 - fSlow10) / fSlow7) * fSlow8);
 		double fSlow13 = (((1.0 - fSlow6) / fSlow7) * fSlow8);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow9);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
@@ -172,7 +172,7 @@ class faustEqPeak : public sfzFilterDsp {
 			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
 			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec2[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfzHpf1p.hxx
+++ b/src/sfizz/gen/filters/sfzHpf1p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustHpf1p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -65,7 +65,7 @@ class faustHpf1p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (1.0 / fConst0);
 		//[End:instanceConstants]
@@ -114,12 +114,12 @@ class faustHpf1p : public sfzFilterDsp {
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0))))))) * (1.0 - fSlow0));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow1);
 			fRec0[0] = (fTemp0 + (fRec1[0] * fRec0[1]));
 			double fTemp1 = (fRec1[0] + 1.0);
-			output0[i] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp1)) + (fRec0[1] * (0.0 - (0.5 * fTemp1)))));
+			output0[i0] = FAUSTFLOAT(((0.5 * (fRec0[0] * fTemp1)) + (fRec0[1] * (0.0 - (0.5 * fTemp1)))));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
 		}

--- a/src/sfizz/gen/filters/sfzHpf2p.hxx
+++ b/src/sfizz/gen/filters/sfzHpf2p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustHpf2p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -73,7 +73,7 @@ class faustHpf2p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -152,8 +152,8 @@ class faustHpf2p : public sfzFilterDsp {
 		double fSlow7 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
 		double fSlow9 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow7);
@@ -164,7 +164,7 @@ class faustHpf2p : public sfzFilterDsp {
 			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow9);
 			fRec1[0] = ((fVec0[1] + (fTemp1 + fVec2[1])) - (fRec5[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfzHpf2pSv.hxx
+++ b/src/sfizz/gen/filters/sfzHpf2pSv.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustHpf2pSv : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -69,7 +69,7 @@ class faustHpf2pSv : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
 		//[End:instanceConstants]
@@ -130,8 +130,8 @@ class faustHpf2pSv : public sfzFilterDsp {
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0))))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * std::min<double>(60.0, std::max<double>(-60.0, double(fVslider0))))));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec4[0] = ((fSlow0 * fRec4[1]) + fSlow2);
 			double fTemp1 = (fSlow3 + fRec4[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + (fSlow1 / ((fRec4[0] * fTemp1) + 1.0)));
@@ -143,7 +143,7 @@ class faustHpf2pSv : public sfzFilterDsp {
 			fRec1[0] = (fRec1[1] + (2.0 * (fRec4[0] * fTemp4)));
 			double fTemp5 = (fRec2[1] + (2.0 * fTemp3));
 			fRec2[0] = fTemp5;
-			output0[i] = FAUSTFLOAT(fRec0);
+			output0[i0] = FAUSTFLOAT(fRec0);
 			fRec4[1] = fRec4[0];
 			fRec3[1] = fRec3[0];
 			fRec5[1] = fRec5[0];

--- a/src/sfizz/gen/filters/sfzHpf4p.hxx
+++ b/src/sfizz/gen/filters/sfzHpf4p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustHpf4p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -78,7 +78,7 @@ class faustHpf4p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -172,8 +172,8 @@ class faustHpf4p : public sfzFilterDsp {
 		double fSlow7 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
 		double fSlow9 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec5[0] = ((fSlow0 * fRec5[1]) + fSlow7);
@@ -190,7 +190,7 @@ class faustHpf4p : public sfzFilterDsp {
 			fVec5[0] = (fVec4[1] - (fRec6[0] * fRec0[1]));
 			fRec1[0] = ((fVec3[1] + (fTemp2 + fVec5[1])) - (fRec7[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec5[1] = fRec5[0];

--- a/src/sfizz/gen/filters/sfzHpf6p.hxx
+++ b/src/sfizz/gen/filters/sfzHpf6p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustHpf6p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -83,7 +83,7 @@ class faustHpf6p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -192,8 +192,8 @@ class faustHpf6p : public sfzFilterDsp {
 		double fSlow7 = ((0.5 * ((fSlow2 + 1.0) / fSlow4)) * fSlow5);
 		double fSlow8 = (((1.0 - fSlow3) / fSlow4) * fSlow5);
 		double fSlow9 = (((0.0 - (2.0 * fSlow2)) / fSlow4) * fSlow5);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow6);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec7[0] = ((fSlow0 * fRec7[1]) + fSlow7);
@@ -216,7 +216,7 @@ class faustHpf6p : public sfzFilterDsp {
 			fVec8[0] = (fVec7[1] - (fRec8[0] * fRec0[1]));
 			fRec1[0] = ((fVec6[1] + (fTemp3 + fVec8[1])) - (fRec9[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec7[1] = fRec7[0];

--- a/src/sfizz/gen/filters/sfzHsh.hxx
+++ b/src/sfizz/gen/filters/sfzHsh.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustHsh : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fVslider0;
 	double fConst2;
@@ -75,7 +75,7 @@ class faustHsh : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -163,8 +163,8 @@ class faustHsh : public sfzFilterDsp {
 		double fSlow12 = (((fSlow1 * ((fSlow1 + fSlow6) + (1.0 - fSlow5))) / fSlow7) * fSlow8);
 		double fSlow13 = (((fSlow1 + (1.0 - fSlow10)) / fSlow7) * fSlow8);
 		double fSlow14 = ((2.0 * ((fSlow1 + (-1.0 - fSlow4)) / fSlow7)) * fSlow8);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow9);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
@@ -175,7 +175,7 @@ class faustHsh : public sfzFilterDsp {
 			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow14);
 			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfzLpf1p.hxx
+++ b/src/sfizz/gen/filters/sfzLpf1p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustLpf1p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -65,7 +65,7 @@ class faustLpf1p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (1.0 / fConst0);
 		//[End:instanceConstants]
@@ -114,11 +114,11 @@ class faustLpf1p : public sfzFilterDsp {
 		FAUSTFLOAT* output0 = outputs[0];
 		double fSlow0 = (fSmoothEnable ? fConst1 : 0.0);
 		double fSlow1 = (std::exp((fConst2 * (0.0 - (6.2831853071795862 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0))))))) * (1.0 - fSlow0));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec1[0] = ((fSlow0 * fRec1[1]) + fSlow1);
 			fRec0[0] = (fTemp0 + (fRec1[0] * fRec0[1]));
-			output0[i] = FAUSTFLOAT((fRec0[0] * (1.0 - fRec1[0])));
+			output0[i0] = FAUSTFLOAT((fRec0[0] * (1.0 - fRec1[0])));
 			fRec1[1] = fRec1[0];
 			fRec0[1] = fRec0[0];
 		}

--- a/src/sfizz/gen/filters/sfzLpf2p.hxx
+++ b/src/sfizz/gen/filters/sfzLpf2p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustLpf2p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fHslider0;
 	FAUSTFLOAT fVslider0;
@@ -73,7 +73,7 @@ class faustLpf2p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = (6.2831853071795862 / fConst0);
 		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 		//[End:instanceConstants]
@@ -153,8 +153,8 @@ class faustLpf2p : public sfzFilterDsp {
 		double fSlow8 = ((0.5 * fSlow4) * fSlow6);
 		double fSlow9 = (((1.0 - fSlow2) / fSlow3) * fSlow6);
 		double fSlow10 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = (fSlow7 + (fSlow5 * fRec2[1]));
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow5 * fRec3[1]) + fSlow8);
@@ -165,7 +165,7 @@ class faustLpf2p : public sfzFilterDsp {
 			fRec5[0] = ((fSlow5 * fRec5[1]) + fSlow10);
 			fRec1[0] = ((fVec0[1] + (fTemp1 + fVec2[1])) - (fRec5[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfzLpf2pSv.hxx
+++ b/src/sfizz/gen/filters/sfzLpf2pSv.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustLpf2pSv : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -69,7 +69,7 @@ class faustLpf2pSv : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (3.1415926535897931 / fConst0);
 		//[End:instanceConstants]
@@ -130,8 +130,8 @@ class faustLpf2pSv : public sfzFilterDsp {
 		double fSlow1 = (1.0 - fSlow0);
 		double fSlow2 = (std::tan((fConst2 * std::min<double>(20000.0, std::max<double>(1.0, double(fHslider0))))) * fSlow1);
 		double fSlow3 = (1.0 / std::pow(10.0, (0.050000000000000003 * std::min<double>(60.0, std::max<double>(-60.0, double(fVslider0))))));
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow2);
 			double fTemp1 = (fSlow3 + fRec3[0]);
 			fRec4[0] = ((fSlow0 * fRec4[1]) + (fSlow1 / ((fRec3[0] * fTemp1) + 1.0)));
@@ -143,7 +143,7 @@ class faustLpf2pSv : public sfzFilterDsp {
 			double fTemp5 = (fRec2[1] + fTemp3);
 			fRec1[0] = (fRec1[1] + (2.0 * (fRec3[0] * fTemp5)));
 			fRec2[0] = fTemp4;
-			output0[i] = FAUSTFLOAT(fRec0);
+			output0[i0] = FAUSTFLOAT(fRec0);
 			fRec3[1] = fRec3[0];
 			fRec4[1] = fRec4[0];
 			fRec5[1] = fRec5[0];

--- a/src/sfizz/gen/filters/sfzLpf4p.hxx
+++ b/src/sfizz/gen/filters/sfzLpf4p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustLpf4p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fHslider0;
 	FAUSTFLOAT fVslider0;
@@ -78,7 +78,7 @@ class faustLpf4p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = (6.2831853071795862 / fConst0);
 		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 		//[End:instanceConstants]
@@ -173,8 +173,8 @@ class faustLpf4p : public sfzFilterDsp {
 		double fSlow8 = ((0.5 * fSlow4) * fSlow6);
 		double fSlow9 = (((1.0 - fSlow2) / fSlow3) * fSlow6);
 		double fSlow10 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = (fSlow7 + (fSlow5 * fRec2[1]));
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec5[0] = ((fSlow5 * fRec5[1]) + fSlow8);
@@ -191,7 +191,7 @@ class faustLpf4p : public sfzFilterDsp {
 			fVec5[0] = (fVec4[1] - (fRec6[0] * fRec0[1]));
 			fRec1[0] = ((fVec3[1] + (fTemp2 + fVec5[1])) - (fRec7[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec5[1] = fRec5[0];

--- a/src/sfizz/gen/filters/sfzLpf6p.hxx
+++ b/src/sfizz/gen/filters/sfzLpf6p.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustLpf6p : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fHslider0;
 	FAUSTFLOAT fVslider0;
@@ -83,7 +83,7 @@ class faustLpf6p : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = (6.2831853071795862 / fConst0);
 		fConst2 = std::exp((0.0 - (1000.0 / fConst0)));
 		//[End:instanceConstants]
@@ -193,8 +193,8 @@ class faustLpf6p : public sfzFilterDsp {
 		double fSlow8 = ((0.5 * fSlow4) * fSlow6);
 		double fSlow9 = (((1.0 - fSlow2) / fSlow3) * fSlow6);
 		double fSlow10 = (((0.0 - (2.0 * fSlow1)) / fSlow3) * fSlow6);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = (fSlow7 + (fSlow5 * fRec2[1]));
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec7[0] = ((fSlow5 * fRec7[1]) + fSlow8);
@@ -217,7 +217,7 @@ class faustLpf6p : public sfzFilterDsp {
 			fVec8[0] = (fVec7[1] - (fRec8[0] * fRec0[1]));
 			fRec1[0] = ((fVec6[1] + (fTemp3 + fVec8[1])) - (fRec9[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec7[1] = fRec7[0];

--- a/src/sfizz/gen/filters/sfzLsh.hxx
+++ b/src/sfizz/gen/filters/sfzLsh.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustLsh : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	FAUSTFLOAT fVslider0;
 	double fConst2;
@@ -75,7 +75,7 @@ class faustLsh : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -163,8 +163,8 @@ class faustLsh : public sfzFilterDsp {
 		double fSlow12 = (((fSlow1 * (fSlow1 + (1.0 - fSlow7))) / fSlow8) * fSlow9);
 		double fSlow13 = ((((fSlow1 + fSlow5) + (1.0 - fSlow6)) / fSlow8) * fSlow9);
 		double fSlow14 = (((0.0 - (2.0 * ((fSlow1 + fSlow4) + -1.0))) / fSlow8) * fSlow9);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow10);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow11);
@@ -175,7 +175,7 @@ class faustLsh : public sfzFilterDsp {
 			fRec6[0] = ((fSlow0 * fRec6[1]) + fSlow14);
 			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec6[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfzPeq.hxx
+++ b/src/sfizz/gen/filters/sfzPeq.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <math.h>
 
 
@@ -40,7 +41,6 @@ class faustPeq : public sfzFilterDsp {
  private:
 	
 	int fSampleRate;
-	double fConst0;
 	double fConst1;
 	double fConst2;
 	FAUSTFLOAT fHslider0;
@@ -74,7 +74,7 @@ class faustPeq : public sfzFilterDsp {
 	void instanceConstants(int sample_rate) {
 		//[Begin:instanceConstants]
 		fSampleRate = sample_rate;
-		fConst0 = double(fSampleRate);
+		double fConst0 = double(fSampleRate);
 		fConst1 = std::exp((0.0 - (1000.0 / fConst0)));
 		fConst2 = (6.2831853071795862 / fConst0);
 		//[End:instanceConstants]
@@ -157,8 +157,8 @@ class faustPeq : public sfzFilterDsp {
 		double fSlow10 = (((fSlow9 + 1.0) / fSlow6) * fSlow7);
 		double fSlow11 = (((1.0 - fSlow9) / fSlow6) * fSlow7);
 		double fSlow12 = (((1.0 - fSlow5) / fSlow6) * fSlow7);
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec2[0] = ((fSlow0 * fRec2[1]) + fSlow8);
 			fVec0[0] = (fTemp0 * fRec2[0]);
 			fRec3[0] = ((fSlow0 * fRec3[1]) + fSlow10);
@@ -168,7 +168,7 @@ class faustPeq : public sfzFilterDsp {
 			fVec2[0] = (fVec1[1] - (fRec5[0] * fRec0[1]));
 			fRec1[0] = ((fVec0[1] + ((fTemp0 * fRec3[0]) + fVec2[1])) - (fRec2[0] * fRec1[1]));
 			fRec0[0] = fRec1[0];
-			output0[i] = FAUSTFLOAT(fRec0[0]);
+			output0[i0] = FAUSTFLOAT(fRec0[0]);
 			fRec2[1] = fRec2[0];
 			fVec0[1] = fVec0[0];
 			fRec3[1] = fRec3[0];

--- a/src/sfizz/gen/filters/sfzPink.hxx
+++ b/src/sfizz/gen/filters/sfzPink.hxx
@@ -6,7 +6,7 @@
 author: "Jean Pierre Cimalando"
 license: "BSD-2-Clause"
 name: "sfz_filters"
-Code generated with Faust 2.30.5 (https://faust.grame.fr)
+Code generated with Faust 2.37.3 (https://faust.grame.fr)
 Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 ------------------------------------------------------------ */
 
@@ -19,6 +19,7 @@ Compilation options: -lang cpp -inpl -es 1 -double -ftz 0
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 
 
 #ifndef FAUSTCLASS 
@@ -99,10 +100,10 @@ class faustPink : public sfzFilterDsp {
 		//[Begin:compute]
 		FAUSTFLOAT const* input0 = inputs[0];
 		FAUSTFLOAT* output0 = outputs[0];
-		for (int i = 0; (i < count); i = (i + 1)) {
-			double fTemp0 = double(input0[i]);
+		for (int i0 = 0; (i0 < count); i0 = (i0 + 1)) {
+			double fTemp0 = double(input0[i0]);
 			fRec0[0] = ((fTemp0 + ((2.4949560019999999 * fRec0[1]) + (0.52218940000000003 * fRec0[3]))) - (2.0172658750000001 * fRec0[2]));
-			output0[i] = FAUSTFLOAT((((0.049922034999999997 * fRec0[0]) + (0.050612698999999997 * fRec0[2])) - ((0.095993537000000004 * fRec0[1]) + (0.0044087859999999996 * fRec0[3]))));
+			output0[i0] = FAUSTFLOAT((((0.049922034999999997 * fRec0[0]) + (0.050612698999999997 * fRec0[2])) - ((0.095993537000000004 * fRec0[1]) + (0.0044087859999999996 * fRec0[3]))));
 			for (int j0 = 3; (j0 > 0); j0 = (j0 - 1)) {
 				fRec0[j0] = fRec0[(j0 - 1)];
 			}


### PR DESCRIPTION
and fix the relationship between BW and Q for the shelving EQs

Note:  For EQs in sforzando, the `hshelf` and `lshelf` values for `eqN_type` appear ignored. For the `filN_type` values `lsh` and `hsh`, the filters are indeed shelves, but a factor 0.5 appears to be applied on the resonance (i.e. the bandwidth of the shelves is twice that of sfizz). As far as I can tell our implem follows the RBJ's biquad cookbook properly though, so I left it as is.

Closes: #937 