### PR TITLE
Lv2 midi rollback

### DIFF
--- a/cmake/LV2Config.cmake
+++ b/cmake/LV2Config.cmake
@@ -1,5 +1,5 @@
 # This option is for MIDI CC support in absence of host midi:binding support
-option(SFIZZ_LV2_PSA "Enable plugin-side MIDI automations" OFF)
+option(SFIZZ_LV2_PSA "Enable plugin-side MIDI automations" ON)
 
 # Configuration for this plugin
 # TODO: generate version from git
@@ -57,6 +57,10 @@ function(sfizz_lv2_generate_controllers_ttl FILE)
 ")
     math(EXPR _j "${SFIZZ_NUM_CCS}-1")
     foreach(_i RANGE "${_j}")
+        if(_i LESS 128 AND SFIZZ_LV2_PSA)
+            continue() # Don't generate automation parameters for CCs with plugin-side automation
+        endif()
+
         string_left_pad(_i "${_i}" 3 0)
         file(APPEND "${FILE}" "
 sfizz:cc${_i}

--- a/cmake/SfizzConfig.cmake
+++ b/cmake/SfizzConfig.cmake
@@ -159,6 +159,7 @@ Release asserts:               ${SFIZZ_RELEASE_ASSERTS}
 
 Install prefix:                ${CMAKE_INSTALL_PREFIX}
 LV2 destination directory:     ${LV2PLUGIN_INSTALL_DIR}
+LV2 plugin-side CC automation  ${SFIZZ_LV2_PSA}
 
 Compiler CXX debug flags:      ${CMAKE_CXX_FLAGS_DEBUG}
 Compiler CXX release flags:    ${CMAKE_CXX_FLAGS_RELEASE}

--- a/plugins/lv2/CMakeLists.txt
+++ b/plugins/lv2/CMakeLists.txt
@@ -35,7 +35,9 @@ endif()
 
 if(SFIZZ_LV2_PSA)
     target_compile_definitions(${LV2PLUGIN_PRJ_NAME} PRIVATE "SFIZZ_LV2_PSA=1")
-    target_compile_definitions(${LV2PLUGIN_PRJ_NAME}_ui PRIVATE "SFIZZ_LV2_PSA=1")
+    if(SFIZZ_LV2_UI)
+        target_compile_definitions(${LV2PLUGIN_PRJ_NAME}_ui PRIVATE "SFIZZ_LV2_PSA=1")
+    endif()
 endif()
 
 # Explicitely strip all symbols on Linux but lv2_descriptor()

--- a/plugins/lv2/sfizz_lv2_plugin.h
+++ b/plugins/lv2/sfizz_lv2_plugin.h
@@ -140,10 +140,6 @@ struct sfizz_plugin_t
     // updated by hdcc or file load
     float *cc_current {};
 
-    // CC queued for automation on next run(). (synchronized by `synth_mutex`)
-    absl::optional<float>* ccauto {};
-    volatile bool have_ccauto {};
-
     // Timing data
     int bar {};
     double bar_beat {};

--- a/plugins/lv2/sfizz_ui.cpp
+++ b/plugins/lv2/sfizz_ui.cpp
@@ -761,6 +761,17 @@ void sfizz_ui_t::uiSendValue(EditId id, const EditValue& v)
     default:
         if (editIdIsCC(id)) {
             int cc = ccForEditId(id);
+#if defined(SFIZZ_LV2_PSA)
+            if (cc >= 0 && cc < 128) {
+                // Send MIDI message
+                uint8_t msg[3];
+                msg[0] = 0xB0;
+                msg[1] = static_cast<uint8_t>(cc);
+                msg[2] = static_cast<uint8_t>(v.to_float() * 127);
+                uiSendMIDI(msg, 3);
+                break;
+            }
+#endif
             LV2_URID urid = sfizz_lv2_ccmap_map(ccmap.get(), cc);
             sendController(urid, v.to_float());
         }

--- a/src/sfizz/Layer.cpp
+++ b/src/sfizz/Layer.cpp
@@ -179,7 +179,8 @@ bool Layer::registerCC(int ccNumber, float ccValue, float randValue) noexcept
 
         sequenceSwitched_ =
             ((sequenceCounter_++ % region.sequenceLength) == region.sequencePosition - 1);
-        if (isSwitchedOn())
+
+        if (isSwitchedOn() && (ccValue != midiState_.getCCValue(ccNumber)))
             return true;
     }
 

--- a/tests/SynthT.cpp
+++ b/tests/SynthT.cpp
@@ -1983,10 +1983,10 @@ TEST_CASE("[Synth] Sequences also work on cc triggers")
     synth.cc(0, 61, 20);
     synth.renderBlock(buffer);
     REQUIRE( playingSamples(synth) == std::vector<std::string> { "*sine", "*saw" } );
-    synth.cc(0, 61, 20);
+    synth.cc(0, 61, 21);
     synth.renderBlock(buffer);
     REQUIRE( playingSamples(synth) == std::vector<std::string> { "*sine", "*saw" } );
-    synth.cc(0, 61, 20);
+    synth.cc(0, 61, 22);
     synth.renderBlock(buffer);
     REQUIRE( playingSamples(synth) == std::vector<std::string> { "*sine", "*saw", "*sine" } );
 }


### PR DESCRIPTION
- Adds plugin-side automation by default. This means that the LV2 will respond to midi CC.
- When PSA is active, CC-type parameters are disabled.
- Disable the sendback of CC messages when a CC-type parameter is received
- When a repeated CC value is sent, notes are not retriggering. This helps on CC-bound automation lanes. However, this departs from ARIA.

Closes: #1045 #1042 (hopefully)