### PR TITLE
jack: Wait for CLI thread to finish on quit

### DIFF
--- a/clients/jack_client.cpp
+++ b/clients/jack_client.cpp
@@ -393,5 +393,6 @@ int main(int argc, char** argv)
 
     std::cout << "Closing..." << '\n';
     jack_client_close(client);
+    cli_thread.join();
     return 0;
 }


### PR DESCRIPTION
Before:
```
$ ./clients/sfizz_jack                                       
Flags
- Client name: sfizz
- Oversampling: 1x
- Preloaded size: 8192
- Num of voices: 32
- Audio Autoconnect: 0
- Verbose State: 0
Positional arguments:

> quit
Closing...
terminate called without an active exception
[1]    18124 IOT instruction (core dumped)  ./clients/sfizz_jack
```

After:

```
$ ./clients/sfizz_jack                                       
Flags
- Client name: sfizz
- Oversampling: 1x
- Preloaded size: 8192
- Num of voices: 32
- Audio Autoconnect: 0
- Verbose State: 0
Positional arguments:

> quit
Closing...
```