### PR TITLE
Crash fix for reloading SFZ : needed to copy preloadCallCount in FilePool copy constructors

### DIFF
--- a/src/sfizz/FilePool.h
+++ b/src/sfizz/FilePool.h
@@ -90,6 +90,7 @@ struct FileData
         information = std::move(other.information);
         preloadedData = std::move(other.preloadedData);
         fileData = std::move(other.fileData);
+        preloadCallCount = other.preloadCallCount;
         availableFrames = other.availableFrames.load();
         lastViewerLeftAt = other.lastViewerLeftAt;
         status = other.status.load();
@@ -100,6 +101,7 @@ struct FileData
         information = std::move(other.information);
         preloadedData = std::move(other.preloadedData);
         fileData = std::move(other.fileData);
+        preloadCallCount = other.preloadCallCount;
         availableFrames = other.availableFrames.load();
         lastViewerLeftAt = other.lastViewerLeftAt;
         status = other.status.load();


### PR DESCRIPTION
 This was critical to avoid crashing behavior when an SFZ is reloaded... because this element wasn't retained in the actual preloadedFiles collection between calls to FilePool::preloadFile() and FilePool::removeUnusedPreloadedData() in Synth::Impl::finalizeSfzLoad().