### PR TITLE
Add support for opcodes lotimer/hitimer

### DIFF
--- a/src/sfizz/Defaults.cpp
+++ b/src/sfizz/Defaults.cpp
@@ -199,6 +199,8 @@ FloatSpec lofiDecim { 0.0f, {0.0f, 100.0f}, 0 };
 FloatSpec rectify { 0.0f, {0.0f, 100.0f}, 0 };
 UInt32Spec stringsNumber { maxStrings, {0, maxStrings}, 0 };
 BoolSpec sustainCancelsRelease { false, {0, 1}, kEnforceBounds };
+FloatSpec loTimer { 0.0f, {0.0f, float_max}, 0 };
+FloatSpec hiTimer { float_max, {0.0f, float_max}, 0 };
 
 ESpec<Trigger> trigger { Trigger::attack, {Trigger::attack, Trigger::release_key}, 0};
 ESpec<CrossfadeCurve> crossfadeCurve { CrossfadeCurve::power, {CrossfadeCurve::gain, CrossfadeCurve::power}, 0};

--- a/src/sfizz/Defaults.h
+++ b/src/sfizz/Defaults.h
@@ -317,6 +317,8 @@ namespace Default
     extern const OpcodeSpec<FilterType> filter;
     extern const OpcodeSpec<EqType> eq;
     extern const OpcodeSpec<bool> sustainCancelsRelease;
+    extern const OpcodeSpec<float> loTimer;
+    extern const OpcodeSpec<float> hiTimer;
 
     // Default/max count for objects
     constexpr int numEQs { 3 };

--- a/src/sfizz/MidiState.h
+++ b/src/sfizz/MidiState.h
@@ -166,6 +166,12 @@ public:
     void advanceTime(int numSamples) noexcept;
 
     /**
+     * @brief Returns current internal sample clock
+     *
+     */
+    unsigned getInternalClock() const noexcept { return internalClock; }
+
+    /**
      * @brief Flush events in all states, keeping only the last one as the "base" state
      *
      */

--- a/src/sfizz/PolyphonyGroup.cpp
+++ b/src/sfizz/PolyphonyGroup.cpp
@@ -15,6 +15,7 @@ void sfz::PolyphonyGroup::registerVoice(Voice* voice) noexcept
 {
     if (absl::c_find(voices, voice) == voices.end())
         voices.push_back(voice);
+    mostRecentStartStamp_ = voice->getStartTimestampSamples();
 }
 
 void sfz::PolyphonyGroup::removeVoice(const Voice* voice) noexcept

--- a/src/sfizz/PolyphonyGroup.h
+++ b/src/sfizz/PolyphonyGroup.h
@@ -62,9 +62,15 @@ public:
      * @return std::vector<Voice*>&
      */
     std::vector<Voice*>& getActiveVoices() noexcept { return voices; }
+    /**
+     * @brief Returns the start timestamp in samples of the most recently activated voice
+     */
+    unsigned getMostRecentStartTimestamp() const noexcept { return mostRecentStartStamp_; }
+
 private:
     unsigned polyphonyLimit { config::maxVoices };
     std::vector<Voice*> voices;
+    unsigned mostRecentStartStamp_ { 0 };
 };
 
 }

--- a/src/sfizz/Region.cpp
+++ b/src/sfizz/Region.cpp
@@ -562,6 +562,15 @@ bool sfz::Region::parseOpcode(const Opcode& rawOpcode, bool cleanOpcode)
         groupVolume = opcode.read(Default::volume);
         break;
 
+    case hash("lotimer"):
+        timerRange.setStart(opcode.read(Default::loTimer));
+        useTimerRange = useTimerRange || timerRange.getStart() != Default::loTimer;
+        break;
+    case hash("hitimer"):
+        timerRange.setEnd(opcode.read(Default::hiTimer));
+        useTimerRange = useTimerRange || timerRange.getEnd() != Default::hiTimer;
+        break;
+
     // Performance parameters: filters
     case hash("cutoff&"): // also cutoff
         {

--- a/src/sfizz/Region.h
+++ b/src/sfizz/Region.h
@@ -335,6 +335,8 @@ struct Region {
     CCMap<UncheckedRange<float>> crossfadeCCInRange { Default::crossfadeCCInRange }; // xfin_loccN xfin_hiccN
     CCMap<UncheckedRange<float>> crossfadeCCOutRange { Default::crossfadeCCOutRange }; // xfout_loccN xfout_hiccN
     float rtDecay { Default::rtDecay }; // rt_decay
+    UncheckedRange<float> timerRange { Default::loTimer, Default::hiTimer }; // hitimer and lotimer (seconds)
+    bool useTimerRange { false }; // to optimize having to check the timer range, because this is very rare opcode
 
     float globalAmplitude { 1.0 }; // global_amplitude
     float masterAmplitude { 1.0 }; // master_amplitude

--- a/src/sfizz/SynthMessaging.cpp
+++ b/src/sfizz/SynthMessaging.cpp
@@ -730,6 +730,14 @@ void sfz::Synth::dispatchMessage(Client& client, int delay, const char* path, co
             }
         } break;
 
+        MATCH("/region&/timer_range", "") {
+            GET_REGION_OR_BREAK(indices[0])
+            sfizz_arg_t args[2];
+            args[0].f = region.timerRange.getStart();
+            args[1].f = region.timerRange.getEnd();
+            client.receive(delay, path, "ff", args);
+        } break;
+
         MATCH("/region&/position", "") {
             GET_REGION_OR_BREAK(indices[0])
             client.receive<'f'>(delay, path, region.position * 100.0f);

--- a/src/sfizz/SynthMessaging.cpp
+++ b/src/sfizz/SynthMessaging.cpp
@@ -309,6 +309,15 @@ void sfz::Synth::dispatchMessage(Client& client, int delay, const char* path, co
             }
         } break;
 
+        MATCH("/region&/use_timer_range", "") {
+            GET_REGION_OR_BREAK(indices[0])
+            if (region.useTimerRange) {
+                client.receive<'T'>(delay, path, {});
+            } else {
+                client.receive<'F'>(delay, path, {});
+            }
+        } break;
+
         MATCH("/region&/count", "") {
             GET_REGION_OR_BREAK(indices[0])
             if (region.sampleCount)

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -437,6 +437,13 @@ public:
      */
     int getSourcePosition() const noexcept;
 
+    /**
+     * @brief Get the timestamp in midistate transport sample time when the voice was started, in samples
+     *
+     * @return int
+     */
+    unsigned getStartTimestampSamples() const noexcept;
+
 public:
     /**
      * @brief Check if the voice already belongs to a sister ring

--- a/src/sfizz/VoiceManager.cpp
+++ b/src/sfizz/VoiceManager.cpp
@@ -244,6 +244,16 @@ void VoiceManager::checkNotePolyphony(const Region* region, int delay, const Tri
     }
 }
 
+bool VoiceManager::withinValidTimerRange(const Region* region, unsigned timestampSamples, float sampleRate) const noexcept
+{
+    auto found = polyphonyGroups_.find(static_cast<int>(region->group));
+    if (found != polyphonyGroups_.end()) {
+        // convert timestamp to seconds
+        return region->timerRange.contains((timestampSamples - found->second.getMostRecentStartTimestamp()) / sampleRate);
+    }
+    return true;
+}
+
 void VoiceManager::checkGroupPolyphony(const Region* region, int delay) noexcept
 {
     auto& group = polyphonyGroups_[region->group];

--- a/src/sfizz/VoiceManager.h
+++ b/src/sfizz/VoiceManager.h
@@ -139,6 +139,16 @@ struct VoiceManager final : public Voice::StateListener
      */
     void requireNumVoices(int numVoices, Resources& resources);
 
+    /**
+     * @brief Is this timestamp within the lo/hitimer range for this region based on current group activity
+     *
+     * @param region
+     * @param timestampSamples in samples
+     * @param sampleRate
+     * @return bool
+     */
+    bool withinValidTimerRange(const Region* region, unsigned timestampSamples, float sampleRate) const noexcept;
+
 private:
     int numRequiredVoices_ { config::numVoices };
     std::vector<Voice> list_;

--- a/tests/RegionValuesT.cpp
+++ b/tests/RegionValuesT.cpp
@@ -1106,6 +1106,39 @@ TEST_CASE("[Values] Rand range")
     REQUIRE(messageList == expected);
 }
 
+TEST_CASE("[Values] Timer range")
+{
+    Synth synth;
+    std::vector<std::string> messageList;
+    Client client(&messageList);
+    client.setReceiveCallback(&simpleMessageReceiver);
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/value_tests.sfz", R"(
+        <region> sample=kick.wav
+        <region> sample=kick.wav lotimer=0.2 hitimer=0.4
+        <region> sample=kick.wav lotimer=-0.1 hitimer=0.4
+        <region> sample=kick.wav lotimer=0.2 hitimer=-0.1
+    )");
+    synth.dispatchMessage(client, 0, "/region0/timer_range", "", nullptr);
+    synth.dispatchMessage(client, 0, "/region0/use_timer_range", "", nullptr);
+    synth.dispatchMessage(client, 0, "/region1/timer_range", "", nullptr);
+    synth.dispatchMessage(client, 0, "/region1/use_timer_range", "", nullptr);
+    synth.dispatchMessage(client, 0, "/region2/timer_range", "", nullptr);
+    synth.dispatchMessage(client, 0, "/region2/use_timer_range", "", nullptr);
+    synth.dispatchMessage(client, 0, "/region3/timer_range", "", nullptr);
+    synth.dispatchMessage(client, 0, "/region3/use_timer_range", "", nullptr);
+    std::vector<std::string> expected {
+        "/region0/timer_range,ff : { 0, 3.40282e+38 }",
+        "/region0/use_timer_range,F : {  }",
+        "/region1/timer_range,ff : { 0.2, 0.4 }",
+        "/region1/use_timer_range,T : {  }",
+        "/region2/timer_range,ff : { 0, 0.4 }",
+        "/region2/use_timer_range,T : {  }",
+        "/region3/timer_range,ff : { 0.2, 3.40282e+38 }",
+        "/region3/use_timer_range,T : {  }",
+    };
+    REQUIRE(messageList == expected);
+}
+
 TEST_CASE("[Values] Sequence length")
 {
     Synth synth;


### PR DESCRIPTION
While not widely supported or well documented, is very useful especially when triggering a note with on_locc/on_hicc to prevent a bunch of retriggers.

The region will trigger as long as the elapsed time from the note-on of the most recently triggered region in the current polyphony group is between lotimer and hitimer amount of seconds. lotimer default 0, hitimer default is max_float.

Example use: to preventing a region from retriggering too quickly, set lotimer=0.1