### PR TITLE
allow polyaftertouch extended CC (130) to respect note num

### DIFF
--- a/src/sfizz/Layer.cpp
+++ b/src/sfizz/Layer.cpp
@@ -157,7 +157,7 @@ void Layer::updateCCState(int ccNumber, float ccValue) noexcept
     ccSwitched_.set(ccNumber, conditions->containsWithEnd(ccValue));
 }
 
-bool Layer::registerCC(int ccNumber, float ccValue, float randValue) noexcept
+bool Layer::registerCC(int ccNumber, float ccValue, float randValue, int extendedArg) noexcept
 {
     const Region& region = region_;
 
@@ -175,6 +175,11 @@ bool Layer::registerCC(int ccNumber, float ccValue, float randValue) noexcept
     if (auto triggerRange = region.ccTriggers.get(ccNumber)) {
         if (!triggerRange->containsWithEnd(ccValue))
             return false;
+
+        // only respect this polyAT trigger if the note number is one of ours
+        if (ccNumber == ExtendedCCs::polyphonicAftertouch && extendedArg >= 0 && !region.keyRange.containsWithEnd(extendedArg)) {
+            return false;
+        }
 
         sequenceSwitched_ =
             ((sequenceCounter_++ % region.sequenceLength) == region.sequencePosition - 1);

--- a/src/sfizz/Layer.cpp
+++ b/src/sfizz/Layer.cpp
@@ -184,7 +184,7 @@ bool Layer::registerCC(int ccNumber, float ccValue, float randValue, int extende
         sequenceSwitched_ =
             ((sequenceCounter_++ % region.sequenceLength) == region.sequencePosition - 1);
 
-        if (isSwitchedOn() && (ccValue != midiState_.getCCValue(ccNumber)))
+        if (isSwitchedOn() && (ccNumber == ExtendedCCs::polyphonicAftertouch || ccValue != midiState_.getCCValue(ccNumber)))
             return true;
     }
 

--- a/src/sfizz/Layer.h
+++ b/src/sfizz/Layer.h
@@ -96,10 +96,11 @@ public:
      * @param ccNumber
      * @param ccValue
      * @param randValue
+     * @param extendedArg is used for special extendedCCs (eg. polyaftertouch to represent note num, etc)
      * @return true if the region should trigger on this event
      * @return false otherwise
      */
-    bool registerCC(int ccNumber, float ccValue, float randValue) noexcept;
+    bool registerCC(int ccNumber, float ccValue, float randValue, int extendedArg=-1) noexcept;
     /**
      * @brief Register a new pitch wheel event.
      *

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1309,12 +1309,12 @@ void Synth::Impl::startVoice(Layer* layer, int delay, const TriggerEvent& trigge
         ring.addVoiceToRing(selectedVoice);
 }
 
-void Synth::Impl::checkOffGroups(const Region* region, int delay, int number)
+void Synth::Impl::checkOffGroups(const Region* region, int delay, int number, bool chokedByCC)
 {
     for (auto& voice : voiceManager_) {
         if (voice.checkOffGroup(region, delay, number)) {
             const TriggerEvent& event = voice.getTriggerEvent();
-            if (event.type == TriggerEventType::NoteOn)
+            if (event.type == TriggerEventType::NoteOn && !chokedByCC)
                 noteOffDispatch(delay, event.number, event.value);
         }
     }
@@ -1451,7 +1451,7 @@ void Synth::Impl::ccDispatch(int delay, int ccNumber, float value, int extendedA
             if (region.useTimerRange && ! voiceManager_.withinValidTimerRange(&region, midiState.getInternalClock() + delay, sampleRate_))
                 continue;
 
-            checkOffGroups(&region, delay, ccNumber);
+            checkOffGroups(&region, delay, ccNumber, true);
             startVoice(layer, delay, triggerEvent, ring);
         }
     }

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1424,7 +1424,7 @@ void Synth::cc(int delay, int ccNumber, int ccValue) noexcept
     hdcc(delay, ccNumber, normalizedCC);
 }
 
-void Synth::Impl::ccDispatch(int delay, int ccNumber, float value) noexcept
+void Synth::Impl::ccDispatch(int delay, int ccNumber, float value, int extendedArg) noexcept
 {
     SisterVoiceRingBuilder ring;
     TriggerEvent triggerEvent { TriggerEventType::CC, ccNumber, value };
@@ -1447,7 +1447,7 @@ void Synth::Impl::ccDispatch(int delay, int ccNumber, float value) noexcept
             }
         }
 
-        if (layer->registerCC(ccNumber, value, randValue)) {
+        if (layer->registerCC(ccNumber, value, randValue, extendedArg)) {
             if (region.useTimerRange && ! voiceManager_.withinValidTimerRange(&region, midiState.getInternalClock() + delay, sampleRate_))
                 continue;
 
@@ -1469,7 +1469,7 @@ void Synth::automateHdcc(int delay, int ccNumber, float normValue) noexcept
     impl.performHdcc(delay, ccNumber, normValue, false);
 }
 
-void Synth::Impl::performHdcc(int delay, int ccNumber, float normValue, bool asMidi) noexcept
+void Synth::Impl::performHdcc(int delay, int ccNumber, float normValue, bool asMidi, int extendedArg) noexcept
 {
     ASSERT(ccNumber < config::numCCs);
     ASSERT(ccNumber >= 0);
@@ -1497,7 +1497,7 @@ void Synth::Impl::performHdcc(int delay, int ccNumber, float normValue, bool asM
     for (auto& voice : voiceManager_)
         voice.registerCC(delay, ccNumber, normValue);
 
-    ccDispatch(delay, ccNumber, normValue);
+    ccDispatch(delay, ccNumber, normValue, extendedArg);
     midiState.ccEvent(delay, ccNumber, normValue);
 }
 
@@ -1597,8 +1597,7 @@ void Synth::hdPolyAftertouch(int delay, int noteNumber, float normAftertouch) no
     for (auto& voice : impl.voiceManager_)
         voice.registerPolyAftertouch(delay, noteNumber, normAftertouch);
 
-    // Note information is lost on this CC
-    impl.performHdcc(delay, ExtendedCCs::polyphonicAftertouch, normAftertouch, false);
+    impl.performHdcc(delay, ExtendedCCs::polyphonicAftertouch, normAftertouch, false, noteNumber);
 }
 
 void Synth::tempo(int delay, float secondsPerBeat) noexcept

--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -150,8 +150,9 @@ struct Synth::Impl final: public Parser::Listener {
      * @param delay
      * @param ccNumber
      * @param value
+     * @param extendedArg used for some extendedCC (eg. polyaftertouch note num, etc)
      */
-    void ccDispatch(int delay, int ccNumber, float value) noexcept;
+    void ccDispatch(int delay, int ccNumber, float value, int extendedArg=-1) noexcept;
 
     /**
      * @brief Start a voice for a specific region.
@@ -239,8 +240,9 @@ struct Synth::Impl final: public Parser::Listener {
      * @param ccNumber   The CC number
      * @param normValue  The normalized value
      * @param asMidi     Whether to process as a MIDI event
+     * @param extendedArg for some extendedCC (eg. polyaftertouch: note num, etc)
      */
-    void performHdcc(int delay, int ccNumber, float normValue, bool asMidi) noexcept;
+    void performHdcc(int delay, int ccNumber, float normValue, bool asMidi, int extendedArg=-1) noexcept;
 
     /**
      * @brief Set the default value for a CC

--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -260,7 +260,7 @@ struct Synth::Impl final: public Parser::Listener {
      * @param delay
      * @param number
      */
-    void checkOffGroups(const Region* region, int delay, int number);
+    void checkOffGroups(const Region* region, int delay, int number, bool chokedByCC = false);
 
     /**
      * @brief Resets the callback duration breakdown to 0

--- a/tests/PolyphonyT.cpp
+++ b/tests/PolyphonyT.cpp
@@ -589,6 +589,31 @@ TEST_CASE("[Polyphony] Choke same group and note if the region is switched off (
     REQUIRE( playingSamples(synth) == std::vector<std::string> { "*sine" } );
 }
 
+TEST_CASE("[Polyphony] Choking on poly-aftertouch respects the note number")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyat_choke.sfz", R"(
+        <region> key=55 group=1 off_by=2 sample=*saw
+        <region> key=55 group=2 on_locc130=127 on_hicc130=127 trigger=release sample=*sine
+    )");
+    synth.noteOn(0, 55, 63 );
+    synth.renderBlock(buffer);
+    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*saw" } );
+    synth.hdPolyAftertouch(0, 54, 1.0f);
+    synth.renderBlock(buffer);
+    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*saw" } );
+    synth.hdPolyAftertouch(0, 57, 1.0f);
+    synth.renderBlock(buffer);
+    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*saw" } );
+    synth.hdPolyAftertouch(0, 55, 1.0f);
+    synth.renderBlock(buffer);
+    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*sine"} );
+    synth.hdPolyAftertouch(0, 55, 0.0f);
+    synth.renderBlock(buffer);
+    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*sine"} );
+}
+
 TEST_CASE("[Polyphony] A note coming at the same time as another can choke it")
 {
     sfz::Synth synth;
@@ -631,29 +656,4 @@ TEST_CASE("[Polyphony] A note coming one sample before another note cannot choke
     synth.noteOn(2, 69, 63);
     synth.renderBlock(buffer);
     REQUIRE( playingSamples(synth) == std::vector<std::string> { "kick.wav", "snare.wav" } );
-}
-
-TEST_CASE("[Polyphony] Choking on poly-aftertouch respects the note number")
-{
-    sfz::Synth synth;
-    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
-    synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyat_choke.sfz", R"(
-        <region> key=55 group=1 off_by=2 sample=*saw
-        <region> key=55 group=2 on_locc130=127 on_hicc130=127 trigger=release polyphony=1 sample=*sine
-    )");
-    synth.noteOn(0, 55, 63 );
-    synth.renderBlock(buffer);
-    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*saw" } );
-    synth.hdPolyAftertouch(0, 54, 1.0f);
-    synth.renderBlock(buffer);
-    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*saw" } );
-    synth.hdPolyAftertouch(0, 57, 1.0f);
-    synth.renderBlock(buffer);
-    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*saw" } );
-    synth.hdPolyAftertouch(0, 55, 1.0f);
-    synth.renderBlock(buffer);
-    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*sine"} );
-    synth.hdPolyAftertouch(0, 55, 0.0f);
-    synth.renderBlock(buffer);
-    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*sine"} );
 }

--- a/tests/PolyphonyT.cpp
+++ b/tests/PolyphonyT.cpp
@@ -632,3 +632,28 @@ TEST_CASE("[Polyphony] A note coming one sample before another note cannot choke
     synth.renderBlock(buffer);
     REQUIRE( playingSamples(synth) == std::vector<std::string> { "kick.wav", "snare.wav" } );
 }
+
+TEST_CASE("[Polyphony] Choking on poly-aftertouch respects the note number")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/polyat_choke.sfz", R"(
+        <region> key=55 group=1 off_by=2 sample=*saw
+        <region> key=55 group=2 on_locc130=127 on_hicc130=127 trigger=release polyphony=1 sample=*sine
+    )");
+    synth.noteOn(0, 55, 63 );
+    synth.renderBlock(buffer);
+    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*saw" } );
+    synth.hdPolyAftertouch(0, 54, 1.0f);
+    synth.renderBlock(buffer);
+    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*saw" } );
+    synth.hdPolyAftertouch(0, 57, 1.0f);
+    synth.renderBlock(buffer);
+    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*saw" } );
+    synth.hdPolyAftertouch(0, 55, 1.0f);
+    synth.renderBlock(buffer);
+    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*sine"} );
+    synth.hdPolyAftertouch(0, 55, 0.0f);
+    synth.renderBlock(buffer);
+    REQUIRE( playingSamples(synth) == std::vector<std::string> { "*sine"} );
+}

--- a/tests/RegionTriggersT.cpp
+++ b/tests/RegionTriggersT.cpp
@@ -550,3 +550,23 @@ TEST_CASE("[Triggers] hitimer (with group)")
     synth.noteOn(0, 41, 100);
     REQUIRE(playingSamples(synth) == std::vector<std::string> { "snare.wav", "kick.wav", "kick.wav" });
 }
+
+TEST_CASE("[Triggers] Respect poly-aftertouch note values when triggering on cc130")
+{
+    Synth synth;
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/poly_at_trigger.sfz", R"(
+        <region> key=55 on_locc130=127 on_hicc130=127 sample=*saw
+        <region> key=57 on_locc130=127 on_hicc130=127 sample=*sine
+    )");
+
+    synth.polyAftertouch(0, 54, 127);
+    REQUIRE(playingSamples(synth) == std::vector<std::string> { });
+    synth.polyAftertouch(0, 56, 127);
+    REQUIRE(playingSamples(synth) == std::vector<std::string> { });
+    synth.polyAftertouch(0, 58, 127);
+    REQUIRE(playingSamples(synth) == std::vector<std::string> { });
+    synth.polyAftertouch(0, 55, 127);
+    REQUIRE(playingSamples(synth) == std::vector<std::string> { "*saw" });
+    synth.polyAftertouch(10, 57, 127);
+    REQUIRE(playingSamples(synth) == std::vector<std::string> { "*saw", "*sine" });
+}


### PR DESCRIPTION
This is especially useful when used as trigger with on_lo/hicc130 opcodes, so that the key range can be used select appropriate regions independently. This is primarily useful with e-drums which send polyAT for cymbal chokes, and with this change it's now possible to choke multiple independent notes based on polyAT. (sforzando/ARIA handled it correctly already, now sfizz does too).

The implementation also opens up the possibility that other extended CCs could pass needed extra value if necessary (haven't checked if any others need it yet...)