### PR TITLE
synth: Reset the voice before starting it

### DIFF
--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1310,6 +1310,7 @@ void Synth::Impl::startVoice(Layer* layer, int delay, const TriggerEvent& trigge
     if (selectedVoice == nullptr)
         return;
 
+    selectedVoice->reset();
     if (selectedVoice->startVoice(layer, delay, triggerEvent))
         ring.addVoiceToRing(selectedVoice);
 }


### PR DESCRIPTION
The voice manager may select a voice that is
currently audible, so its state has to be cleaned
up before starting over.

Fixes: https://github.com/sfztools/sfizz/issues/1180