### PR TITLE
Adjusted the gain compensation to not lose gain due to applied pan stages

### DIFF
--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -977,6 +977,10 @@ void Voice::Impl::panStageMono(AudioSpan<float> buffer) noexcept
             (*modulationSpan)[i] += mod[i];
     }
     pan(*modulationSpan, leftBuffer, rightBuffer);
+
+    // add +3dB (10^(3/20)) to compensate for the pan stage (-3dB per stage)
+    applyGain1(1.4125375446227544f, leftBuffer);
+    applyGain1(1.4125375446227544f, rightBuffer);
 }
 
 void Voice::Impl::panStageStereo(AudioSpan<float> buffer) noexcept
@@ -1017,9 +1021,9 @@ void Voice::Impl::panStageStereo(AudioSpan<float> buffer) noexcept
     }
     pan(*modulationSpan, leftBuffer, rightBuffer);
 
-    // add +3dB to compensate for the 2 pan stages (-3dB each stage)
-    applyGain1(1.4125375446227544f, leftBuffer);
-    applyGain1(1.4125375446227544f, rightBuffer);
+    // add +6dB (10^(6/20)) to compensate for the 2 pan stages (-3dB per stage)
+    applyGain1(1.9952623149688797f, leftBuffer);
+    applyGain1(1.9952623149688797f, rightBuffer);
 }
 
 void Voice::Impl::filterStageMono(AudioSpan<float> buffer) noexcept


### PR DESCRIPTION
This fixes the issue (https://github.com/sfztools/sfizz/issues/1086) that the output level of a sample played through sfizz is ~3dB lower compared to playing the sample directly.

