### PR TITLE
Added invoke.hpp to git submodule check.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ if(SFIZZ_GIT_SUBMODULE_CHECK AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git"
     git_submodule_check(external/st_audiofile/thirdparty/dr_libs)
     git_submodule_check(external/st_audiofile/thirdparty/libaiff)
     git_submodule_check(external/st_audiofile/thirdparty/wavpack)
+    git_submodule_check(external/invoke.hpp)
 endif()
 
 include(SfizzConfig)


### PR DESCRIPTION
In order to build without `git submodule init`, I added invoke.hpp to the submodule check list.