### PR TITLE
Fixed a bug that causes invalid effect output

### DIFF
--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1159,7 +1159,6 @@ void Synth::renderBlock(AudioSpan<float> buffer) noexcept
 
     { // Main render block
         ScopedTiming logger { callbackBreakdown.renderMethod, ScopedTiming::Operation::addToDuration };
-        tempMixSpan->fill(0.0f);
 
         for (auto& voice : impl.voiceManager_) {
             if (voice.isFree())
@@ -1197,6 +1196,7 @@ void Synth::renderBlock(AudioSpan<float> buffer) noexcept
 
         const int numChannels = static_cast<int>(buffer.getNumChannels());
         for (int i = 0; i < impl.numOutputs_; ++i) {
+            tempMixSpan->fill(0.0f);
             const auto outputStart = numChannels == 0 ? 0 : (2 * i) % numChannels;
             auto outputSpan = buffer.getStereoSpan(outputStart);
             const auto& effectBuses = impl.getEffectBusesForOutput(i);


### PR DESCRIPTION
The tempMixSpan didn't reset at a loop.
This cause an issue with the following sfz example.

```
<effect>
bus=fx1 type=fverb reverb_type=mid_hall reverb_dry=80 reverb_wet=20 reverb_input=40 reverb_size=0 reverb_predelay=0.01 reverb_tone=50 reverb_damp=50 fx1tomix=100
<global>
effect1=100
<region>sample=*sine
ampeg_attack=0.02 ampeg_release=0.1
output=0
<region>sample=*saw
ampeg_attack=0.02 ampeg_release=0.1
output=3
```

The 2nd and the 3rd output should be silent but actually it sounds.