### PR TITLE
Fixes the infinite-loop-on-eof problem

### DIFF
--- a/clients/jack_client.cpp
+++ b/clients/jack_client.cpp
@@ -259,6 +259,8 @@ void cliThreadProc()
             } catch (...) {
                 std::cout << "ERROR: Can't set num of voices!\n";
             }
+        } else if (!std::cin) {
+            shouldClose = true;
         } else if (kw == "quit") {
             shouldClose = true;
         } else if (kw.size() > 0) {


### PR DESCRIPTION
This isn’t ideal, but it doesn’t introduce whitespace changes and it does fix the bug where sfizz_jack goes into an infinite loop if stdin gets eof (#1266).