### PR TITLE
Various minor formatting and wording fixes. Added missing description for set_oversampling

### DIFF
--- a/clients/sfizz_jack.man.in
+++ b/clients/sfizz_jack.man.in
@@ -1,31 +1,34 @@
-.TH sfizz_jack 1 "@MAN_TODAY@" "@CMAKE_PROJECT_VERSION@" "sfizz_jack man page"
+.TH sfizz_jack 1 "@MAN_TODAY@" "@CMAKE_PROJECT_VERSION@" "sfizz"
 .SH NAME
-sfizz_jack \- Launch a sfizz instance as a JACK client
+sfizz_jack \- launch a sfizz instance as a JACK client
 .SH SYNOPSIS
-sfizz_jack [FILE] [OPTIONS...]
+.B sfizz_jack
+[\fIFILE\fR] [\fIOPTIONS\fR...]
 .SH DESCRIPTION
 sfizz_jack wraps the sfizz SFZ library in a JACK client that can be controlled by a text interface.
 .SH OPTIONS
-.IP FILE
-An optional SFZ file name to load at firsts
-.IP "--client_name"
+.IP \fIFILE\fR
+An optional SFZ file name to load on startup
+.IP "\fB--client_name\fR"
 Name for the JACK client
-.IP "--num_voices NUMBER"
+.IP "\fB--num_voices\fR \fINUMBER\fR"
 Change the maximum polyphony
-.IP "--preload_size NUMBER"
+.IP "\fB--preload_size\fR \fINUMBER\fR"
 Bytes to preload in cache for samples
-.IP "--state"
-Output the state in the JACK loop
-.IP "--jack_autoconnect"
+.IP "\fB--state\fR"
+Periodically output the state of the synth
+.IP "\fB--jack_autoconnect\fR"
 Autoconnect the JACK outputs
 .SH TEXT INTERFACE
 It is possible it interact with the JACK client through the standard input.
 The possible commands are
-.IP "load_instrument FILE"
+.IP "load_instrument \fIFILE\fR"
 Load an instrument
-.IP "set_preload_size NUMBER"
-Set the number of bytes to preload in cache for samples
-.IP "set_voices NUMBER"
+.IP "set_oversampling \fINUMBER\fR"
+Change the oversampling factor
+.IP "set_preload_size \fINUMBER\fR"
+Set the number of bytes to preload in the cache for samples
+.IP "set_voices \fINUMBER\fR"
 Change the maximum polyphony
 .IP quit
 Quit

--- a/clients/sfizz_render.man.in
+++ b/clients/sfizz_render.man.in
@@ -29,7 +29,7 @@ Verbose output
 .IP "\fB--log\fR \fIPREFIX\fR"
 Produce logs
 .IP "\fB--use-eot\fR"
-End the rendering at the last End of Track Midi message
+End the rendering at the last End of Track MIDI message
 .IP "\fB-h\fR, \fB--help\fR"
 Show help
 .SH SEE ALSO

--- a/clients/sfizz_render.man.in
+++ b/clients/sfizz_render.man.in
@@ -1,26 +1,36 @@
-.TH sfizz_render 1 "@MAN_TODAY@" "@CMAKE_PROJECT_VERSION@" "sfizz_render man page"
+.TH sfizz_render 1 "@MAN_TODAY@" "@CMAKE_PROJECT_VERSION@" "sfizz"
 .SH NAME
-sfizz_render \- Render a MIDI file as a WAV file using an SFZ instrument description.
+sfizz_render \- render a MIDI file as a WAV file using an SFZ instrument description
 .SH SYNOPSIS
-sfizz_render --sfz FILE --wav FILE --midi FILE [OPTIONS...]
+.B sfizz_render
+.B --sfz
+.I FILE
+.B --wav
+.I FILE
+.B --midi
+.I FILE
+[\fIOPTIONS\fR...]
 .SH DESCRIPTION
-sfizz_render wraps the sfizz SFZ library and can be used to render midi file as sound files using an SFZ description file and its associated samples.
+sfizz_render uses the sfizz SFZ library to render a MIDI file into a sound file using an SFZ description file and its associated samples.
 .SH OPTIONS
-.IP "-b, --blocksize NUMBER"
+.IP "\fB-b\fR, \fB--blocksize\fR \fINUMBER\fP"
 Block size for the sfizz callbacks
-.IP "-s, --samplerate NUMBER"
+.IP "\fB-s\fR, \fB--samplerate\fR \fINUMBER\fP"
 Output sample rate
-.IP "-q, --quality NUMBER"
-Resampling quality, like the SFZ sample_quality opcode. A value of 1 will use a linear interpolation of source samples, while higher value will use increasingly better algorithms.
-.IP "-p, --polyphony NUMBER"
+.IP "\fB-q\fR, \fB--quality\fR \fINUMBER\fP"
+Resampling quality.
+.I NUMBER
+has the same meaning as the SFZ sample_quality opcode.
+A value of 1 will use a linear interpolation of source samples, while higher values will use increasingly better algorithms.
+.IP "\fB-p\fR, \fB--polyphony\fR \fINUMBER\fP"
 Maximum polyphony
-.IP "-v, --verbose"
+.IP "\fB-v\fR, \fB--verbose\fR"
 Verbose output
-.IP "--log PREFIX"
+.IP "\fB--log\fR \fIPREFIX\fR"
 Produce logs
-.IP "--use-eot"
+.IP "\fB--use-eot\fR"
 End the rendering at the last End of Track Midi message
-.IP "-h, --help"
+.IP "\fB-h\fR, \fB--help\fR"
 Show help
 .SH SEE ALSO
 sfizz_jack(1)


### PR DESCRIPTION
- Added description for set_oversampling interactive command
- Various minor wording fixes
- Various minor formatting fixes
   - Manual section title should be just “sfizz” (or left out)
   - Description in name section should not be capped
   - In synopsis section, constant parts should be bolded and variables should be in italics
   - Added bold and italics for options in other sections as appropriate