### PR TITLE
Fixes the infinite-loop-on-EOF problem (smallest patch)

### DIFF
--- a/clients/jack_client.cpp
+++ b/clients/jack_client.cpp
@@ -259,7 +259,7 @@ void cliThreadProc()
             } catch (...) {
                 std::cout << "ERROR: Can't set num of voices!\n";
             }
-        } else if (kw == "quit") {
+        } else if (kw == "quit" || !std::cin) {
             shouldClose = true;
         } else if (kw.size() > 0) {
             std::cout << "ERROR: Unknown command '" << kw << "'!\n";


### PR DESCRIPTION
This fixes #1266. It’s not really an idiomatic way to fix this but this is the smallest patch that works and plays nicer with the other fix.