### PR TITLE
Ignore spaces and tabs when looking for a command for sfizz_jack

### DIFF
--- a/clients/jack_client.cpp
+++ b/clients/jack_client.cpp
@@ -226,8 +226,9 @@ void cliThreadProc()
 
         std::string command;
         std::getline(std::cin, command);
-        std::size_t pos = command.find(" ");
-        std::string kw = command.substr(0, pos);
+        std::size_t start = command.length()? command.find_first_not_of(" "): 0;
+        std::size_t pos = command.find(" ", start);
+        std::string kw = command.substr(start, pos - start);
         std::string args = command.substr(pos + 1);
         std::vector<std::string> tokens = stringTokenize(args);
 

--- a/clients/jack_client.cpp
+++ b/clients/jack_client.cpp
@@ -221,13 +221,14 @@ std::vector<std::string> stringTokenize(const std::string& str)
 
 void cliThreadProc()
 {
+    const std::string whitespace = " \t";
     while (!shouldClose) {
         std::cout << "\n> ";
 
         std::string command;
         std::getline(std::cin, command);
-        std::size_t start = command.length()? command.find_first_not_of(" "): 0;
-        std::size_t pos = command.find(" ", start);
+        std::size_t start = command.length()? command.find_first_not_of(whitespace): 0;
+        std::size_t pos = command.find_first_of(whitespace, start);
         std::string kw = command.substr(start, pos - start);
         std::string args = command.substr(pos + 1);
         std::vector<std::string> tokens = stringTokenize(args);


### PR DESCRIPTION
Skip over leading spaces *and tabs* when parsing the command line; also treat tab as a delimeter to end the command. Fixes #1271 (plus make the behaviour of the interpreter less weird by treating tabs the same as spaces).