### PR TITLE
Fix Android thread priority

### DIFF
--- a/src/sfizz/FilePool.cpp
+++ b/src/sfizz/FilePool.cpp
@@ -612,8 +612,8 @@ void sfz::FilePool::raiseCurrentThreadPriority() noexcept
         DBG("[sfizz] Cannot set current thread priority: " << error.what());
     }
 #elif defined(__ANDROID__)
-    int tid = gettid();  // Android specific function to get thread ID
-    int priority = -20;  // Highest priority for nice value
+    int tid = gettid(); // Android specific function to get thread ID
+    int priority = -2;  // android.os.Process.THREAD_PRIORITY_FOREGROUND
     if (setpriority(PRIO_PROCESS, tid, priority) != 0) {
         // setpriority sets errno on failure
         DBG("[sfizz] Cannot set current thread priority: " << strerror(errno));


### PR DESCRIPTION
Android threads are Linux threads which differ from the POSIX standard.  
Calling pthread_setschedparam does not produce the intended effect on Android.