### PR TITLE
Workaround for the sfizz_jack infinite loop.

### DIFF
--- a/clients/jack_client.cpp
+++ b/clients/jack_client.cpp
@@ -221,7 +221,7 @@ std::vector<std::string> stringTokenize(const std::string& str)
 
 void cliThreadProc()
 {
-    while (!shouldClose) {
+    while (!shouldClose && std::cin) {
         std::cout << "\n> ";
 
         std::string command;


### PR DESCRIPTION
Fixes #1266 
Press Ctrl-C to quit if you input Ctrl-D or EOF.