### PR TITLE
Fixes build with Clang 17

### DIFF
--- a/external/atomic_queue/include/atomic_queue/atomic_queue.h
+++ b/external/atomic_queue/include/atomic_queue/atomic_queue.h
@@ -400,13 +400,13 @@ class AtomicQueue2 : public AtomicQueueCommon<AtomicQueue2<T, SIZE, MINIMIZE_CON
 
     T do_pop(unsigned tail) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(tail % size_);
-        return Base::template do_pop_any(states_[index], elements_[index]);
+        return Base::do_pop_any(states_[index], elements_[index]);
     }
 
     template<class U>
     void do_push(U&& element, unsigned head) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(head % size_);
-        Base::template do_push_any(std::forward<U>(element), states_[index], elements_[index]);
+        Base::do_push_any(std::forward<U>(element), states_[index], elements_[index]);
     }
 
 public:
@@ -529,13 +529,13 @@ class AtomicQueueB2 : private std::allocator_traits<A>::template rebind_alloc<un
 
     T do_pop(unsigned tail) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(tail & (size_ - 1));
-        return Base::template do_pop_any(states_[index], elements_[index]);
+        return Base::do_pop_any(states_[index], elements_[index]);
     }
 
     template<class U>
     void do_push(U&& element, unsigned head) noexcept {
         unsigned index = details::remap_index<SHUFFLE_BITS>(head & (size_ - 1));
-        Base::template do_push_any(std::forward<U>(element), states_[index], elements_[index]);
+        Base::do_push_any(std::forward<U>(element), states_[index], elements_[index]);
     }
 
     template<class U>


### PR DESCRIPTION
## Description
This PR fixes invalid use of 'template' keyword when calling do_pop_any in `atomic_queue.h`

While do_pop_any is a function template, Clang 17 fails to compile the following call:

```cpp
Base::template do_pop_any(states_[index], elements_[index]);
```

with error `error: a template argument list is expected after a name prefixed by the 'template' keyword`

This is because the template keyword is only allowed when explicitly specifying template arguments (e.g., Base::template do_pop_any<T>(...)). In this case, template argument deduction is used, so the template keyword must not be present. This change adheres to the C++ language rules regarding dependent names and member function templates. Other calls that explicitly specify template arguments (like do_pop_atomic<T, NIL>) continue to use the template keyword correctly.

Potentially fixes https://github.com/sfztools/sfizz/issues/1305

## Screenshot
<img width="900" alt="Screenshot 2025-04-10 at 23 39 25" src="https://github.com/user-attachments/assets/24259401-8784-46a3-8182-b6b84f59bab0" />
