### PR TITLE
Crash fix: if `Voice::startVoice()` fails, clean up immediately

### DIFF
--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1307,8 +1307,12 @@ void Synth::Impl::startVoice(Layer* layer, int delay, const TriggerEvent& trigge
         return;
 
     selectedVoice->reset();
-    if (selectedVoice->startVoice(layer, delay, triggerEvent))
+    if (selectedVoice->startVoice(layer, delay, triggerEvent)) {
         ring.addVoiceToRing(selectedVoice);
+    } else {
+        // Clean up immediately, so the main render loop doesn't try to process it (and it's also available again)
+        selectedVoice->reset();
+    }
 }
 
 void Synth::Impl::checkOffGroups(const Region* region, int delay, int number, bool chokedByCC)


### PR DESCRIPTION
If a `Voice` fails to start, it's left as `State::cleanMeUp`.  However, the [main render loop](https://github.com/sfztools/sfizz/blob/f5c6e29f23b8057867c08e88f5f6ac6738baa30b/src/sfizz/Synth.cpp#L1164-L1166) assumes voices are either `State::idle` or `State::playing`, and only checks `voice.toBeCleanedUp()` at the end.

There are various ways to fix it (e.g. checking at the top of the main render loop!) but resetting `Voice`s immediately after a failed start also makes them available again to respond to the _next_ incoming trigger.