### PR TITLE
MPE: per-channel pitch / CC / aftertouch + MPE-aware voice stealing

### DIFF
--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -624,7 +624,7 @@ SFIZZ_EXPORTED_API void sfizz_send_hd_poly_aftertouch(sfizz_synth_t* synth, int 
  * sfizz_set_mpe_enabled() is informational for the engine: it gates
  * same-channel-preference voice stealing. Per-channel input dispatch
  * works regardless of the flag — calling
- * sfizz_send_pitch_wheel_mpe(channel=2, ...) always lands in the
+ * sfizz_send_pitch_wheel_channel(channel=2, ...) always lands in the
  * channel-2 modulation slot.
  *
  * @{
@@ -642,7 +642,7 @@ SFIZZ_EXPORTED_API void sfizz_send_hd_poly_aftertouch(sfizz_synth_t* synth, int 
  * @par Thread-safety constraints
  * - @b RT: the function must be invoked from the Real-time thread
  */
-SFIZZ_EXPORTED_API void sfizz_send_note_on_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, int velocity);
+SFIZZ_EXPORTED_API void sfizz_send_note_on_channel(sfizz_synth_t* synth, int delay, int channel, int note_number, int velocity);
 
 /**
  * @brief Send a high-precision note on event on a specific MIDI channel.
@@ -656,7 +656,7 @@ SFIZZ_EXPORTED_API void sfizz_send_note_on_mpe(sfizz_synth_t* synth, int delay, 
  * @par Thread-safety constraints
  * - @b RT: the function must be invoked from the Real-time thread
  */
-SFIZZ_EXPORTED_API void sfizz_send_hd_note_on_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, float velocity);
+SFIZZ_EXPORTED_API void sfizz_send_hd_note_on_channel(sfizz_synth_t* synth, int delay, int channel, int note_number, float velocity);
 
 /**
  * @brief Send a note off event on a specific MIDI channel (0..15).
@@ -670,7 +670,7 @@ SFIZZ_EXPORTED_API void sfizz_send_hd_note_on_mpe(sfizz_synth_t* synth, int dela
  * @par Thread-safety constraints
  * - @b RT: the function must be invoked from the Real-time thread
  */
-SFIZZ_EXPORTED_API void sfizz_send_note_off_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, int velocity);
+SFIZZ_EXPORTED_API void sfizz_send_note_off_channel(sfizz_synth_t* synth, int delay, int channel, int note_number, int velocity);
 
 /**
  * @brief Send a high-precision note off event on a specific MIDI channel.
@@ -684,7 +684,7 @@ SFIZZ_EXPORTED_API void sfizz_send_note_off_mpe(sfizz_synth_t* synth, int delay,
  * @par Thread-safety constraints
  * - @b RT: the function must be invoked from the Real-time thread
  */
-SFIZZ_EXPORTED_API void sfizz_send_hd_note_off_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, float velocity);
+SFIZZ_EXPORTED_API void sfizz_send_hd_note_off_channel(sfizz_synth_t* synth, int delay, int channel, int note_number, float velocity);
 
 /**
  * @brief Send a CC event on a specific MIDI channel (0..15).
@@ -698,7 +698,7 @@ SFIZZ_EXPORTED_API void sfizz_send_hd_note_off_mpe(sfizz_synth_t* synth, int del
  * @par Thread-safety constraints
  * - @b RT: the function must be invoked from the Real-time thread
  */
-SFIZZ_EXPORTED_API void sfizz_send_cc_mpe(sfizz_synth_t* synth, int delay, int channel, int cc_number, int cc_value);
+SFIZZ_EXPORTED_API void sfizz_send_cc_channel(sfizz_synth_t* synth, int delay, int channel, int cc_number, int cc_value);
 
 /**
  * @brief Send a high-precision CC event on a specific MIDI channel.
@@ -712,7 +712,7 @@ SFIZZ_EXPORTED_API void sfizz_send_cc_mpe(sfizz_synth_t* synth, int delay, int c
  * @par Thread-safety constraints
  * - @b RT: the function must be invoked from the Real-time thread
  */
-SFIZZ_EXPORTED_API void sfizz_send_hdcc_mpe(sfizz_synth_t* synth, int delay, int channel, int cc_number, float norm_value);
+SFIZZ_EXPORTED_API void sfizz_send_hdcc_channel(sfizz_synth_t* synth, int delay, int channel, int cc_number, float norm_value);
 
 /**
  * @brief Send a pitch wheel event on a specific MIDI channel (0..15).
@@ -725,7 +725,7 @@ SFIZZ_EXPORTED_API void sfizz_send_hdcc_mpe(sfizz_synth_t* synth, int delay, int
  * @par Thread-safety constraints
  * - @b RT: the function must be invoked from the Real-time thread
  */
-SFIZZ_EXPORTED_API void sfizz_send_pitch_wheel_mpe(sfizz_synth_t* synth, int delay, int channel, int pitch);
+SFIZZ_EXPORTED_API void sfizz_send_pitch_wheel_channel(sfizz_synth_t* synth, int delay, int channel, int pitch);
 
 /**
  * @brief Send a high-precision pitch wheel event on a specific MIDI channel.
@@ -738,7 +738,7 @@ SFIZZ_EXPORTED_API void sfizz_send_pitch_wheel_mpe(sfizz_synth_t* synth, int del
  * @par Thread-safety constraints
  * - @b RT: the function must be invoked from the Real-time thread
  */
-SFIZZ_EXPORTED_API void sfizz_send_hd_pitch_wheel_mpe(sfizz_synth_t* synth, int delay, int channel, float pitch);
+SFIZZ_EXPORTED_API void sfizz_send_hd_pitch_wheel_channel(sfizz_synth_t* synth, int delay, int channel, float pitch);
 
 /**
  * @brief Send a channel aftertouch (channel pressure) event on a specific MIDI channel.
@@ -751,7 +751,7 @@ SFIZZ_EXPORTED_API void sfizz_send_hd_pitch_wheel_mpe(sfizz_synth_t* synth, int 
  * @par Thread-safety constraints
  * - @b RT: the function must be invoked from the Real-time thread
  */
-SFIZZ_EXPORTED_API void sfizz_send_channel_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, int aftertouch);
+SFIZZ_EXPORTED_API void sfizz_send_channel_aftertouch_channel(sfizz_synth_t* synth, int delay, int channel, int aftertouch);
 
 /**
  * @brief Send a high-precision channel aftertouch event on a specific MIDI channel.
@@ -764,7 +764,7 @@ SFIZZ_EXPORTED_API void sfizz_send_channel_aftertouch_mpe(sfizz_synth_t* synth, 
  * @par Thread-safety constraints
  * - @b RT: the function must be invoked from the Real-time thread
  */
-SFIZZ_EXPORTED_API void sfizz_send_hd_channel_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, float aftertouch);
+SFIZZ_EXPORTED_API void sfizz_send_hd_channel_aftertouch_channel(sfizz_synth_t* synth, int delay, int channel, float aftertouch);
 
 /**
  * @brief Send a polyphonic aftertouch event on a specific MIDI channel.
@@ -778,7 +778,7 @@ SFIZZ_EXPORTED_API void sfizz_send_hd_channel_aftertouch_mpe(sfizz_synth_t* synt
  * @par Thread-safety constraints
  * - @b RT: the function must be invoked from the Real-time thread
  */
-SFIZZ_EXPORTED_API void sfizz_send_poly_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, int aftertouch);
+SFIZZ_EXPORTED_API void sfizz_send_poly_aftertouch_channel(sfizz_synth_t* synth, int delay, int channel, int note_number, int aftertouch);
 
 /**
  * @brief Send a high-precision polyphonic aftertouch event on a specific MIDI channel.
@@ -792,7 +792,7 @@ SFIZZ_EXPORTED_API void sfizz_send_poly_aftertouch_mpe(sfizz_synth_t* synth, int
  * @par Thread-safety constraints
  * - @b RT: the function must be invoked from the Real-time thread
  */
-SFIZZ_EXPORTED_API void sfizz_send_hd_poly_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, float aftertouch);
+SFIZZ_EXPORTED_API void sfizz_send_hd_poly_aftertouch_channel(sfizz_synth_t* synth, int delay, int channel, int note_number, float aftertouch);
 
 /**
  * @brief Enable or disable MPE mode.

--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -612,6 +612,243 @@ SFIZZ_EXPORTED_API void sfizz_send_poly_aftertouch(sfizz_synth_t* synth, int del
 SFIZZ_EXPORTED_API void sfizz_send_hd_poly_aftertouch(sfizz_synth_t* synth, int delay, int note_number, float aftertouch);
 
 /**
+ * @defgroup MPE MIDI Polyphonic Expression
+ *
+ * Channel-aware variants of the input API. They populate per-channel
+ * modulation state in the underlying engine so voices triggered on a
+ * member channel respond independently to per-note pitch bend, per-note
+ * CC, and per-note aftertouch. Hosts that don't care about MPE can keep
+ * using the existing single-channel methods; they are equivalent to
+ * calling the corresponding `_mpe` method with channel = 0 (master).
+ *
+ * sfizz_set_mpe_enabled() is informational for the engine: it gates
+ * same-channel-preference voice stealing. Per-channel input dispatch
+ * works regardless of the flag — calling
+ * sfizz_send_pitch_wheel_mpe(channel=2, ...) always lands in the
+ * channel-2 modulation slot.
+ *
+ * @{
+ */
+
+/**
+ * @brief Send a note on event on a specific MIDI channel (0..15).
+ *
+ * @param synth        The synth.
+ * @param delay        The delay of the event in the block, in samples.
+ * @param channel      The MIDI channel, in domain 0 to 15.
+ * @param note_number  The MIDI note number, in domain 0 to 127.
+ * @param velocity     The MIDI velocity, in domain 0 to 127.
+ *
+ * @par Thread-safety constraints
+ * - @b RT: the function must be invoked from the Real-time thread
+ */
+SFIZZ_EXPORTED_API void sfizz_send_note_on_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, int velocity);
+
+/**
+ * @brief Send a high-precision note on event on a specific MIDI channel.
+ *
+ * @param synth        The synth.
+ * @param delay        The delay of the event in the block, in samples.
+ * @param channel      The MIDI channel, in domain 0 to 15.
+ * @param note_number  The MIDI note number, in domain 0 to 127.
+ * @param velocity     The normalized MIDI velocity, in domain 0 to 1.
+ *
+ * @par Thread-safety constraints
+ * - @b RT: the function must be invoked from the Real-time thread
+ */
+SFIZZ_EXPORTED_API void sfizz_send_hd_note_on_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, float velocity);
+
+/**
+ * @brief Send a note off event on a specific MIDI channel (0..15).
+ *
+ * @param synth        The synth.
+ * @param delay        The delay of the event in the block, in samples.
+ * @param channel      The MIDI channel, in domain 0 to 15.
+ * @param note_number  The MIDI note number, in domain 0 to 127.
+ * @param velocity     The MIDI velocity, in domain 0 to 127.
+ *
+ * @par Thread-safety constraints
+ * - @b RT: the function must be invoked from the Real-time thread
+ */
+SFIZZ_EXPORTED_API void sfizz_send_note_off_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, int velocity);
+
+/**
+ * @brief Send a high-precision note off event on a specific MIDI channel.
+ *
+ * @param synth        The synth.
+ * @param delay        The delay of the event in the block, in samples.
+ * @param channel      The MIDI channel, in domain 0 to 15.
+ * @param note_number  The MIDI note number, in domain 0 to 127.
+ * @param velocity     The normalized MIDI velocity, in domain 0 to 1.
+ *
+ * @par Thread-safety constraints
+ * - @b RT: the function must be invoked from the Real-time thread
+ */
+SFIZZ_EXPORTED_API void sfizz_send_hd_note_off_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, float velocity);
+
+/**
+ * @brief Send a CC event on a specific MIDI channel (0..15).
+ *
+ * @param synth      The synth.
+ * @param delay      The delay of the event in the block, in samples.
+ * @param channel    The MIDI channel, in domain 0 to 15.
+ * @param cc_number  The MIDI CC number, in domain 0 to 127.
+ * @param cc_value   The MIDI CC value, in domain 0 to 127.
+ *
+ * @par Thread-safety constraints
+ * - @b RT: the function must be invoked from the Real-time thread
+ */
+SFIZZ_EXPORTED_API void sfizz_send_cc_mpe(sfizz_synth_t* synth, int delay, int channel, int cc_number, int cc_value);
+
+/**
+ * @brief Send a high-precision CC event on a specific MIDI channel.
+ *
+ * @param synth       The synth.
+ * @param delay       The delay of the event in the block, in samples.
+ * @param channel     The MIDI channel, in domain 0 to 15.
+ * @param cc_number   The MIDI CC number, in domain 0 to 127.
+ * @param norm_value  The normalized CC value, in domain 0 to 1.
+ *
+ * @par Thread-safety constraints
+ * - @b RT: the function must be invoked from the Real-time thread
+ */
+SFIZZ_EXPORTED_API void sfizz_send_hdcc_mpe(sfizz_synth_t* synth, int delay, int channel, int cc_number, float norm_value);
+
+/**
+ * @brief Send a pitch wheel event on a specific MIDI channel (0..15).
+ *
+ * @param synth    The synth.
+ * @param delay    The delay of the event in the block, in samples.
+ * @param channel  The MIDI channel, in domain 0 to 15.
+ * @param pitch    The pitch.
+ *
+ * @par Thread-safety constraints
+ * - @b RT: the function must be invoked from the Real-time thread
+ */
+SFIZZ_EXPORTED_API void sfizz_send_pitch_wheel_mpe(sfizz_synth_t* synth, int delay, int channel, int pitch);
+
+/**
+ * @brief Send a high-precision pitch wheel event on a specific MIDI channel.
+ *
+ * @param synth    The synth.
+ * @param delay    The delay of the event in the block, in samples.
+ * @param channel  The MIDI channel, in domain 0 to 15.
+ * @param pitch    The normalized pitch, in domain -1 to 1.
+ *
+ * @par Thread-safety constraints
+ * - @b RT: the function must be invoked from the Real-time thread
+ */
+SFIZZ_EXPORTED_API void sfizz_send_hd_pitch_wheel_mpe(sfizz_synth_t* synth, int delay, int channel, float pitch);
+
+/**
+ * @brief Send a channel aftertouch (channel pressure) event on a specific MIDI channel.
+ *
+ * @param synth       The synth.
+ * @param delay       The delay of the event in the block, in samples.
+ * @param channel     The MIDI channel, in domain 0 to 15.
+ * @param aftertouch  The aftertouch value, in domain 0 to 127.
+ *
+ * @par Thread-safety constraints
+ * - @b RT: the function must be invoked from the Real-time thread
+ */
+SFIZZ_EXPORTED_API void sfizz_send_channel_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, int aftertouch);
+
+/**
+ * @brief Send a high-precision channel aftertouch event on a specific MIDI channel.
+ *
+ * @param synth       The synth.
+ * @param delay       The delay of the event in the block, in samples.
+ * @param channel     The MIDI channel, in domain 0 to 15.
+ * @param aftertouch  The normalized aftertouch value, in domain 0 to 1.
+ *
+ * @par Thread-safety constraints
+ * - @b RT: the function must be invoked from the Real-time thread
+ */
+SFIZZ_EXPORTED_API void sfizz_send_hd_channel_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, float aftertouch);
+
+/**
+ * @brief Send a polyphonic aftertouch event on a specific MIDI channel.
+ *
+ * @param synth        The synth.
+ * @param delay        The delay of the event in the block, in samples.
+ * @param channel      The MIDI channel, in domain 0 to 15.
+ * @param note_number  The note number, in domain 0 to 127.
+ * @param aftertouch   The aftertouch value, in domain 0 to 127.
+ *
+ * @par Thread-safety constraints
+ * - @b RT: the function must be invoked from the Real-time thread
+ */
+SFIZZ_EXPORTED_API void sfizz_send_poly_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, int aftertouch);
+
+/**
+ * @brief Send a high-precision polyphonic aftertouch event on a specific MIDI channel.
+ *
+ * @param synth        The synth.
+ * @param delay        The delay of the event in the block, in samples.
+ * @param channel      The MIDI channel, in domain 0 to 15.
+ * @param note_number  The note number, in domain 0 to 127.
+ * @param aftertouch   The normalized aftertouch value, in domain 0 to 1.
+ *
+ * @par Thread-safety constraints
+ * - @b RT: the function must be invoked from the Real-time thread
+ */
+SFIZZ_EXPORTED_API void sfizz_send_hd_poly_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, float aftertouch);
+
+/**
+ * @brief Enable or disable MPE mode.
+ *
+ * Gates same-channel-preference voice stealing inside the engine.
+ * Per-channel input dispatch (the `_mpe` send functions above) works
+ * regardless of this flag.
+ *
+ * @param synth    The synth.
+ * @param enabled  Whether MPE mode is enabled.
+ *
+ * @par Thread-safety constraints
+ * - @b RT: the function must be invoked from the Real-time thread
+ */
+SFIZZ_EXPORTED_API void sfizz_set_mpe_enabled(sfizz_synth_t* synth, bool enabled);
+
+/**
+ * @brief Get the current MPE mode flag.
+ *
+ * @param synth  The synth.
+ *
+ * @return Whether MPE mode is enabled.
+ */
+SFIZZ_EXPORTED_API bool sfizz_get_mpe_enabled(sfizz_synth_t* synth);
+
+/**
+ * @brief Set the MPE pitch bend range, in semitones (master / per-note).
+ *
+ * MPE 1.0 conventions: master 2 semitones, per-note 48 semitones.
+ *
+ * @param synth               The synth.
+ * @param master_semitones    The master-channel pitch bend range, in semitones.
+ * @param per_note_semitones  The per-note pitch bend range, in semitones.
+ *
+ * @par Thread-safety constraints
+ * - @b RT: the function must be invoked from the Real-time thread
+ */
+SFIZZ_EXPORTED_API void sfizz_set_mpe_pitch_bend_range(sfizz_synth_t* synth, float master_semitones, float per_note_semitones);
+
+/**
+ * @brief Get the configured MPE master pitch bend range, in semitones.
+ *
+ * @param synth  The synth.
+ */
+SFIZZ_EXPORTED_API float sfizz_get_mpe_master_pitch_bend_range(sfizz_synth_t* synth);
+
+/**
+ * @brief Get the configured MPE per-note pitch bend range, in semitones.
+ *
+ * @param synth  The synth.
+ */
+SFIZZ_EXPORTED_API float sfizz_get_mpe_per_note_pitch_bend_range(sfizz_synth_t* synth);
+
+/** @} */
+
+/**
  * @brief Send a tempo event.
  *
  * This command should be delay-ordered with all other time/signature commands, namely

--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -883,6 +883,20 @@ SFIZZ_EXPORTED_API void sfizz_set_mpe_per_note_bend_auto_config_enabled(sfizz_sy
  */
 SFIZZ_EXPORTED_API bool sfizz_get_mpe_per_note_bend_auto_config_enabled(sfizz_synth_t* synth);
 
+/**
+ * @brief Diagnostic count of Polyphonic Key Pressure events the engine
+ * dropped because they arrived on a Member Channel while MPE was enabled.
+ *
+ * MPE 1.0 §2.2.7 / Appendix E Table 5 mark Polyphonic Key Pressure on
+ * Member Channels as prohibited. The engine drops such events at the
+ * `sfizz_send_*_poly_aftertouch_mpe` entry and increments this counter so
+ * hosts can observe spec-violating traffic. Counter is not reset by
+ * `sfizz_set_mpe_enabled`, polyphony changes, or SFZ reloads.
+ *
+ * @param synth  The synth.
+ */
+SFIZZ_EXPORTED_API int sfizz_get_dropped_poly_kp_on_member_count(sfizz_synth_t* synth);
+
 /** @} */
 
 /**

--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -897,6 +897,23 @@ SFIZZ_EXPORTED_API bool sfizz_get_mpe_per_note_bend_auto_config_enabled(sfizz_sy
  */
 SFIZZ_EXPORTED_API int sfizz_get_dropped_poly_kp_on_member_count(sfizz_synth_t* synth);
 
+/**
+ * @brief Diagnostic count of Manager-only CC messages the engine dropped
+ * because they arrived on a Member Channel while MPE was enabled.
+ *
+ * MPE 1.0 §2.3.1 / §2.3.3 (Appendix E Table 5) require pedal CCs (64-69),
+ * mode/reset CCs (120-125 excluding 122) and Bank Select (CC 0 / CC 32)
+ * to be honoured only on the Manager Channel. The engine drops such
+ * events at the `sfizz_send_*cc` entry and increments this counter so
+ * hosts can observe spec-violating traffic. Program Change is filtered
+ * host-side because `sfizz_send_program_change` does not carry a channel.
+ * Counter is not reset by `sfizz_set_mpe_enabled`, polyphony changes, or
+ * SFZ reloads.
+ *
+ * @param synth  The synth.
+ */
+SFIZZ_EXPORTED_API int sfizz_get_dropped_manager_only_message_count(sfizz_synth_t* synth);
+
 /** @} */
 
 /**

--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -846,6 +846,43 @@ SFIZZ_EXPORTED_API float sfizz_get_mpe_master_pitch_bend_range(sfizz_synth_t* sy
  */
 SFIZZ_EXPORTED_API float sfizz_get_mpe_per_note_pitch_bend_range(sfizz_synth_t* synth);
 
+/**
+ * @brief Toggle whether incoming MPE Pitch Bend Sensitivity (RPN 0)
+ * messages on the master channel update the master bend range. The
+ * MPE Configuration Message (RPN 6) is processed unconditionally —
+ * this gate covers only the bend range updates. Default is true.
+ *
+ * @param synth   The synth.
+ * @param enabled true to accept the messages, false to ignore them.
+ */
+SFIZZ_EXPORTED_API void sfizz_set_mpe_master_bend_auto_config_enabled(sfizz_synth_t* synth, bool enabled);
+
+/**
+ * @brief Get whether master-channel Pitch Bend Sensitivity messages
+ * update the master bend range.
+ *
+ * @param synth  The synth.
+ */
+SFIZZ_EXPORTED_API bool sfizz_get_mpe_master_bend_auto_config_enabled(sfizz_synth_t* synth);
+
+/**
+ * @brief Toggle whether incoming MPE Pitch Bend Sensitivity (RPN 0)
+ * messages on member channels update the per-note bend range. Default
+ * is true.
+ *
+ * @param synth   The synth.
+ * @param enabled true to accept the messages, false to ignore them.
+ */
+SFIZZ_EXPORTED_API void sfizz_set_mpe_per_note_bend_auto_config_enabled(sfizz_synth_t* synth, bool enabled);
+
+/**
+ * @brief Get whether member-channel Pitch Bend Sensitivity messages
+ * update the per-note bend range.
+ *
+ * @param synth  The synth.
+ */
+SFIZZ_EXPORTED_API bool sfizz_get_mpe_per_note_bend_auto_config_enabled(sfizz_synth_t* synth);
+
 /** @} */
 
 /**

--- a/src/sfizz.h
+++ b/src/sfizz.h
@@ -619,13 +619,14 @@ SFIZZ_EXPORTED_API void sfizz_send_hd_poly_aftertouch(sfizz_synth_t* synth, int 
  * member channel respond independently to per-note pitch bend, per-note
  * CC, and per-note aftertouch. Hosts that don't care about MPE can keep
  * using the existing single-channel methods; they are equivalent to
- * calling the corresponding `_mpe` method with channel = 0 (master).
+ * calling the corresponding `_channel` method with channel = 0 (master).
  *
- * sfizz_set_mpe_enabled() is informational for the engine: it gates
- * same-channel-preference voice stealing. Per-channel input dispatch
- * works regardless of the flag — calling
- * sfizz_send_pitch_wheel_channel(channel=2, ...) always lands in the
- * channel-2 modulation slot.
+ * sfizz_set_mpe_enabled() gates channel routing engine-wide. With MPE
+ * disabled, the `_channel` methods collapse channel to 0 internally so
+ * both API surfaces behave identically (single-channel, pre-MPE
+ * semantics). With MPE enabled, the channel argument is honoured
+ * end-to-end and the MPE 1.0 spec-compliance filters (Manager-only
+ * CCs, member-channel Poly KP) apply.
  *
  * @{
  */

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -677,33 +677,33 @@ public:
     //
     // setMPEEnabled() is informational for the engine: it gates same-channel-
     // preference voice stealing. Per-channel input dispatch works regardless
-    // of the flag — calling pitchWheelMPE(channel=2, ...) always lands in
+    // of the flag — calling pitchWheel(channel=2, ...) always lands in
     // the channel-2 modulation slot.
 
     /** @brief Send a note on event on a specific MIDI channel (0..15). */
-    void noteOnMPE(int delay, int channel, int noteNumber, int velocity) noexcept;
+    void noteOn(int delay, int channel, int noteNumber, int velocity) noexcept;
     /** @brief High-precision note on on a specific MIDI channel. */
-    void hdNoteOnMPE(int delay, int channel, int noteNumber, float velocity) noexcept;
+    void hdNoteOn(int delay, int channel, int noteNumber, float velocity) noexcept;
     /** @brief Send a note off event on a specific MIDI channel (0..15). */
-    void noteOffMPE(int delay, int channel, int noteNumber, int velocity) noexcept;
+    void noteOff(int delay, int channel, int noteNumber, int velocity) noexcept;
     /** @brief High-precision note off on a specific MIDI channel. */
-    void hdNoteOffMPE(int delay, int channel, int noteNumber, float velocity) noexcept;
+    void hdNoteOff(int delay, int channel, int noteNumber, float velocity) noexcept;
     /** @brief Send a CC event on a specific MIDI channel (0..15). */
-    void ccMPE(int delay, int channel, int ccNumber, int ccValue) noexcept;
+    void cc(int delay, int channel, int ccNumber, int ccValue) noexcept;
     /** @brief High-precision CC on a specific MIDI channel. */
-    void hdccMPE(int delay, int channel, int ccNumber, float normValue) noexcept;
+    void hdcc(int delay, int channel, int ccNumber, float normValue) noexcept;
     /** @brief Send a pitch bend event on a specific MIDI channel (0..15). */
-    void pitchWheelMPE(int delay, int channel, int pitch) noexcept;
+    void pitchWheel(int delay, int channel, int pitch) noexcept;
     /** @brief High-precision pitch bend on a specific MIDI channel. */
-    void hdPitchWheelMPE(int delay, int channel, float pitch) noexcept;
+    void hdPitchWheel(int delay, int channel, float pitch) noexcept;
     /** @brief Send a channel aftertouch event on a specific MIDI channel. */
-    void channelAftertouchMPE(int delay, int channel, int aftertouch) noexcept;
+    void channelAftertouch(int delay, int channel, int aftertouch) noexcept;
     /** @brief High-precision channel aftertouch on a specific MIDI channel. */
-    void hdChannelAftertouchMPE(int delay, int channel, float normAftertouch) noexcept;
+    void hdChannelAftertouch(int delay, int channel, float normAftertouch) noexcept;
     /** @brief Send a polyphonic aftertouch event on a specific MIDI channel. */
-    void polyAftertouchMPE(int delay, int channel, int noteNumber, int aftertouch) noexcept;
+    void polyAftertouch(int delay, int channel, int noteNumber, int aftertouch) noexcept;
     /** @brief High-precision polyphonic aftertouch on a specific MIDI channel. */
-    void hdPolyAftertouchMPE(int delay, int channel, int noteNumber, float normAftertouch) noexcept;
+    void hdPolyAftertouch(int delay, int channel, int noteNumber, float normAftertouch) noexcept;
 
     /** @brief Enable or disable MPE mode (gates same-channel voice stealing). */
     void setMPEEnabled(bool enabled) noexcept;

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -742,6 +742,17 @@ public:
      */
     int getDroppedPolyKpOnMemberCount() const noexcept;
 
+    /**
+     * @brief Diagnostic count of Manager-only CC messages the engine
+     * dropped because they arrived on a Member Channel while MPE was
+     * enabled. MPE 1.0 §2.3.1 / §2.3.3 (Appendix E Table 5) require pedal
+     * CCs (64-69), mode/reset CCs (120-125 excluding 122) and Bank Select
+     * (CC 0 / CC 32) to be honoured only on the Manager Channel; the
+     * engine silently drops them and increments this counter so hosts /
+     * tests can observe spec-violating traffic.
+     */
+    int getDroppedManagerOnlyMessageCount() const noexcept;
+
     // =========================================================================
 
     /**

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -666,6 +666,59 @@ public:
      */
     void hdPolyAftertouch(int delay, int noteNumber, float aftertouch) noexcept;
 
+    // === MPE (MIDI Polyphonic Expression) support ============================
+    //
+    // Channel-aware variants of the input API. They populate per-channel
+    // modulation state in the underlying engine so voices triggered on a
+    // member channel respond independently to per-note pitch bend, per-note
+    // CC, and per-note aftertouch. Hosts that don't care about MPE can keep
+    // using the existing single-channel methods; they are equivalent to
+    // calling the corresponding *MPE method with channel = 0 (master).
+    //
+    // setMPEEnabled() is informational for the engine: it gates same-channel-
+    // preference voice stealing. Per-channel input dispatch works regardless
+    // of the flag — calling pitchWheelMPE(channel=2, ...) always lands in
+    // the channel-2 modulation slot.
+
+    /** @brief Send a note on event on a specific MIDI channel (0..15). */
+    void noteOnMPE(int delay, int channel, int noteNumber, int velocity) noexcept;
+    /** @brief High-precision note on on a specific MIDI channel. */
+    void hdNoteOnMPE(int delay, int channel, int noteNumber, float velocity) noexcept;
+    /** @brief Send a note off event on a specific MIDI channel (0..15). */
+    void noteOffMPE(int delay, int channel, int noteNumber, int velocity) noexcept;
+    /** @brief High-precision note off on a specific MIDI channel. */
+    void hdNoteOffMPE(int delay, int channel, int noteNumber, float velocity) noexcept;
+    /** @brief Send a CC event on a specific MIDI channel (0..15). */
+    void ccMPE(int delay, int channel, int ccNumber, int ccValue) noexcept;
+    /** @brief High-precision CC on a specific MIDI channel. */
+    void hdccMPE(int delay, int channel, int ccNumber, float normValue) noexcept;
+    /** @brief Send a pitch bend event on a specific MIDI channel (0..15). */
+    void pitchWheelMPE(int delay, int channel, int pitch) noexcept;
+    /** @brief High-precision pitch bend on a specific MIDI channel. */
+    void hdPitchWheelMPE(int delay, int channel, float pitch) noexcept;
+    /** @brief Send a channel aftertouch event on a specific MIDI channel. */
+    void channelAftertouchMPE(int delay, int channel, int aftertouch) noexcept;
+    /** @brief High-precision channel aftertouch on a specific MIDI channel. */
+    void hdChannelAftertouchMPE(int delay, int channel, float normAftertouch) noexcept;
+    /** @brief Send a polyphonic aftertouch event on a specific MIDI channel. */
+    void polyAftertouchMPE(int delay, int channel, int noteNumber, int aftertouch) noexcept;
+    /** @brief High-precision polyphonic aftertouch on a specific MIDI channel. */
+    void hdPolyAftertouchMPE(int delay, int channel, int noteNumber, float normAftertouch) noexcept;
+
+    /** @brief Enable or disable MPE mode (gates same-channel voice stealing). */
+    void setMPEEnabled(bool enabled) noexcept;
+    /** @brief Get the current MPE mode flag. */
+    bool getMPEEnabled() const noexcept;
+    /**
+     * @brief Set the MPE pitch bend range, in semitones (master / per-note).
+     * MPE 1.0 conventions: master 2 semitones, per-note 48 semitones.
+     */
+    void setMPEPitchBendRange(float masterSemitones, float perNoteSemitones) noexcept;
+    float getMPEMasterPitchBendRange() const noexcept;
+    float getMPEPerNotePitchBendRange() const noexcept;
+
+    // =========================================================================
+
     /**
      * @brief Send a tempo event to the synth.
      *

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -717,6 +717,22 @@ public:
     float getMPEMasterPitchBendRange() const noexcept;
     float getMPEPerNotePitchBendRange() const noexcept;
 
+    /**
+     * @brief Toggle whether incoming MPE Pitch Bend Sensitivity (RPN 0)
+     * messages on the master channel update the master bend range.
+     * MPE Configuration Messages (RPN 6) are processed unconditionally.
+     * Defaults to true.
+     */
+    void setMPEMasterBendAutoConfigEnabled(bool enabled) noexcept;
+    bool getMPEMasterBendAutoConfigEnabled() const noexcept;
+    /**
+     * @brief Toggle whether incoming MPE Pitch Bend Sensitivity (RPN 0)
+     * messages on member channels update the per-note bend range.
+     * Defaults to true.
+     */
+    void setMPEPerNoteBendAutoConfigEnabled(bool enabled) noexcept;
+    bool getMPEPerNoteBendAutoConfigEnabled() const noexcept;
+
     // =========================================================================
 
     /**

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -733,6 +733,15 @@ public:
     void setMPEPerNoteBendAutoConfigEnabled(bool enabled) noexcept;
     bool getMPEPerNoteBendAutoConfigEnabled() const noexcept;
 
+    /**
+     * @brief Diagnostic count of Polyphonic Key Pressure events the engine
+     * dropped because they arrived on a Member Channel while MPE was
+     * enabled. MPE 1.0 §2.2.7 / Appendix E Table 5 prohibit Poly KP on
+     * Member Channels; the engine silently drops them and increments this
+     * counter so hosts / tests can observe spec-violating traffic.
+     */
+    int getDroppedPolyKpOnMemberCount() const noexcept;
+
     // =========================================================================
 
     /**

--- a/src/sfizz.hpp
+++ b/src/sfizz.hpp
@@ -666,19 +666,21 @@ public:
      */
     void hdPolyAftertouch(int delay, int noteNumber, float aftertouch) noexcept;
 
-    // === MPE (MIDI Polyphonic Expression) support ============================
+    // === Channel-aware input API (MPE / multitimbral) ========================
     //
-    // Channel-aware variants of the input API. They populate per-channel
+    // Overloads that take a MIDI channel argument. They populate per-channel
     // modulation state in the underlying engine so voices triggered on a
     // member channel respond independently to per-note pitch bend, per-note
     // CC, and per-note aftertouch. Hosts that don't care about MPE can keep
-    // using the existing single-channel methods; they are equivalent to
-    // calling the corresponding *MPE method with channel = 0 (master).
+    // using the existing single-channel overloads; they are equivalent to
+    // calling the channel-taking overload with channel = 0 (master).
     //
-    // setMPEEnabled() is informational for the engine: it gates same-channel-
-    // preference voice stealing. Per-channel input dispatch works regardless
-    // of the flag — calling pitchWheel(channel=2, ...) always lands in
-    // the channel-2 modulation slot.
+    // setMPEEnabled() gates channel routing engine-wide: with MPE disabled,
+    // the channel-taking overloads collapse channel to 0 internally so both
+    // API surfaces behave identically (single-channel, pre-MPE semantics).
+    // With MPE enabled, the channel argument is honoured end-to-end and
+    // the MPE 1.0 spec-compliance filters (Manager-only CCs, member-channel
+    // Poly KP) apply.
 
     /** @brief Send a note on event on a specific MIDI channel (0..15). */
     void noteOn(int delay, int channel, int noteNumber, int velocity) noexcept;

--- a/src/sfizz/MidiState.cpp
+++ b/src/sfizz/MidiState.cpp
@@ -200,8 +200,11 @@ float sfz::MidiState::getPitchBend(int channel) const noexcept
     if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
         return 0.0f;
     const auto& events = channelStates[channel].pitchEvents;
-    if (events.empty())
+    if (events.empty()) {
+        if (channel != masterChannel)
+            return getPitchBend(masterChannel);
         return 0.0f;
+    }
     return events.back().value;
 }
 
@@ -245,8 +248,11 @@ float sfz::MidiState::getChannelAftertouch(int channel) const noexcept
     if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
         return 0.0f;
     const auto& events = channelStates[channel].channelAftertouchEvents;
-    if (events.empty())
+    if (events.empty()) {
+        if (channel != masterChannel)
+            return getChannelAftertouch(masterChannel);
         return 0.0f;
+    }
     return events.back().value;
 }
 
@@ -263,8 +269,11 @@ float sfz::MidiState::getPolyAftertouch(int channel, int noteNumber) const noexc
         return 0.0f;
 
     const auto& events = channelStates[channel].polyAftertouchEvents[noteNumber];
-    if (events.empty())
+    if (events.empty()) {
+        if (channel != masterChannel)
+            return getPolyAftertouch(masterChannel, noteNumber);
         return 0.0f;
+    }
     return events.back().value;
 }
 
@@ -293,8 +302,11 @@ float sfz::MidiState::getCCValue(int channel, int ccNumber) const noexcept
     if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
         return 0.0f;
     const auto& events = channelStates[channel].ccEvents[ccNumber];
-    if (events.empty())
+    if (events.empty()) {
+        if (channel != masterChannel)
+            return getCCValue(masterChannel, ccNumber);
         return 0.0f;
+    }
     return events.back().value;
 }
 
@@ -309,8 +321,11 @@ float sfz::MidiState::getCCValueAt(int channel, int ccNumber, int delay) const n
     if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
         return 0.0f;
     const auto& events = channelStates[channel].ccEvents[ccNumber];
-    if (events.empty())
+    if (events.empty()) {
+        if (channel != masterChannel)
+            return getCCValueAt(masterChannel, ccNumber, delay);
         return 0.0f;
+    }
     const auto ccEvent = absl::c_lower_bound(
         events, delay, MidiEventDelayComparator {});
     if (ccEvent != events.end())

--- a/src/sfizz/MidiState.cpp
+++ b/src/sfizz/MidiState.cpp
@@ -363,6 +363,32 @@ void sfz::MidiState::resetNoteStates() noexcept
     absl::c_fill(noteOffTimes, 0);
 }
 
+const sfz::EventVector& sfz::MidiState::getPitchEventsRaw(int channel) const noexcept
+{
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return nullEvent;
+    return channelStates[channel].pitchEvents;
+}
+
+float sfz::MidiState::getPitchBendRaw(int channel) const noexcept
+{
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return 0.0f;
+    const auto& events = channelStates[channel].pitchEvents;
+    return events.empty() ? 0.0f : events.back().value;
+}
+
+void sfz::MidiState::setMPEPitchBendRange(float masterSemitones, float perNoteSemitones) noexcept
+{
+    mpeMasterPitchBendRange_ = masterSemitones;
+    mpePerNotePitchBendRange_ = perNoteSemitones;
+}
+
+float sfz::MidiState::getMPEBendRangeForChannel(int channel) const noexcept
+{
+    return (channel == masterChannel) ? mpeMasterPitchBendRange_ : mpePerNotePitchBendRange_;
+}
+
 void sfz::MidiState::resetEventStates() noexcept
 {
     auto clearEvents = [] (EventVector& events) {

--- a/src/sfizz/MidiState.cpp
+++ b/src/sfizz/MidiState.cpp
@@ -94,14 +94,17 @@ void sfz::MidiState::flushEvents() noexcept
         events.resize(1);
     };
 
-    for (auto& events : ccEvents)
+    // M1: only master channel is populated; M3 will iterate over all
+    // channels that received events this block.
+    auto& cs = channelStates[masterChannel];
+    for (auto& events : cs.ccEvents)
         flushEventVector(events);
 
-    for (auto& events: polyAftertouchEvents)
+    for (auto& events: cs.polyAftertouchEvents)
         flushEventVector(events);
 
-    flushEventVector(pitchEvents);
-    flushEventVector(channelAftertouchEvents);
+    flushEventVector(cs.pitchEvents);
+    flushEventVector(cs.channelAftertouchEvents);
 }
 
 
@@ -112,14 +115,17 @@ void sfz::MidiState::setSamplesPerBlock(int samplesPerBlock) noexcept
         events.reserve(samplesPerBlock);
     };
     this->samplesPerBlock = samplesPerBlock;
-    for (auto& events: ccEvents)
+    // M1: only master channel reserves buffer space; M3 will reserve
+    // for any active member channel as well.
+    auto& cs = channelStates[masterChannel];
+    for (auto& events: cs.ccEvents)
         updateEventBufferSize(events);
 
-    for (auto& events: polyAftertouchEvents)
+    for (auto& events: cs.polyAftertouchEvents)
         updateEventBufferSize(events);
 
-    updateEventBufferSize(pitchEvents);
-    updateEventBufferSize(channelAftertouchEvents);
+    updateEventBufferSize(cs.pitchEvents);
+    updateEventBufferSize(cs.channelAftertouchEvents);
 }
 
 float sfz::MidiState::getNoteDuration(int noteNumber, int delay) const
@@ -161,34 +167,37 @@ void sfz::MidiState::insertEventInVector(EventVector& events, int delay, float v
 void sfz::MidiState::pitchBendEvent(int delay, float pitchBendValue) noexcept
 {
     ASSERT(pitchBendValue >= -1.0f && pitchBendValue <= 1.0f);
-    insertEventInVector(pitchEvents, delay, pitchBendValue);
+    insertEventInVector(channelStates[masterChannel].pitchEvents, delay, pitchBendValue);
 }
 
 float sfz::MidiState::getPitchBend() const noexcept
 {
-    ASSERT(pitchEvents.size() > 0);
-    return pitchEvents.back().value;
+    const auto& events = channelStates[masterChannel].pitchEvents;
+    ASSERT(events.size() > 0);
+    return events.back().value;
 }
 
 void sfz::MidiState::channelAftertouchEvent(int delay, float aftertouch) noexcept
 {
     ASSERT(aftertouch >= -1.0f && aftertouch <= 1.0f);
-    insertEventInVector(channelAftertouchEvents, delay, aftertouch);
+    insertEventInVector(channelStates[masterChannel].channelAftertouchEvents, delay, aftertouch);
 }
 
 void sfz::MidiState::polyAftertouchEvent(int delay, int noteNumber, float aftertouch) noexcept
 {
     ASSERT(aftertouch >= 0.0f && aftertouch <= 1.0f);
-    if (noteNumber < 0 || noteNumber >= static_cast<int>(polyAftertouchEvents.size()))
+    auto& events = channelStates[masterChannel].polyAftertouchEvents;
+    if (noteNumber < 0 || noteNumber >= static_cast<int>(events.size()))
         return;
 
-    insertEventInVector(polyAftertouchEvents[noteNumber], delay, aftertouch);
+    insertEventInVector(events[noteNumber], delay, aftertouch);
 }
 
 float sfz::MidiState::getChannelAftertouch() const noexcept
 {
-    ASSERT(channelAftertouchEvents.size() > 0);
-    return channelAftertouchEvents.back().value;
+    const auto& events = channelStates[masterChannel].channelAftertouchEvents;
+    ASSERT(events.size() > 0);
+    return events.back().value;
 }
 
 float sfz::MidiState::getPolyAftertouch(int noteNumber) const noexcept
@@ -196,30 +205,32 @@ float sfz::MidiState::getPolyAftertouch(int noteNumber) const noexcept
     if (noteNumber < 0 || noteNumber > 127)
         return 0.0f;
 
-    ASSERT(polyAftertouchEvents[noteNumber].size() > 0);
-    return polyAftertouchEvents[noteNumber].back().value;
+    const auto& events = channelStates[masterChannel].polyAftertouchEvents[noteNumber];
+    ASSERT(events.size() > 0);
+    return events.back().value;
 }
 
 void sfz::MidiState::ccEvent(int delay, int ccNumber, float ccValue) noexcept
 {
-    insertEventInVector(ccEvents[ccNumber], delay, ccValue);
+    insertEventInVector(channelStates[masterChannel].ccEvents[ccNumber], delay, ccValue);
 }
 
 float sfz::MidiState::getCCValue(int ccNumber) const noexcept
 {
     ASSERT(ccNumber >= 0 && ccNumber < config::numCCs);
-    return ccEvents[ccNumber].back().value;
+    return channelStates[masterChannel].ccEvents[ccNumber].back().value;
 }
 
 float sfz::MidiState::getCCValueAt(int ccNumber, int delay) const noexcept
 {
     ASSERT(ccNumber >= 0 && ccNumber < config::numCCs);
+    const auto& events = channelStates[masterChannel].ccEvents[ccNumber];
     const auto ccEvent = absl::c_lower_bound(
-        ccEvents[ccNumber], delay, MidiEventDelayComparator {});
-    if (ccEvent != ccEvents[ccNumber].end())
+        events, delay, MidiEventDelayComparator {});
+    if (ccEvent != events.end())
         return ccEvent->value;
     else
-        return ccEvents[ccNumber].back().value;
+        return events.back().value;
 }
 
 void sfz::MidiState::resetNoteStates() noexcept
@@ -238,12 +249,13 @@ void sfz::MidiState::resetNoteStates() noexcept
         events.push_back({ 0, value });
     };
 
-    setEvents(ccEvents[ExtendedCCs::noteOnVelocity], 0.0f);
-    setEvents(ccEvents[ExtendedCCs::keyboardNoteNumber], 0.0f);
-    setEvents(ccEvents[ExtendedCCs::unipolarRandom], 0.0f);
-    setEvents(ccEvents[ExtendedCCs::bipolarRandom], 0.0f);
-    setEvents(ccEvents[ExtendedCCs::keyboardNoteGate], 0.0f);
-    setEvents(ccEvents[ExtendedCCs::alternate], 0.0f);
+    auto& cs = channelStates[masterChannel];
+    setEvents(cs.ccEvents[ExtendedCCs::noteOnVelocity], 0.0f);
+    setEvents(cs.ccEvents[ExtendedCCs::keyboardNoteNumber], 0.0f);
+    setEvents(cs.ccEvents[ExtendedCCs::unipolarRandom], 0.0f);
+    setEvents(cs.ccEvents[ExtendedCCs::bipolarRandom], 0.0f);
+    setEvents(cs.ccEvents[ExtendedCCs::keyboardNoteGate], 0.0f);
+    setEvents(cs.ccEvents[ExtendedCCs::alternate], 0.0f);
 
     noteStates.reset();
     absl::c_fill(noteOnTimes, 0);
@@ -257,14 +269,17 @@ void sfz::MidiState::resetEventStates() noexcept
         events.push_back({ 0, 0.0f });
     };
 
-    for (auto& events : ccEvents)
+    // M1: only master channel needs initialised event vectors. M3 will
+    // initialise additional channels lazily on first write.
+    auto& cs = channelStates[masterChannel];
+    for (auto& events : cs.ccEvents)
         clearEvents(events);
 
-   for (auto& events : polyAftertouchEvents)
+    for (auto& events : cs.polyAftertouchEvents)
         clearEvents(events);
 
-    clearEvents(pitchEvents);
-    clearEvents(channelAftertouchEvents);
+    clearEvents(cs.pitchEvents);
+    clearEvents(cs.channelAftertouchEvents);
 }
 
 const sfz::EventVector& sfz::MidiState::getCCEvents(int ccIdx) const noexcept
@@ -272,17 +287,17 @@ const sfz::EventVector& sfz::MidiState::getCCEvents(int ccIdx) const noexcept
     if (ccIdx < 0 || ccIdx >= config::numCCs)
         return nullEvent;
 
-    return ccEvents[ccIdx];
+    return channelStates[masterChannel].ccEvents[ccIdx];
 }
 
 const sfz::EventVector& sfz::MidiState::getPitchEvents() const noexcept
 {
-    return pitchEvents;
+    return channelStates[masterChannel].pitchEvents;
 }
 
 const sfz::EventVector& sfz::MidiState::getChannelAftertouchEvents() const noexcept
 {
-    return channelAftertouchEvents;
+    return channelStates[masterChannel].channelAftertouchEvents;
 }
 
 const sfz::EventVector& sfz::MidiState::getPolyAftertouchEvents(int noteNumber) const noexcept
@@ -290,7 +305,7 @@ const sfz::EventVector& sfz::MidiState::getPolyAftertouchEvents(int noteNumber) 
     if (noteNumber < 0 || noteNumber > 127)
         return nullEvent;
 
-    return polyAftertouchEvents[noteNumber];
+    return channelStates[masterChannel].polyAftertouchEvents[noteNumber];
 }
 
 int sfz::MidiState::getProgram() const noexcept

--- a/src/sfizz/MidiState.cpp
+++ b/src/sfizz/MidiState.cpp
@@ -172,8 +172,16 @@ void sfz::MidiState::pitchBendEvent(int delay, float pitchBendValue) noexcept
 
 float sfz::MidiState::getPitchBend() const noexcept
 {
-    const auto& events = channelStates[masterChannel].pitchEvents;
-    ASSERT(events.size() > 0);
+    return getPitchBend(masterChannel);
+}
+
+float sfz::MidiState::getPitchBend(int channel) const noexcept
+{
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return 0.0f;
+    const auto& events = channelStates[channel].pitchEvents;
+    if (events.empty())
+        return 0.0f;
     return events.back().value;
 }
 
@@ -195,18 +203,34 @@ void sfz::MidiState::polyAftertouchEvent(int delay, int noteNumber, float aftert
 
 float sfz::MidiState::getChannelAftertouch() const noexcept
 {
-    const auto& events = channelStates[masterChannel].channelAftertouchEvents;
-    ASSERT(events.size() > 0);
+    return getChannelAftertouch(masterChannel);
+}
+
+float sfz::MidiState::getChannelAftertouch(int channel) const noexcept
+{
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return 0.0f;
+    const auto& events = channelStates[channel].channelAftertouchEvents;
+    if (events.empty())
+        return 0.0f;
     return events.back().value;
 }
 
 float sfz::MidiState::getPolyAftertouch(int noteNumber) const noexcept
 {
+    return getPolyAftertouch(masterChannel, noteNumber);
+}
+
+float sfz::MidiState::getPolyAftertouch(int channel, int noteNumber) const noexcept
+{
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return 0.0f;
     if (noteNumber < 0 || noteNumber > 127)
         return 0.0f;
 
-    const auto& events = channelStates[masterChannel].polyAftertouchEvents[noteNumber];
-    ASSERT(events.size() > 0);
+    const auto& events = channelStates[channel].polyAftertouchEvents[noteNumber];
+    if (events.empty())
+        return 0.0f;
     return events.back().value;
 }
 
@@ -217,14 +241,33 @@ void sfz::MidiState::ccEvent(int delay, int ccNumber, float ccValue) noexcept
 
 float sfz::MidiState::getCCValue(int ccNumber) const noexcept
 {
+    return getCCValue(masterChannel, ccNumber);
+}
+
+float sfz::MidiState::getCCValue(int channel, int ccNumber) const noexcept
+{
     ASSERT(ccNumber >= 0 && ccNumber < config::numCCs);
-    return channelStates[masterChannel].ccEvents[ccNumber].back().value;
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return 0.0f;
+    const auto& events = channelStates[channel].ccEvents[ccNumber];
+    if (events.empty())
+        return 0.0f;
+    return events.back().value;
 }
 
 float sfz::MidiState::getCCValueAt(int ccNumber, int delay) const noexcept
 {
+    return getCCValueAt(masterChannel, ccNumber, delay);
+}
+
+float sfz::MidiState::getCCValueAt(int channel, int ccNumber, int delay) const noexcept
+{
     ASSERT(ccNumber >= 0 && ccNumber < config::numCCs);
-    const auto& events = channelStates[masterChannel].ccEvents[ccNumber];
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return 0.0f;
+    const auto& events = channelStates[channel].ccEvents[ccNumber];
+    if (events.empty())
+        return 0.0f;
     const auto ccEvent = absl::c_lower_bound(
         events, delay, MidiEventDelayComparator {});
     if (ccEvent != events.end())
@@ -284,28 +327,58 @@ void sfz::MidiState::resetEventStates() noexcept
 
 const sfz::EventVector& sfz::MidiState::getCCEvents(int ccIdx) const noexcept
 {
+    return getCCEvents(masterChannel, ccIdx);
+}
+
+const sfz::EventVector& sfz::MidiState::getCCEvents(int channel, int ccIdx) const noexcept
+{
     if (ccIdx < 0 || ccIdx >= config::numCCs)
         return nullEvent;
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return nullEvent;
 
-    return channelStates[masterChannel].ccEvents[ccIdx];
+    return channelStates[channel].ccEvents[ccIdx];
 }
 
 const sfz::EventVector& sfz::MidiState::getPitchEvents() const noexcept
 {
-    return channelStates[masterChannel].pitchEvents;
+    return getPitchEvents(masterChannel);
+}
+
+const sfz::EventVector& sfz::MidiState::getPitchEvents(int channel) const noexcept
+{
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return nullEvent;
+
+    return channelStates[channel].pitchEvents;
 }
 
 const sfz::EventVector& sfz::MidiState::getChannelAftertouchEvents() const noexcept
 {
-    return channelStates[masterChannel].channelAftertouchEvents;
+    return getChannelAftertouchEvents(masterChannel);
+}
+
+const sfz::EventVector& sfz::MidiState::getChannelAftertouchEvents(int channel) const noexcept
+{
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return nullEvent;
+
+    return channelStates[channel].channelAftertouchEvents;
 }
 
 const sfz::EventVector& sfz::MidiState::getPolyAftertouchEvents(int noteNumber) const noexcept
 {
+    return getPolyAftertouchEvents(masterChannel, noteNumber);
+}
+
+const sfz::EventVector& sfz::MidiState::getPolyAftertouchEvents(int channel, int noteNumber) const noexcept
+{
     if (noteNumber < 0 || noteNumber > 127)
         return nullEvent;
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return nullEvent;
 
-    return channelStates[masterChannel].polyAftertouchEvents[noteNumber];
+    return channelStates[channel].polyAftertouchEvents[noteNumber];
 }
 
 int sfz::MidiState::getProgram() const noexcept

--- a/src/sfizz/MidiState.cpp
+++ b/src/sfizz/MidiState.cpp
@@ -88,23 +88,27 @@ void sfz::MidiState::advanceTime(int numSamples) noexcept
 void sfz::MidiState::flushEvents() noexcept
 {
     auto flushEventVector = [] (EventVector& events) {
-        ASSERT(!events.empty()); // CC event vectors should never be empty
+        if (events.empty())
+            return;
         events.front().value = events.back().value;
         events.front().delay = 0;
         events.resize(1);
     };
 
-    // M1: only master channel is populated; M3 will iterate over all
-    // channels that received events this block.
-    auto& cs = channelStates[masterChannel];
-    for (auto& events : cs.ccEvents)
-        flushEventVector(events);
+    // Master always carries its initialised sentinel event vectors, so its
+    // flush is unconditional. Member channels are populated lazily on
+    // first write, so most of their event vectors stay empty under
+    // non-MPE input — flushEventVector skips empties cheaply.
+    for (auto& cs : channelStates) {
+        for (auto& events : cs.ccEvents)
+            flushEventVector(events);
 
-    for (auto& events: cs.polyAftertouchEvents)
-        flushEventVector(events);
+        for (auto& events : cs.polyAftertouchEvents)
+            flushEventVector(events);
 
-    flushEventVector(cs.pitchEvents);
-    flushEventVector(cs.channelAftertouchEvents);
+        flushEventVector(cs.pitchEvents);
+        flushEventVector(cs.channelAftertouchEvents);
+    }
 }
 
 
@@ -366,8 +370,10 @@ const sfz::EventVector& sfz::MidiState::getCCEvents(int channel, int ccIdx) cons
         return nullEvent;
     if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
         return nullEvent;
-
-    return channelStates[channel].ccEvents[ccIdx];
+    const auto& events = channelStates[channel].ccEvents[ccIdx];
+    if (events.empty())
+        return nullEvent;
+    return events;
 }
 
 const sfz::EventVector& sfz::MidiState::getPitchEvents() const noexcept
@@ -379,8 +385,10 @@ const sfz::EventVector& sfz::MidiState::getPitchEvents(int channel) const noexce
 {
     if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
         return nullEvent;
-
-    return channelStates[channel].pitchEvents;
+    const auto& events = channelStates[channel].pitchEvents;
+    if (events.empty())
+        return nullEvent;
+    return events;
 }
 
 const sfz::EventVector& sfz::MidiState::getChannelAftertouchEvents() const noexcept
@@ -392,8 +400,10 @@ const sfz::EventVector& sfz::MidiState::getChannelAftertouchEvents(int channel) 
 {
     if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
         return nullEvent;
-
-    return channelStates[channel].channelAftertouchEvents;
+    const auto& events = channelStates[channel].channelAftertouchEvents;
+    if (events.empty())
+        return nullEvent;
+    return events;
 }
 
 const sfz::EventVector& sfz::MidiState::getPolyAftertouchEvents(int noteNumber) const noexcept
@@ -407,8 +417,10 @@ const sfz::EventVector& sfz::MidiState::getPolyAftertouchEvents(int channel, int
         return nullEvent;
     if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
         return nullEvent;
-
-    return channelStates[channel].polyAftertouchEvents[noteNumber];
+    const auto& events = channelStates[channel].polyAftertouchEvents[noteNumber];
+    if (events.empty())
+        return nullEvent;
+    return events;
 }
 
 int sfz::MidiState::getProgram() const noexcept

--- a/src/sfizz/MidiState.cpp
+++ b/src/sfizz/MidiState.cpp
@@ -166,8 +166,15 @@ void sfz::MidiState::insertEventInVector(EventVector& events, int delay, float v
 
 void sfz::MidiState::pitchBendEvent(int delay, float pitchBendValue) noexcept
 {
+    pitchBendEvent(delay, masterChannel, pitchBendValue);
+}
+
+void sfz::MidiState::pitchBendEvent(int delay, int channel, float pitchBendValue) noexcept
+{
     ASSERT(pitchBendValue >= -1.0f && pitchBendValue <= 1.0f);
-    insertEventInVector(channelStates[masterChannel].pitchEvents, delay, pitchBendValue);
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return;
+    insertEventInVector(channelStates[channel].pitchEvents, delay, pitchBendValue);
 }
 
 float sfz::MidiState::getPitchBend() const noexcept
@@ -187,14 +194,28 @@ float sfz::MidiState::getPitchBend(int channel) const noexcept
 
 void sfz::MidiState::channelAftertouchEvent(int delay, float aftertouch) noexcept
 {
+    channelAftertouchEvent(delay, masterChannel, aftertouch);
+}
+
+void sfz::MidiState::channelAftertouchEvent(int delay, int channel, float aftertouch) noexcept
+{
     ASSERT(aftertouch >= -1.0f && aftertouch <= 1.0f);
-    insertEventInVector(channelStates[masterChannel].channelAftertouchEvents, delay, aftertouch);
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return;
+    insertEventInVector(channelStates[channel].channelAftertouchEvents, delay, aftertouch);
 }
 
 void sfz::MidiState::polyAftertouchEvent(int delay, int noteNumber, float aftertouch) noexcept
 {
+    polyAftertouchEvent(delay, masterChannel, noteNumber, aftertouch);
+}
+
+void sfz::MidiState::polyAftertouchEvent(int delay, int channel, int noteNumber, float aftertouch) noexcept
+{
     ASSERT(aftertouch >= 0.0f && aftertouch <= 1.0f);
-    auto& events = channelStates[masterChannel].polyAftertouchEvents;
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return;
+    auto& events = channelStates[channel].polyAftertouchEvents;
     if (noteNumber < 0 || noteNumber >= static_cast<int>(events.size()))
         return;
 
@@ -236,7 +257,16 @@ float sfz::MidiState::getPolyAftertouch(int channel, int noteNumber) const noexc
 
 void sfz::MidiState::ccEvent(int delay, int ccNumber, float ccValue) noexcept
 {
-    insertEventInVector(channelStates[masterChannel].ccEvents[ccNumber], delay, ccValue);
+    ccEvent(delay, masterChannel, ccNumber, ccValue);
+}
+
+void sfz::MidiState::ccEvent(int delay, int channel, int ccNumber, float ccValue) noexcept
+{
+    if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
+        return;
+    if (ccNumber < 0 || ccNumber >= config::numCCs)
+        return;
+    insertEventInVector(channelStates[channel].ccEvents[ccNumber], delay, ccValue);
 }
 
 float sfz::MidiState::getCCValue(int ccNumber) const noexcept

--- a/src/sfizz/MidiState.cpp
+++ b/src/sfizz/MidiState.cpp
@@ -161,6 +161,15 @@ float sfz::MidiState::getVelocityOverride() const noexcept
 
 void sfz::MidiState::insertEventInVector(EventVector& events, int delay, float value)
 {
+    // Member channels are populated lazily — their vectors start empty and
+    // only grow on first write. linearEnvelope downstream ASSERTs the
+    // vector starts at delay 0, so seed the centre-value sentinel before
+    // inserting if this is the first ever event on this channel/CC slot.
+    // Master channels are pre-seeded at construction so this is a no-op
+    // for them.
+    if (events.empty())
+        events.push_back({ 0, 0.0f });
+
     const auto insertionPoint = absl::c_lower_bound(events, delay, MidiEventDelayComparator {});
     if (insertionPoint == events.end() || insertionPoint->delay != delay)
         events.insert(insertionPoint, { delay, value });
@@ -371,8 +380,15 @@ const sfz::EventVector& sfz::MidiState::getCCEvents(int channel, int ccIdx) cons
     if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
         return nullEvent;
     const auto& events = channelStates[channel].ccEvents[ccIdx];
-    if (events.empty())
+    if (events.empty()) {
+        // MPE 1.0 inheritance: a member channel that has never received its
+        // own CC value reads the master channel's value. Without this the
+        // engine's defaults (CC7=Volume@~0.79, CC10=Pan@0.5, CC11=Expression
+        // @1.0) collapse to 0 on member channels and voices play near-silent.
+        if (channel != masterChannel)
+            return channelStates[masterChannel].ccEvents[ccIdx];
         return nullEvent;
+    }
     return events;
 }
 
@@ -386,8 +402,11 @@ const sfz::EventVector& sfz::MidiState::getPitchEvents(int channel) const noexce
     if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
         return nullEvent;
     const auto& events = channelStates[channel].pitchEvents;
-    if (events.empty())
+    if (events.empty()) {
+        if (channel != masterChannel)
+            return channelStates[masterChannel].pitchEvents;
         return nullEvent;
+    }
     return events;
 }
 
@@ -401,8 +420,11 @@ const sfz::EventVector& sfz::MidiState::getChannelAftertouchEvents(int channel) 
     if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
         return nullEvent;
     const auto& events = channelStates[channel].channelAftertouchEvents;
-    if (events.empty())
+    if (events.empty()) {
+        if (channel != masterChannel)
+            return channelStates[masterChannel].channelAftertouchEvents;
         return nullEvent;
+    }
     return events;
 }
 
@@ -418,8 +440,11 @@ const sfz::EventVector& sfz::MidiState::getPolyAftertouchEvents(int channel, int
     if (channel < 0 || channel >= static_cast<int>(channelStates.size()))
         return nullEvent;
     const auto& events = channelStates[channel].polyAftertouchEvents[noteNumber];
-    if (events.empty())
+    if (events.empty()) {
+        if (channel != masterChannel)
+            return channelStates[masterChannel].polyAftertouchEvents[noteNumber];
         return nullEvent;
+    }
     return events;
 }
 

--- a/src/sfizz/MidiState.h
+++ b/src/sfizz/MidiState.h
@@ -273,6 +273,21 @@ public:
     const EventVector& getPolyAftertouchEvents(int channel, int noteNumber) const noexcept;
     const EventVector& getPitchEvents() const noexcept;
     const EventVector& getPitchEvents(int channel) const noexcept;
+    /**
+     * @brief Return the pitch-bend events for the given channel, with no
+     *        master fallback. The vector may be empty if that channel has
+     *        never received its own bend events. Use this when combining
+     *        member and master bend contributions separately for MPE.
+     */
+    const EventVector& getPitchEventsRaw(int channel) const noexcept;
+
+    /**
+     * @brief Return the latest pitch bend value for the given channel, with
+     *        no master fallback. Returns 0 if the channel has never received
+     *        its own bend. Pair with getMPEBendRangeForChannel to compute a
+     *        per-channel bend contribution.
+     */
+    float getPitchBendRaw(int channel) const noexcept;
     const EventVector& getChannelAftertouchEvents() const noexcept;
     const EventVector& getChannelAftertouchEvents(int channel) const noexcept;
     /**
@@ -280,6 +295,23 @@ public:
      *
      */
     void resetEventStates() noexcept;
+
+    /**
+     * @brief Configure the MPE pitch bend ranges used when computing the
+     *        bend amount applied to a voice. Master and member channels
+     *        carry independent ranges per MPE 1.0; SFZ regions only have
+     *        a single bend_up / bend_down pair, so member channels can't
+     *        rely on the region opcodes and need this synth-level setting.
+     */
+    void setMPEPitchBendRange(float masterSemitones, float perNoteSemitones) noexcept;
+
+    /**
+     * @brief Return the bend range (in semitones) the given channel should
+     *        use to scale a normalized [-1, +1] pitch bend value. Master
+     *        channel returns the master range, member channels return the
+     *        per-note range.
+     */
+    float getMPEBendRangeForChannel(int channel) const noexcept;
 
 private:
 
@@ -355,6 +387,10 @@ private:
      */
     static constexpr int masterChannel = 0;
     std::array<ChannelState, 16> channelStates;
+
+    // MPE 1.0 defaults: master = 2 st, per-note = 48 st.
+    float mpeMasterPitchBendRange_ { 2.0f };
+    float mpePerNotePitchBendRange_ { 48.0f };
 
     /**
      * @brief Null event

--- a/src/sfizz/MidiState.h
+++ b/src/sfizz/MidiState.h
@@ -100,6 +100,13 @@ public:
     void pitchBendEvent(int delay, float pitchBendValue) noexcept;
 
     /**
+     * @brief Register a pitch bend event on a specific MIDI channel.
+     * Out-of-range channels are silently ignored. The single-arg
+     * overload forwards to this with channel = masterChannel.
+     */
+    void pitchBendEvent(int delay, int channel, float pitchBendValue) noexcept;
+
+    /**
      * @brief Get the pitch bend status
 
      * @return int
@@ -123,11 +130,23 @@ public:
     void channelAftertouchEvent(int delay, float aftertouch) noexcept;
 
     /**
+     * @brief Register a channel aftertouch event on a specific MIDI
+     * channel. Out-of-range channels are silently ignored.
+     */
+    void channelAftertouchEvent(int delay, int channel, float aftertouch) noexcept;
+
+    /**
      * @brief Register a channel aftertouch event
      *
      * @param aftertouch
      */
     void polyAftertouchEvent(int delay, int noteNumber, float aftertouch) noexcept;
+
+    /**
+     * @brief Register a polyphonic aftertouch event on a specific MIDI
+     * channel. Out-of-range channels or notes are silently ignored.
+     */
+    void polyAftertouchEvent(int delay, int channel, int noteNumber, float aftertouch) noexcept;
 
     /**
      * @brief Get the channel aftertouch status
@@ -176,6 +195,12 @@ public:
      * @param ccValue
      */
     void ccEvent(int delay, int ccNumber, float ccValue) noexcept;
+
+    /**
+     * @brief Register a CC event on a specific MIDI channel.
+     * Out-of-range channels are silently ignored.
+     */
+    void ccEvent(int delay, int channel, int ccNumber, float ccValue) noexcept;
 
     /**
      * @brief Advances the internal clock of a given amount of samples.

--- a/src/sfizz/MidiState.h
+++ b/src/sfizz/MidiState.h
@@ -107,6 +107,15 @@ public:
     float getPitchBend() const noexcept;
 
     /**
+     * @brief Get the pitch bend status for a specific MIDI channel.
+     * Out-of-range channels return 0.0f. Used by per-voice consumers
+     * (Voice etc.) to read modulation events scoped to the voice's
+     * originating channel; master-channel reads via the no-arg overload
+     * are unchanged.
+     */
+    float getPitchBend(int channel) const noexcept;
+
+    /**
      * @brief Register a channel aftertouch event
      *
      * @param aftertouch
@@ -128,11 +137,23 @@ public:
     float getChannelAftertouch() const noexcept;
 
     /**
+     * @brief Get the channel aftertouch status for a specific MIDI
+     * channel. Out-of-range channels return 0.0f.
+     */
+    float getChannelAftertouch(int channel) const noexcept;
+
+    /**
      * @brief Get the polyphonic aftertouch status
 
      * @return int
      */
     float getPolyAftertouch(int noteNumber) const noexcept;
+
+    /**
+     * @brief Get the polyphonic aftertouch status for a specific MIDI
+     * channel and note. Out-of-range channels or notes return 0.0f.
+     */
+    float getPolyAftertouch(int channel, int noteNumber) const noexcept;
 
     /**
      * @brief Get the current midi program
@@ -195,6 +216,12 @@ public:
     float getCCValue(int ccNumber) const noexcept;
 
     /**
+     * @brief Get the last CC value for CC number on a specific MIDI
+     * channel. Out-of-range channels return 0.0f.
+     */
+    float getCCValue(int channel, int ccNumber) const noexcept;
+
+    /**
      * @brief Get the CC value for CC number
      *
      * @param ccNumber
@@ -204,15 +231,25 @@ public:
     float getCCValueAt(int ccNumber, int delay) const noexcept;
 
     /**
+     * @brief Get the CC value for CC number on a specific MIDI channel
+     * at a given delay. Out-of-range channels return 0.0f.
+     */
+    float getCCValueAt(int channel, int ccNumber, int delay) const noexcept;
+
+    /**
      * @brief Reset the midi note states
      *
      */
     void resetNoteStates() noexcept;
 
     const EventVector& getCCEvents(int ccIdx) const noexcept;
+    const EventVector& getCCEvents(int channel, int ccIdx) const noexcept;
     const EventVector& getPolyAftertouchEvents(int noteNumber) const noexcept;
+    const EventVector& getPolyAftertouchEvents(int channel, int noteNumber) const noexcept;
     const EventVector& getPitchEvents() const noexcept;
+    const EventVector& getPitchEvents(int channel) const noexcept;
     const EventVector& getChannelAftertouchEvents() const noexcept;
+    const EventVector& getChannelAftertouchEvents(int channel) const noexcept;
     /**
      * @brief Reset the midi event states (CC, AT, and pitch bend)
      *

--- a/src/sfizz/MidiState.h
+++ b/src/sfizz/MidiState.h
@@ -269,31 +269,36 @@ private:
     int lastNotePlayed { -1 };
 
     /**
-     * @brief Current known values for the CCs.
-     *
+     * @brief Per-channel event state. Holds the pitch/CC/aftertouch event
+     * vectors for one MIDI channel. Introduced so MPE-aware callers can
+     * route events to a specific member channel without colliding with
+     * other channels' modulation. M1 wires only the master channel; M3
+     * will add channel-aware public API methods that target channels
+     * 1..15. Until then, all events resolve to channelStates[masterChannel]
+     * and behavior is byte-for-byte identical to the pre-refactor code.
      */
-    std::array<EventVector, config::numCCs> ccEvents;
+    struct ChannelState {
+        std::array<EventVector, config::numCCs> ccEvents;
+        std::array<EventVector, 128> polyAftertouchEvents;
+        EventVector pitchEvents;
+        EventVector channelAftertouchEvents;
+    };
+
+    /**
+     * @brief Per-channel pitch/CC/aftertouch state. Indexed 0..15 to match
+     * MIDI channels 1..16 (0-indexed). The master channel for non-MPE
+     * input is index 0; MPE member channels occupy 1..15 (or 0..14 with
+     * channel 16 as master, depending on zone configuration — currently
+     * fixed at master=0 pending M3).
+     */
+    static constexpr int masterChannel = 0;
+    std::array<ChannelState, 16> channelStates;
 
     /**
      * @brief Null event
      *
      */
     const EventVector nullEvent { { 0, 0.0f } };
-
-    /**
-     * @brief Pitch bend status
-     */
-    EventVector pitchEvents;
-
-    /**
-     * @brief Aftertouch status
-     */
-    EventVector channelAftertouchEvents;
-
-    /**
-     * @brief Polyphonic aftertouch status.
-     */
-    std::array<EventVector, 128> polyAftertouchEvents;
 
     /**
      * @brief Current midi program

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1688,6 +1688,9 @@ void Synth::setMPEPitchBendRange(float masterSemitones, float perNoteSemitones) 
 {
     impl_->mpeMasterPitchBendRange_ = masterSemitones;
     impl_->mpePerNotePitchBendRange_ = perNoteSemitones;
+    // Mirror into MidiState so per-voice bend application can pick up the
+    // configured range without reaching back into Synth::Impl.
+    impl_->resources_.getMidiState().setMPEPitchBendRange(masterSemitones, perNoteSemitones);
 }
 
 float Synth::getMPEMasterPitchBendRange() const noexcept

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1257,6 +1257,17 @@ void Synth::noteOn(int delay, int noteNumber, int velocity) noexcept
 
 void Synth::hdNoteOn(int delay, int noteNumber, float normalizedVelocity) noexcept
 {
+    hdNoteOnMPE(delay, 0, noteNumber, normalizedVelocity);
+}
+
+void Synth::noteOnMPE(int delay, int channel, int noteNumber, int velocity) noexcept
+{
+    const float normalizedVelocity = normalizeVelocity(velocity);
+    hdNoteOnMPE(delay, channel, noteNumber, normalizedVelocity);
+}
+
+void Synth::hdNoteOnMPE(int delay, int channel, int noteNumber, float normalizedVelocity) noexcept
+{
     ASSERT(noteNumber < 128);
     ASSERT(noteNumber >= 0);
     Impl& impl = *impl_;
@@ -1265,7 +1276,7 @@ void Synth::hdNoteOn(int delay, int noteNumber, float normalizedVelocity) noexce
     if (impl.lastKeyswitchLists_[noteNumber].empty())
         impl.resources_.getMidiState().noteOnEvent(delay, noteNumber, normalizedVelocity);
 
-    impl.noteOnDispatch(delay, noteNumber, normalizedVelocity);
+    impl.noteOnDispatch(delay, channel, noteNumber, normalizedVelocity);
 }
 
 void Synth::noteOff(int delay, int noteNumber, int velocity) noexcept
@@ -1275,6 +1286,17 @@ void Synth::noteOff(int delay, int noteNumber, int velocity) noexcept
 }
 
 void Synth::hdNoteOff(int delay, int noteNumber, float normalizedVelocity) noexcept
+{
+    hdNoteOffMPE(delay, 0, noteNumber, normalizedVelocity);
+}
+
+void Synth::noteOffMPE(int delay, int channel, int noteNumber, int velocity) noexcept
+{
+    const float normalizedVelocity = normalizeVelocity(velocity);
+    hdNoteOffMPE(delay, channel, noteNumber, normalizedVelocity);
+}
+
+void Synth::hdNoteOffMPE(int delay, int channel, int noteNumber, float normalizedVelocity) noexcept
 {
     ASSERT(noteNumber < 128);
     ASSERT(noteNumber >= 0);
@@ -1294,7 +1316,7 @@ void Synth::hdNoteOff(int delay, int noteNumber, float normalizedVelocity) noexc
     for (auto& voice : impl.voiceManager_)
         voice.registerNoteOff(delay, noteNumber, replacedVelocity);
 
-    impl.noteOffDispatch(delay, noteNumber, replacedVelocity);
+    impl.noteOffDispatch(delay, channel, noteNumber, replacedVelocity);
 }
 
 void Synth::Impl::startVoice(Layer* layer, int delay, const TriggerEvent& triggerEvent, SisterVoiceRingBuilder& ring) noexcept
@@ -1317,16 +1339,16 @@ void Synth::Impl::checkOffGroups(const Region* region, int delay, int number, bo
         if (voice.checkOffGroup(region, delay, number)) {
             const TriggerEvent& event = voice.getTriggerEvent();
             if (event.type == TriggerEventType::NoteOn && !chokedByCC)
-                noteOffDispatch(delay, event.number, event.value);
+                noteOffDispatch(delay, event.channel, event.number, event.value);
         }
     }
 }
 
-void Synth::Impl::noteOffDispatch(int delay, int noteNumber, float velocity) noexcept
+void Synth::Impl::noteOffDispatch(int delay, int channel, int noteNumber, float velocity) noexcept
 {
     const auto randValue = randNoteDistribution_(Random::randomGenerator);
     SisterVoiceRingBuilder ring;
-    const TriggerEvent triggerEvent { TriggerEventType::NoteOff, noteNumber, velocity };
+    const TriggerEvent triggerEvent { TriggerEventType::NoteOff, noteNumber, velocity, channel };
 
     for (Layer* layer : upKeyswitchLists_[noteNumber])
         layer->keySwitched_ = true;
@@ -1346,7 +1368,7 @@ void Synth::Impl::noteOffDispatch(int delay, int noteNumber, float velocity) noe
     }
 }
 
-void Synth::Impl::noteOnDispatch(int delay, int noteNumber, float velocity) noexcept
+void Synth::Impl::noteOnDispatch(int delay, int channel, int noteNumber, float velocity) noexcept
 {
     const auto randValue = randNoteDistribution_(Random::randomGenerator);
     SisterVoiceRingBuilder ring;
@@ -1376,7 +1398,7 @@ void Synth::Impl::noteOnDispatch(int delay, int noteNumber, float velocity) noex
                 continue;
 
             checkOffGroups(&region, delay, noteNumber);
-            TriggerEvent triggerEvent { TriggerEventType::NoteOn, noteNumber, velocity };
+            TriggerEvent triggerEvent { TriggerEventType::NoteOn, noteNumber, velocity, channel };
             startVoice(layer, delay, triggerEvent, ring);
         }
     }
@@ -1426,10 +1448,10 @@ void Synth::cc(int delay, int ccNumber, int ccValue) noexcept
     hdcc(delay, ccNumber, normalizedCC);
 }
 
-void Synth::Impl::ccDispatch(int delay, int ccNumber, float value, int extendedArg) noexcept
+void Synth::Impl::ccDispatch(int delay, int channel, int ccNumber, float value, int extendedArg) noexcept
 {
     SisterVoiceRingBuilder ring;
-    TriggerEvent triggerEvent { TriggerEventType::CC, ccNumber, value };
+    TriggerEvent triggerEvent { TriggerEventType::CC, ccNumber, value, channel };
     const auto randValue = randNoteDistribution_(Random::randomGenerator);
     MidiState& midiState = resources_.getMidiState();
     for (Layer* layer : ccActivationLists_[ccNumber]) {
@@ -1461,17 +1483,28 @@ void Synth::Impl::ccDispatch(int delay, int ccNumber, float value, int extendedA
 
 void Synth::hdcc(int delay, int ccNumber, float normValue) noexcept
 {
+    hdccMPE(delay, 0, ccNumber, normValue);
+}
+
+void Synth::ccMPE(int delay, int channel, int ccNumber, int ccValue) noexcept
+{
+    const auto normalizedCC = normalizeCC(ccValue);
+    hdccMPE(delay, channel, ccNumber, normalizedCC);
+}
+
+void Synth::hdccMPE(int delay, int channel, int ccNumber, float normValue) noexcept
+{
     Impl& impl = *impl_;
-    impl.performHdcc(delay, ccNumber, normValue, true);
+    impl.performHdcc(delay, channel, ccNumber, normValue, true);
 }
 
 void Synth::automateHdcc(int delay, int ccNumber, float normValue) noexcept
 {
     Impl& impl = *impl_;
-    impl.performHdcc(delay, ccNumber, normValue, false);
+    impl.performHdcc(delay, 0, ccNumber, normValue, false);
 }
 
-void Synth::Impl::performHdcc(int delay, int ccNumber, float normValue, bool asMidi, int extendedArg) noexcept
+void Synth::Impl::performHdcc(int delay, int channel, int ccNumber, float normValue, bool asMidi, int extendedArg) noexcept
 {
     ASSERT(ccNumber < config::numCCs);
     ASSERT(ccNumber >= 0);
@@ -1499,8 +1532,8 @@ void Synth::Impl::performHdcc(int delay, int ccNumber, float normValue, bool asM
     for (auto& voice : voiceManager_)
         voice.registerCC(delay, ccNumber, normValue);
 
-    ccDispatch(delay, ccNumber, normValue, extendedArg);
-    midiState.ccEvent(delay, ccNumber, normValue);
+    ccDispatch(delay, channel, ccNumber, normValue, extendedArg);
+    midiState.ccEvent(delay, channel, ccNumber, normValue);
 }
 
 void Synth::Impl::setDefaultHdcc(int ccNumber, float value)
@@ -1534,20 +1567,35 @@ void Synth::pitchWheel(int delay, int pitch) noexcept
 
 void Synth::hdPitchWheel(int delay, float normalizedPitch) noexcept
 {
+    hdPitchWheelMPE(delay, 0, normalizedPitch);
+}
+
+void Synth::pitchWheelMPE(int delay, int channel, int pitch) noexcept
+{
+    const float normalizedPitch = normalizeBend(float(pitch));
+    hdPitchWheelMPE(delay, channel, normalizedPitch);
+}
+
+void Synth::hdPitchWheelMPE(int delay, int channel, float normalizedPitch) noexcept
+{
     Impl& impl = *impl_;
 
     ScopedTiming logger { impl.dispatchDuration_, ScopedTiming::Operation::addToDuration };
-    impl.resources_.getMidiState().pitchBendEvent(delay, normalizedPitch);
+    impl.resources_.getMidiState().pitchBendEvent(delay, channel, normalizedPitch);
 
-    for (const Impl::LayerPtr& layer : impl.layers_) {
+    // M3b: layer- and voice-side registration of pitch bend stays
+    // channel-agnostic for now. Voices read the channel-correct value
+    // via per-voice triggerChannel_-aware MidiState reads, so the
+    // master-channel registerPitchWheel call is harmless cross-talk
+    // bookkeeping. A follow-up commit can filter these to voices on
+    // the matching channel when MPE is enabled.
+    for (const Impl::LayerPtr& layer : impl.layers_)
         layer->registerPitchWheel(normalizedPitch);
-    }
 
-    for (auto& voice : impl.voiceManager_) {
+    for (auto& voice : impl.voiceManager_)
         voice.registerPitchWheel(delay, normalizedPitch);
-    }
 
-    impl.performHdcc(delay, ExtendedCCs::pitchBend, normalizedPitch, false);
+    impl.performHdcc(delay, channel, ExtendedCCs::pitchBend, normalizedPitch, false);
 }
 
 void Synth::programChange(int delay, int program) noexcept
@@ -1567,20 +1615,29 @@ void Synth::channelAftertouch(int delay, int aftertouch) noexcept
 
 void Synth::hdChannelAftertouch(int delay, float normAftertouch) noexcept
 {
+    hdChannelAftertouchMPE(delay, 0, normAftertouch);
+}
+
+void Synth::channelAftertouchMPE(int delay, int channel, int aftertouch) noexcept
+{
+    const float normalizedAftertouch = normalize7Bits(aftertouch);
+    hdChannelAftertouchMPE(delay, channel, normalizedAftertouch);
+}
+
+void Synth::hdChannelAftertouchMPE(int delay, int channel, float normAftertouch) noexcept
+{
     Impl& impl = *impl_;
     ScopedTiming logger { impl.dispatchDuration_, ScopedTiming::Operation::addToDuration };
 
-    impl.resources_.getMidiState().channelAftertouchEvent(delay, normAftertouch);
+    impl.resources_.getMidiState().channelAftertouchEvent(delay, channel, normAftertouch);
 
-    for (const Impl::LayerPtr& layerPtr : impl.layers_) {
+    for (const Impl::LayerPtr& layerPtr : impl.layers_)
         layerPtr->registerAftertouch(normAftertouch);
-    }
 
-    for (auto& voice : impl.voiceManager_) {
+    for (auto& voice : impl.voiceManager_)
         voice.registerAftertouch(delay, normAftertouch);
-    }
 
-    impl.performHdcc(delay, ExtendedCCs::channelAftertouch, normAftertouch, false);
+    impl.performHdcc(delay, channel, ExtendedCCs::channelAftertouch, normAftertouch, false);
 }
 
 void Synth::polyAftertouch(int delay, int noteNumber, int aftertouch) noexcept
@@ -1591,15 +1648,52 @@ void Synth::polyAftertouch(int delay, int noteNumber, int aftertouch) noexcept
 
 void Synth::hdPolyAftertouch(int delay, int noteNumber, float normAftertouch) noexcept
 {
+    hdPolyAftertouchMPE(delay, 0, noteNumber, normAftertouch);
+}
+
+void Synth::polyAftertouchMPE(int delay, int channel, int noteNumber, int aftertouch) noexcept
+{
+    const float normalizedAftertouch = normalize7Bits(aftertouch);
+    hdPolyAftertouchMPE(delay, channel, noteNumber, normalizedAftertouch);
+}
+
+void Synth::hdPolyAftertouchMPE(int delay, int channel, int noteNumber, float normAftertouch) noexcept
+{
     Impl& impl = *impl_;
     ScopedTiming logger { impl.dispatchDuration_, ScopedTiming::Operation::addToDuration };
 
-    impl.resources_.getMidiState().polyAftertouchEvent(delay, noteNumber, normAftertouch);
+    impl.resources_.getMidiState().polyAftertouchEvent(delay, channel, noteNumber, normAftertouch);
 
     for (auto& voice : impl.voiceManager_)
         voice.registerPolyAftertouch(delay, noteNumber, normAftertouch);
 
-    impl.performHdcc(delay, ExtendedCCs::polyphonicAftertouch, normAftertouch, false, noteNumber);
+    impl.performHdcc(delay, channel, ExtendedCCs::polyphonicAftertouch, normAftertouch, false, noteNumber);
+}
+
+void Synth::setMPEEnabled(bool enabled) noexcept
+{
+    impl_->mpeEnabled_ = enabled;
+}
+
+bool Synth::getMPEEnabled() const noexcept
+{
+    return impl_->mpeEnabled_;
+}
+
+void Synth::setMPEPitchBendRange(float masterSemitones, float perNoteSemitones) noexcept
+{
+    impl_->mpeMasterPitchBendRange_ = masterSemitones;
+    impl_->mpePerNotePitchBendRange_ = perNoteSemitones;
+}
+
+float Synth::getMPEMasterPitchBendRange() const noexcept
+{
+    return impl_->mpeMasterPitchBendRange_;
+}
+
+float Synth::getMPEPerNotePitchBendRange() const noexcept
+{
+    return impl_->mpePerNotePitchBendRange_;
 }
 
 void Synth::tempo(int delay, float secondsPerBeat) noexcept

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1750,6 +1750,20 @@ void Synth::polyAftertouchMPE(int delay, int channel, int noteNumber, int aftert
 void Synth::hdPolyAftertouchMPE(int delay, int channel, int noteNumber, float normAftertouch) noexcept
 {
     Impl& impl = *impl_;
+
+    // MPE 1.0 §2.2.7 / Appendix E Table 5: Polyphonic Key Pressure is
+    // prohibited on Member Channels (per-note pressure flows through Channel
+    // Pressure under MPE; Poly KP on Member Channels would compound it).
+    // Manager Channel (Lower Zone: channel 0) Poly KP is permitted at the
+    // discretion of the implementer for compatibility with non-MPE-aware
+    // devices. Drop early so dropped events neither update MidiState nor
+    // reach the mod-matrix; the polyphonicAftertouch ExtendedCC path further
+    // down runs only on accepted events.
+    if (impl.mpeEnabled_ && channel != 0) {
+        ++impl.droppedPolyKpOnMember_;
+        return;
+    }
+
     ScopedTiming logger { impl.dispatchDuration_, ScopedTiming::Operation::addToDuration };
 
     impl.resources_.getMidiState().polyAftertouchEvent(delay, channel, noteNumber, normAftertouch);
@@ -1807,6 +1821,11 @@ void Synth::setMPEPerNoteBendAutoConfigEnabled(bool enabled) noexcept
 bool Synth::getMPEPerNoteBendAutoConfigEnabled() const noexcept
 {
     return impl_->mpePerNoteBendAutoConfigEnabled_;
+}
+
+int Synth::getDroppedPolyKpOnMemberCount() const noexcept
+{
+    return impl_->droppedPolyKpOnMember_;
 }
 
 void Synth::tempo(int delay, float secondsPerBeat) noexcept

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1323,7 +1323,11 @@ void Synth::Impl::startVoice(Layer* layer, int delay, const TriggerEvent& trigge
 {
     const Region& region = layer->getRegion();
 
-    voiceManager_.checkPolyphony(&region, delay, triggerEvent);
+    // Bias voice stealing toward same-channel candidates only when MPE is
+    // enabled. With MPE off, preferredChannel = -1 reproduces the
+    // pre-MPE-fork stealing behavior exactly.
+    const int preferredChannel = mpeEnabled_ ? triggerEvent.channel : -1;
+    voiceManager_.checkPolyphony(&region, delay, triggerEvent, preferredChannel);
     Voice* selectedVoice = voiceManager_.findFreeVoice();
     if (selectedVoice == nullptr)
         return;

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1290,16 +1290,16 @@ void Synth::noteOn(int delay, int noteNumber, int velocity) noexcept
 
 void Synth::hdNoteOn(int delay, int noteNumber, float normalizedVelocity) noexcept
 {
-    hdNoteOnMPE(delay, 0, noteNumber, normalizedVelocity);
+    hdNoteOn(delay, 0, noteNumber, normalizedVelocity);
 }
 
-void Synth::noteOnMPE(int delay, int channel, int noteNumber, int velocity) noexcept
+void Synth::noteOn(int delay, int channel, int noteNumber, int velocity) noexcept
 {
     const float normalizedVelocity = normalizeVelocity(velocity);
-    hdNoteOnMPE(delay, channel, noteNumber, normalizedVelocity);
+    hdNoteOn(delay, channel, noteNumber, normalizedVelocity);
 }
 
-void Synth::hdNoteOnMPE(int delay, int channel, int noteNumber, float normalizedVelocity) noexcept
+void Synth::hdNoteOn(int delay, int channel, int noteNumber, float normalizedVelocity) noexcept
 {
     ASSERT(noteNumber < 128);
     ASSERT(noteNumber >= 0);
@@ -1328,16 +1328,16 @@ void Synth::noteOff(int delay, int noteNumber, int velocity) noexcept
 
 void Synth::hdNoteOff(int delay, int noteNumber, float normalizedVelocity) noexcept
 {
-    hdNoteOffMPE(delay, 0, noteNumber, normalizedVelocity);
+    hdNoteOff(delay, 0, noteNumber, normalizedVelocity);
 }
 
-void Synth::noteOffMPE(int delay, int channel, int noteNumber, int velocity) noexcept
+void Synth::noteOff(int delay, int channel, int noteNumber, int velocity) noexcept
 {
     const float normalizedVelocity = normalizeVelocity(velocity);
-    hdNoteOffMPE(delay, channel, noteNumber, normalizedVelocity);
+    hdNoteOff(delay, channel, noteNumber, normalizedVelocity);
 }
 
-void Synth::hdNoteOffMPE(int delay, int channel, int noteNumber, float normalizedVelocity) noexcept
+void Synth::hdNoteOff(int delay, int channel, int noteNumber, float normalizedVelocity) noexcept
 {
     ASSERT(noteNumber < 128);
     ASSERT(noteNumber >= 0);
@@ -1530,16 +1530,16 @@ void Synth::Impl::ccDispatch(int delay, int channel, int ccNumber, float value, 
 
 void Synth::hdcc(int delay, int ccNumber, float normValue) noexcept
 {
-    hdccMPE(delay, 0, ccNumber, normValue);
+    hdcc(delay, 0, ccNumber, normValue);
 }
 
-void Synth::ccMPE(int delay, int channel, int ccNumber, int ccValue) noexcept
+void Synth::cc(int delay, int channel, int ccNumber, int ccValue) noexcept
 {
     const auto normalizedCC = normalizeCC(ccValue);
-    hdccMPE(delay, channel, ccNumber, normalizedCC);
+    hdcc(delay, channel, ccNumber, normalizedCC);
 }
 
-void Synth::hdccMPE(int delay, int channel, int ccNumber, float normValue) noexcept
+void Synth::hdcc(int delay, int channel, int ccNumber, float normValue) noexcept
 {
     Impl& impl = *impl_;
     impl.performHdcc(delay, channel, ccNumber, normValue, true);
@@ -1723,16 +1723,16 @@ void Synth::pitchWheel(int delay, int pitch) noexcept
 
 void Synth::hdPitchWheel(int delay, float normalizedPitch) noexcept
 {
-    hdPitchWheelMPE(delay, 0, normalizedPitch);
+    hdPitchWheel(delay, 0, normalizedPitch);
 }
 
-void Synth::pitchWheelMPE(int delay, int channel, int pitch) noexcept
+void Synth::pitchWheel(int delay, int channel, int pitch) noexcept
 {
     const float normalizedPitch = normalizeBend(float(pitch));
-    hdPitchWheelMPE(delay, channel, normalizedPitch);
+    hdPitchWheel(delay, channel, normalizedPitch);
 }
 
-void Synth::hdPitchWheelMPE(int delay, int channel, float normalizedPitch) noexcept
+void Synth::hdPitchWheel(int delay, int channel, float normalizedPitch) noexcept
 {
     Impl& impl = *impl_;
     if (!impl.mpeEnabled_)
@@ -1773,16 +1773,16 @@ void Synth::channelAftertouch(int delay, int aftertouch) noexcept
 
 void Synth::hdChannelAftertouch(int delay, float normAftertouch) noexcept
 {
-    hdChannelAftertouchMPE(delay, 0, normAftertouch);
+    hdChannelAftertouch(delay, 0, normAftertouch);
 }
 
-void Synth::channelAftertouchMPE(int delay, int channel, int aftertouch) noexcept
+void Synth::channelAftertouch(int delay, int channel, int aftertouch) noexcept
 {
     const float normalizedAftertouch = normalize7Bits(aftertouch);
-    hdChannelAftertouchMPE(delay, channel, normalizedAftertouch);
+    hdChannelAftertouch(delay, channel, normalizedAftertouch);
 }
 
-void Synth::hdChannelAftertouchMPE(int delay, int channel, float normAftertouch) noexcept
+void Synth::hdChannelAftertouch(int delay, int channel, float normAftertouch) noexcept
 {
     Impl& impl = *impl_;
     if (!impl.mpeEnabled_)
@@ -1808,16 +1808,16 @@ void Synth::polyAftertouch(int delay, int noteNumber, int aftertouch) noexcept
 
 void Synth::hdPolyAftertouch(int delay, int noteNumber, float normAftertouch) noexcept
 {
-    hdPolyAftertouchMPE(delay, 0, noteNumber, normAftertouch);
+    hdPolyAftertouch(delay, 0, noteNumber, normAftertouch);
 }
 
-void Synth::polyAftertouchMPE(int delay, int channel, int noteNumber, int aftertouch) noexcept
+void Synth::polyAftertouch(int delay, int channel, int noteNumber, int aftertouch) noexcept
 {
     const float normalizedAftertouch = normalize7Bits(aftertouch);
-    hdPolyAftertouchMPE(delay, channel, noteNumber, normalizedAftertouch);
+    hdPolyAftertouch(delay, channel, noteNumber, normalizedAftertouch);
 }
 
-void Synth::hdPolyAftertouchMPE(int delay, int channel, int noteNumber, float normAftertouch) noexcept
+void Synth::hdPolyAftertouch(int delay, int channel, int noteNumber, float normAftertouch) noexcept
 {
     Impl& impl = *impl_;
     if (!impl.mpeEnabled_)

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1304,6 +1304,14 @@ void Synth::hdNoteOnMPE(int delay, int channel, int noteNumber, float normalized
     ASSERT(noteNumber < 128);
     ASSERT(noteNumber >= 0);
     Impl& impl = *impl_;
+    // When MPE is disabled, collapse all incoming channels to the Manager
+    // Channel so the legacy and *MPE API surfaces behave identically — all
+    // events land in MidiState channel-0 storage and voices get
+    // triggerChannel_=0. The legacy non-MPE API already passes channel=0
+    // here, so this only affects callers that reached the *MPE entry directly
+    // with a non-zero channel while MPE was off.
+    if (!impl.mpeEnabled_)
+        channel = 0;
     ScopedTiming logger { impl.dispatchDuration_, ScopedTiming::Operation::addToDuration };
 
     if (impl.lastKeyswitchLists_[noteNumber].empty())
@@ -1334,6 +1342,8 @@ void Synth::hdNoteOffMPE(int delay, int channel, int noteNumber, float normalize
     ASSERT(noteNumber < 128);
     ASSERT(noteNumber >= 0);
     Impl& impl = *impl_;
+    if (!impl.mpeEnabled_)
+        channel = 0;
     ScopedTiming logger { impl.dispatchDuration_, ScopedTiming::Operation::addToDuration };
 
     // FIXME: Some keyboards (e.g. Casio PX5S) can send a real note-off velocity. In this case, do we have a
@@ -1582,6 +1592,16 @@ void Synth::Impl::performHdcc(int delay, int channel, int ccNumber, float normVa
         handleRpnControlCC(channel, ccNumber, normValue);
     }
 
+    // Normalize channel AFTER the RPN parser. The parser needs the real
+    // channel to distinguish Manager-vs-Member MCM messages and route
+    // RPN 0 (Pitch Bend Sensitivity) updates to the correct zone (master
+    // bend range vs per-note bend range). The MidiState write + voice CC
+    // updates that follow are the channel-aware storage path, and with
+    // MPE off they should land in channel-0 storage so consumers don't
+    // need to gate dispatch themselves.
+    if (!mpeEnabled_)
+        channel = 0;
+
     for (auto& voice : voiceManager_)
         voice.registerCC(delay, ccNumber, normValue);
 
@@ -1715,6 +1735,8 @@ void Synth::pitchWheelMPE(int delay, int channel, int pitch) noexcept
 void Synth::hdPitchWheelMPE(int delay, int channel, float normalizedPitch) noexcept
 {
     Impl& impl = *impl_;
+    if (!impl.mpeEnabled_)
+        channel = 0;
 
     ScopedTiming logger { impl.dispatchDuration_, ScopedTiming::Operation::addToDuration };
     impl.resources_.getMidiState().pitchBendEvent(delay, channel, normalizedPitch);
@@ -1763,6 +1785,8 @@ void Synth::channelAftertouchMPE(int delay, int channel, int aftertouch) noexcep
 void Synth::hdChannelAftertouchMPE(int delay, int channel, float normAftertouch) noexcept
 {
     Impl& impl = *impl_;
+    if (!impl.mpeEnabled_)
+        channel = 0;
     ScopedTiming logger { impl.dispatchDuration_, ScopedTiming::Operation::addToDuration };
 
     impl.resources_.getMidiState().channelAftertouchEvent(delay, channel, normAftertouch);
@@ -1796,6 +1820,8 @@ void Synth::polyAftertouchMPE(int delay, int channel, int noteNumber, int aftert
 void Synth::hdPolyAftertouchMPE(int delay, int channel, int noteNumber, float normAftertouch) noexcept
 {
     Impl& impl = *impl_;
+    if (!impl.mpeEnabled_)
+        channel = 0;
 
     // MPE 1.0 §2.2.7 / Appendix E Table 5: Polyphonic Key Pressure is
     // prohibited on Member Channels (per-note pressure flows through Channel
@@ -1822,7 +1848,18 @@ void Synth::hdPolyAftertouchMPE(int delay, int channel, int noteNumber, float no
 
 void Synth::setMPEEnabled(bool enabled) noexcept
 {
-    impl_->mpeEnabled_ = enabled;
+    Impl& impl = *impl_;
+    const bool wasEnabled = impl.mpeEnabled_;
+    impl.mpeEnabled_ = enabled;
+    // On the MPE on→off transition, flush active voices. Voices triggered
+    // while MPE was enabled carry triggerChannel_ > 0, and after the flip
+    // all subsequent *MPE / legacy calls normalize channel to 0 — so
+    // matching note-offs can no longer reach them. allSoundOff() resets
+    // all voices; brief silence on a manual toggle flip is acceptable.
+    // off→on needs no flush: channel-0 voices match the new master channel
+    // semantics, and new notes pick up incoming channels naturally.
+    if (wasEnabled && !enabled)
+        allSoundOff();
 }
 
 bool Synth::getMPEEnabled() const noexcept

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -1314,7 +1314,7 @@ void Synth::hdNoteOffMPE(int delay, int channel, int noteNumber, float normalize
     const auto replacedVelocity = midiState.getNoteVelocity(noteNumber);
 
     for (auto& voice : impl.voiceManager_)
-        voice.registerNoteOff(delay, noteNumber, replacedVelocity);
+        voice.registerNoteOff(delay, channel, noteNumber, replacedVelocity);
 
     impl.noteOffDispatch(delay, channel, noteNumber, replacedVelocity);
 }

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -40,6 +40,7 @@
 #include <absl/types/span.h>
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <iostream>
 #include <random>
 #include <utility>
@@ -1531,6 +1532,8 @@ void Synth::Impl::performHdcc(int delay, int channel, int ccNumber, float normVa
             midiState.allNotesOff(delay);
             return;
         }
+
+        handleRpnControlCC(channel, ccNumber, normValue);
     }
 
     for (auto& voice : voiceManager_)
@@ -1538,6 +1541,89 @@ void Synth::Impl::performHdcc(int delay, int channel, int ccNumber, float normVa
 
     ccDispatch(delay, channel, ccNumber, normValue, extendedArg);
     midiState.ccEvent(delay, channel, ccNumber, normValue);
+}
+
+void Synth::Impl::handleRpnControlCC(int channel, int ccNumber, float normValue) noexcept
+{
+    if (channel < 0 || channel >= 16)
+        return;
+
+    RpnParserState& state = rpnParsers_[channel];
+    const auto to7Bit = [](float v) {
+        return static_cast<int>(std::lround(std::min(std::max(v, 0.0f), 1.0f) * 127.0f));
+    };
+
+    switch (ccNumber) {
+    case 99: { // NRPN MSB
+        const int data7 = to7Bit(normValue);
+        state.selectedRpn = static_cast<uint16_t>(
+            (state.selectedRpn & 0x007F) | ((data7 & 0x7F) << 7));
+        state.nrpnMode = true;
+        return;
+    }
+    case 98: { // NRPN LSB
+        const int data7 = to7Bit(normValue);
+        state.selectedRpn = static_cast<uint16_t>(
+            (state.selectedRpn & 0x3F80) | (data7 & 0x7F));
+        state.nrpnMode = true;
+        return;
+    }
+    case 101: { // RPN MSB
+        const int data7 = to7Bit(normValue);
+        state.selectedRpn = static_cast<uint16_t>(
+            (state.selectedRpn & 0x007F) | ((data7 & 0x7F) << 7));
+        state.nrpnMode = false;
+        return;
+    }
+    case 100: { // RPN LSB
+        const int data7 = to7Bit(normValue);
+        state.selectedRpn = static_cast<uint16_t>(
+            (state.selectedRpn & 0x3F80) | (data7 & 0x7F));
+        state.nrpnMode = false;
+        return;
+    }
+    case 6: { // Data Entry MSB — dispatch RPN 0 / RPN 6 handlers
+        if (state.nrpnMode || state.selectedRpn == RpnParserState::kNullRpn)
+            return;
+        const int data7 = to7Bit(normValue);
+        if (state.selectedRpn == 6) {
+            // MPE Configuration Message. Lower Zone master only — channel 0
+            // in sfizz's 0-indexed convention (MIDI channel 1 on the wire).
+            // Upper Zone (channel 15 / MIDI 16) is deferred per the story's
+            // open-questions section; no commercial MPE controller in our
+            // target set uses it. data7 == 0 disables MPE, 1..15 enables
+            // and announces member-channel count (informational — sfizz
+            // already accepts events on all 16 channels regardless).
+            if (channel != 0)
+                return;
+            mpeEnabled_ = (data7 >= 1 && data7 <= 15);
+        } else if (state.selectedRpn == 0) {
+            // Pitch Bend Sensitivity. Master-channel RPN updates the
+            // master range; member-channel RPN updates the per-note range
+            // applied to all members (commercial controllers send the
+            // same value on every member channel).
+            const float newRange = static_cast<float>(data7);
+            if (channel == 0) {
+                if (!mpeMasterBendAutoConfigEnabled_)
+                    return;
+                mpeMasterPitchBendRange_ = newRange;
+                resources_.getMidiState().setMPEPitchBendRange(
+                    newRange, mpePerNotePitchBendRange_);
+            } else {
+                if (!mpePerNoteBendAutoConfigEnabled_)
+                    return;
+                mpePerNotePitchBendRange_ = newRange;
+                resources_.getMidiState().setMPEPitchBendRange(
+                    mpeMasterPitchBendRange_, newRange);
+            }
+        }
+        return;
+    }
+    case 38: // Data Entry LSB — cents fraction for RPN 0, deferred to v2.
+        return;
+    default:
+        return;
+    }
 }
 
 void Synth::Impl::setDefaultHdcc(int ccNumber, float value)
@@ -1701,6 +1787,26 @@ float Synth::getMPEMasterPitchBendRange() const noexcept
 float Synth::getMPEPerNotePitchBendRange() const noexcept
 {
     return impl_->mpePerNotePitchBendRange_;
+}
+
+void Synth::setMPEMasterBendAutoConfigEnabled(bool enabled) noexcept
+{
+    impl_->mpeMasterBendAutoConfigEnabled_ = enabled;
+}
+
+bool Synth::getMPEMasterBendAutoConfigEnabled() const noexcept
+{
+    return impl_->mpeMasterBendAutoConfigEnabled_;
+}
+
+void Synth::setMPEPerNoteBendAutoConfigEnabled(bool enabled) noexcept
+{
+    impl_->mpePerNoteBendAutoConfigEnabled_ = enabled;
+}
+
+bool Synth::getMPEPerNoteBendAutoConfigEnabled() const noexcept
+{
+    return impl_->mpePerNoteBendAutoConfigEnabled_;
 }
 
 void Synth::tempo(int delay, float secondsPerBeat) noexcept

--- a/src/sfizz/Synth.cpp
+++ b/src/sfizz/Synth.cpp
@@ -50,6 +50,38 @@ namespace sfz {
 // unless set to permissive, the loader rejects sfz files with errors
 static constexpr bool loaderParsesPermissively = true;
 
+// MPE 1.0 §2.3.1 / §2.3.3 (Appendix E Table 5): CCs whose effect is
+// zone-wide and that should therefore only be honoured on the Manager
+// Channel. Damper / Portamento / Sostenuto / Soft / Legato Footswitch /
+// Hold 2 (CCs 64-69), All Sounds Off / Reset All Controllers / All Notes
+// Off / Omni Off / Omni On (CCs 120-125, excluding 122 — Local Control is
+// irrelevant for a software synth and the spec doesn't class it here),
+// and Bank Select MSB/LSB (CCs 0 and 32, which queue state for a later
+// Program Change). CC#7 (Volume), CC#10 (Pan) and CC#11 (Expression) are
+// intentionally NOT listed — the spec marks them optional on both channel
+// types so we leave them on the per-channel path.
+static constexpr bool isManagerOnlyCC(int ccNumber) noexcept
+{
+    switch (ccNumber) {
+    case 0:
+    case 32:
+    case 64:
+    case 65:
+    case 66:
+    case 67:
+    case 68:
+    case 69:
+    case 120:
+    case 121:
+    case 123:
+    case 124:
+    case 125:
+        return true;
+    default:
+        return false;
+    }
+}
+
 Synth::Synth()
 : impl_(new Impl) // NOLINT: (paul) I don't get why clang-tidy complains here
 {
@@ -1514,6 +1546,20 @@ void Synth::Impl::performHdcc(int delay, int channel, int ccNumber, float normVa
     ASSERT(ccNumber < config::numCCs);
     ASSERT(ccNumber >= 0);
 
+    // MPE 1.0 §2.3.1 / §2.3.3: zone-wide messages (pedal CCs, mode/reset,
+    // Bank Select) must only be honoured on the Manager Channel. Drop on
+    // Member Channels before any side effects — the global early-returns
+    // for All-Notes-Off / Reset-All-Controllers further down would otherwise
+    // fire on a Member-Channel arrival, and Bank Select on a Member Channel
+    // would queue a bank for a Program Change that the host then has to
+    // filter separately. Gate on asMidi so internal automation paths
+    // (which conceptually target the Manager Channel) keep working.
+    // Lower Zone only (Manager = channel 0); revisit when Upper Zone lands.
+    if (asMidi && mpeEnabled_ && channel != 0 && isManagerOnlyCC(ccNumber)) {
+        ++droppedManagerOnlyCCs_;
+        return;
+    }
+
     ScopedTiming logger { dispatchDuration_, ScopedTiming::Operation::addToDuration };
 
     changedCCsThisCycle_.set(ccNumber);
@@ -1826,6 +1872,11 @@ bool Synth::getMPEPerNoteBendAutoConfigEnabled() const noexcept
 int Synth::getDroppedPolyKpOnMemberCount() const noexcept
 {
     return impl_->droppedPolyKpOnMember_;
+}
+
+int Synth::getDroppedManagerOnlyMessageCount() const noexcept
+{
+    return impl_->droppedManagerOnlyCCs_;
 }
 
 void Synth::tempo(int delay, float secondsPerBeat) noexcept

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -537,6 +537,103 @@ public:
      */
     void playbackState(int delay, int playbackState);
 
+    // === MPE (MIDI Polyphonic Expression) support ============================
+    //
+    // The methods below mirror the existing single-channel input API but take
+    // an additional MIDI channel argument (0..15). They populate per-channel
+    // modulation state in MidiState so voices triggered on a member channel
+    // respond independently to per-note pitch bend, per-note CC, and per-note
+    // aftertouch. Hosts that don't care about MPE can keep using the existing
+    // single-channel methods, which forward to the MPE variants with channel
+    // = 0 (master).
+    //
+    // setMPEEnabled() is informational for now: it gates how the engine will
+    // interpret RPN-derived pitch-bend ranges and how voice stealing prefers
+    // same-channel candidates (follow-up commits). Per-channel input dispatch
+    // works regardless of the flag — calling pitchWheelMPE(channel=2, ...)
+    // always lands in MidiState's channel-2 slot.
+
+    /**
+     * @brief Send a note on event on a specific MIDI channel (0..15).
+     */
+    void noteOnMPE(int delay, int channel, int noteNumber, int velocity) noexcept;
+    /**
+     * @brief High-precision note on on a specific MIDI channel.
+     */
+    void hdNoteOnMPE(int delay, int channel, int noteNumber, float normalizedVelocity) noexcept;
+    /**
+     * @brief Send a note off event on a specific MIDI channel (0..15).
+     */
+    void noteOffMPE(int delay, int channel, int noteNumber, int velocity) noexcept;
+    /**
+     * @brief High-precision note off on a specific MIDI channel.
+     */
+    void hdNoteOffMPE(int delay, int channel, int noteNumber, float normalizedVelocity) noexcept;
+    /**
+     * @brief Send a CC event on a specific MIDI channel (0..15).
+     */
+    void ccMPE(int delay, int channel, int ccNumber, int ccValue) noexcept;
+    /**
+     * @brief High-precision CC on a specific MIDI channel.
+     */
+    void hdccMPE(int delay, int channel, int ccNumber, float normValue) noexcept;
+    /**
+     * @brief Send a pitch bend event on a specific MIDI channel (0..15).
+     */
+    void pitchWheelMPE(int delay, int channel, int pitch) noexcept;
+    /**
+     * @brief High-precision pitch bend on a specific MIDI channel.
+     */
+    void hdPitchWheelMPE(int delay, int channel, float normalizedPitch) noexcept;
+    /**
+     * @brief Send a channel aftertouch event on a specific MIDI channel.
+     */
+    void channelAftertouchMPE(int delay, int channel, int aftertouch) noexcept;
+    /**
+     * @brief High-precision channel aftertouch on a specific MIDI channel.
+     */
+    void hdChannelAftertouchMPE(int delay, int channel, float normAftertouch) noexcept;
+    /**
+     * @brief Send a polyphonic aftertouch event on a specific MIDI channel.
+     */
+    void polyAftertouchMPE(int delay, int channel, int noteNumber, int aftertouch) noexcept;
+    /**
+     * @brief High-precision polyphonic aftertouch on a specific MIDI channel.
+     */
+    void hdPolyAftertouchMPE(int delay, int channel, int noteNumber, float normAftertouch) noexcept;
+
+    /**
+     * @brief Enable or disable MPE mode. The flag is stored on the synth and
+     * surfaced via getMPEEnabled(). Per-channel input dispatch works whether
+     * or not this is set; the flag is consumed by features that need to know
+     * the current zone (RPN-driven pitch-bend range application, MPE-aware
+     * voice stealing). Default is false.
+     */
+    void setMPEEnabled(bool enabled) noexcept;
+    /**
+     * @brief Get whether MPE mode is currently enabled.
+     */
+    bool getMPEEnabled() const noexcept;
+
+    /**
+     * @brief Set the MPE pitch-bend range, in semitones. MPE 1.0 conventions:
+     * master default 2 semitones (typical DAW-side bend), per-note default
+     * 48 semitones (full keyboard range for finger slides). Values are
+     * stored on the synth and applied per-voice during rendering when MPE
+     * is enabled.
+     */
+    void setMPEPitchBendRange(float masterSemitones, float perNoteSemitones) noexcept;
+    /**
+     * @brief Get the master-channel pitch-bend range in semitones.
+     */
+    float getMPEMasterPitchBendRange() const noexcept;
+    /**
+     * @brief Get the member-channel (per-note) pitch-bend range in semitones.
+     */
+    float getMPEPerNotePitchBendRange() const noexcept;
+
+    // =========================================================================
+
     /**
      * @brief Render an block of audio data in the buffer. This call will reset
      * the synth in its waiting state for the next batch of events. The size of

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -632,6 +632,33 @@ public:
      */
     float getMPEPerNotePitchBendRange() const noexcept;
 
+    /**
+     * @brief Toggle whether incoming Pitch Bend Sensitivity (RPN 0)
+     * sequences on the master channel update the master bend range.
+     * Disabling this pins the master range to whatever the host last
+     * set via setMPEPitchBendRange. MPE Configuration Messages (RPN 6)
+     * are processed unconditionally — this gate covers only the bend
+     * range. Defaults to true.
+     */
+    void setMPEMasterBendAutoConfigEnabled(bool enabled) noexcept;
+    /**
+     * @brief Get whether master-channel Pitch Bend Sensitivity messages
+     * update the master bend range.
+     */
+    bool getMPEMasterBendAutoConfigEnabled() const noexcept;
+
+    /**
+     * @brief Toggle whether incoming Pitch Bend Sensitivity (RPN 0)
+     * sequences on member channels update the per-note bend range.
+     * Disabling this pins the per-note range. Defaults to true.
+     */
+    void setMPEPerNoteBendAutoConfigEnabled(bool enabled) noexcept;
+    /**
+     * @brief Get whether member-channel Pitch Bend Sensitivity messages
+     * update the per-note bend range.
+     */
+    bool getMPEPerNoteBendAutoConfigEnabled() const noexcept;
+
     // =========================================================================
 
     /**

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -550,57 +550,57 @@ public:
     // setMPEEnabled() is informational for now: it gates how the engine will
     // interpret RPN-derived pitch-bend ranges and how voice stealing prefers
     // same-channel candidates (follow-up commits). Per-channel input dispatch
-    // works regardless of the flag — calling pitchWheelMPE(channel=2, ...)
+    // works regardless of the flag — calling pitchWheel(channel=2, ...)
     // always lands in MidiState's channel-2 slot.
 
     /**
      * @brief Send a note on event on a specific MIDI channel (0..15).
      */
-    void noteOnMPE(int delay, int channel, int noteNumber, int velocity) noexcept;
+    void noteOn(int delay, int channel, int noteNumber, int velocity) noexcept;
     /**
      * @brief High-precision note on on a specific MIDI channel.
      */
-    void hdNoteOnMPE(int delay, int channel, int noteNumber, float normalizedVelocity) noexcept;
+    void hdNoteOn(int delay, int channel, int noteNumber, float normalizedVelocity) noexcept;
     /**
      * @brief Send a note off event on a specific MIDI channel (0..15).
      */
-    void noteOffMPE(int delay, int channel, int noteNumber, int velocity) noexcept;
+    void noteOff(int delay, int channel, int noteNumber, int velocity) noexcept;
     /**
      * @brief High-precision note off on a specific MIDI channel.
      */
-    void hdNoteOffMPE(int delay, int channel, int noteNumber, float normalizedVelocity) noexcept;
+    void hdNoteOff(int delay, int channel, int noteNumber, float normalizedVelocity) noexcept;
     /**
      * @brief Send a CC event on a specific MIDI channel (0..15).
      */
-    void ccMPE(int delay, int channel, int ccNumber, int ccValue) noexcept;
+    void cc(int delay, int channel, int ccNumber, int ccValue) noexcept;
     /**
      * @brief High-precision CC on a specific MIDI channel.
      */
-    void hdccMPE(int delay, int channel, int ccNumber, float normValue) noexcept;
+    void hdcc(int delay, int channel, int ccNumber, float normValue) noexcept;
     /**
      * @brief Send a pitch bend event on a specific MIDI channel (0..15).
      */
-    void pitchWheelMPE(int delay, int channel, int pitch) noexcept;
+    void pitchWheel(int delay, int channel, int pitch) noexcept;
     /**
      * @brief High-precision pitch bend on a specific MIDI channel.
      */
-    void hdPitchWheelMPE(int delay, int channel, float normalizedPitch) noexcept;
+    void hdPitchWheel(int delay, int channel, float normalizedPitch) noexcept;
     /**
      * @brief Send a channel aftertouch event on a specific MIDI channel.
      */
-    void channelAftertouchMPE(int delay, int channel, int aftertouch) noexcept;
+    void channelAftertouch(int delay, int channel, int aftertouch) noexcept;
     /**
      * @brief High-precision channel aftertouch on a specific MIDI channel.
      */
-    void hdChannelAftertouchMPE(int delay, int channel, float normAftertouch) noexcept;
+    void hdChannelAftertouch(int delay, int channel, float normAftertouch) noexcept;
     /**
      * @brief Send a polyphonic aftertouch event on a specific MIDI channel.
      */
-    void polyAftertouchMPE(int delay, int channel, int noteNumber, int aftertouch) noexcept;
+    void polyAftertouch(int delay, int channel, int noteNumber, int aftertouch) noexcept;
     /**
      * @brief High-precision polyphonic aftertouch on a specific MIDI channel.
      */
-    void hdPolyAftertouchMPE(int delay, int channel, int noteNumber, float normAftertouch) noexcept;
+    void hdPolyAftertouch(int delay, int channel, int noteNumber, float normAftertouch) noexcept;
 
     /**
      * @brief Enable or disable MPE mode. The flag is stored on the synth and
@@ -664,7 +664,7 @@ public:
      * dropped because they arrived on a Member Channel while MPE was
      * enabled. MPE 1.0 §2.2.7 / Appendix E Table 5 mark Poly KP on Member
      * Channels as prohibited; the engine silently drops them at the
-     * hdPolyAftertouchMPE entry and increments this counter so hosts /
+     * hdPolyAftertouch entry and increments this counter so hosts /
      * tests can observe spec-violating traffic. Counter is not reset by
      * setMPEEnabled, polyphony changes, or SFZ reloads.
      */

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -659,6 +659,17 @@ public:
      */
     bool getMPEPerNoteBendAutoConfigEnabled() const noexcept;
 
+    /**
+     * @brief Diagnostic count of Polyphonic Key Pressure events the engine
+     * dropped because they arrived on a Member Channel while MPE was
+     * enabled. MPE 1.0 §2.2.7 / Appendix E Table 5 mark Poly KP on Member
+     * Channels as prohibited; the engine silently drops them at the
+     * hdPolyAftertouchMPE entry and increments this counter so hosts /
+     * tests can observe spec-violating traffic. Counter is not reset by
+     * setMPEEnabled, polyphony changes, or SFZ reloads.
+     */
+    int getDroppedPolyKpOnMemberCount() const noexcept;
+
     // =========================================================================
 
     /**

--- a/src/sfizz/Synth.h
+++ b/src/sfizz/Synth.h
@@ -670,6 +670,20 @@ public:
      */
     int getDroppedPolyKpOnMemberCount() const noexcept;
 
+    /**
+     * @brief Diagnostic count of Manager-only CC messages the engine
+     * dropped because they arrived on a Member Channel while MPE was
+     * enabled. MPE 1.0 §2.3.1 / §2.3.3 (Appendix E Table 5) require pedal
+     * CCs (64-69), mode/reset CCs (120-125 excluding 122) and Bank Select
+     * (CC 0 / CC 32) to be honoured only on the Manager Channel; the
+     * engine drops them at the top of performHdcc and increments this
+     * counter so hosts / tests can observe spec-violating traffic. Program
+     * Change is filtered host-side because the engine programChange API
+     * does not carry a channel argument. Counter is not reset by
+     * setMPEEnabled, polyphony changes, or SFZ reloads.
+     */
+    int getDroppedManagerOnlyMessageCount() const noexcept;
+
     // =========================================================================
 
     /**

--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -439,7 +439,7 @@ struct Synth::Impl final: public Parser::Listener {
     // Spec-violation diagnostic: Polyphonic Key Pressure on a Member Channel
     // is prohibited by MPE 1.0 §2.2.7 ("Polyphonic Key Pressure shall not be
     // sent on other Member Channels"). When mpeEnabled_ is set, the engine
-    // drops such events at the hdPolyAftertouchMPE entry and increments this
+    // drops such events at the hdPolyAftertouch entry and increments this
     // counter so hosts / tests can observe how often it fired.
     int droppedPolyKpOnMember_ { 0 };
 

--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -442,6 +442,15 @@ struct Synth::Impl final: public Parser::Listener {
     // drops such events at the hdPolyAftertouchMPE entry and increments this
     // counter so hosts / tests can observe how often it fired.
     int droppedPolyKpOnMember_ { 0 };
+
+    // Spec-violation diagnostic: Manager-only CC messages (pedal CCs, mode
+    // and reset CCs, Bank Select) arriving on a Member Channel while MPE
+    // is enabled are dropped at the top of performHdcc per MPE 1.0 §2.3.1
+    // / §2.3.3 (Appendix E Table 5). This counter is incremented per drop
+    // so hosts / tests can observe spec-violating traffic. Program Change
+    // on Member Channels is filtered host-side because the engine
+    // programChange API does not carry a channel argument.
+    int droppedManagerOnlyCCs_ { 0 };
 };
 
 } // namespace sfz

--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -435,6 +435,13 @@ struct Synth::Impl final: public Parser::Listener {
         bool nrpnMode { false };
     };
     std::array<RpnParserState, 16> rpnParsers_;
+
+    // Spec-violation diagnostic: Polyphonic Key Pressure on a Member Channel
+    // is prohibited by MPE 1.0 §2.2.7 ("Polyphonic Key Pressure shall not be
+    // sent on other Member Channels"). When mpeEnabled_ is set, the engine
+    // drops such events at the hdPolyAftertouchMPE entry and increments this
+    // counter so hosts / tests can observe how often it fired.
+    int droppedPolyKpOnMember_ { 0 };
 };
 
 } // namespace sfz

--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -248,6 +248,19 @@ struct Synth::Impl final: public Parser::Listener {
     void performHdcc(int delay, int channel, int ccNumber, float normValue, bool asMidi, int extendedArg=-1) noexcept;
 
     /**
+     * @brief Tap on the CCs that drive MIDI RPN/NRPN selection and data
+     *        entry (CCs 6, 38, 98, 99, 100, 101). Called from performHdcc
+     *        before the normal dispatch so the CCs continue through to
+     *        MidiState and SFZ *_oncc bindings untouched. When a complete
+     *        MPE Configuration Message (RPN 6) or Pitch Bend Sensitivity
+     *        (RPN 0) sequence is detected on the relevant channel, drives
+     *        the MPE auto-config handlers (per-direction opt-out via the
+     *        mpeMasterBendAutoConfigEnabled_ / mpePerNoteBendAutoConfigEnabled_
+     *        flags; MCM enable/disable is unconditional per MPE 1.0).
+     */
+    void handleRpnControlCC(int channel, int ccNumber, float normValue) noexcept;
+
+    /**
      * @brief Set the default value for a CC
      *
      * @param ccNumber
@@ -399,6 +412,29 @@ struct Synth::Impl final: public Parser::Listener {
     bool mpeEnabled_ { false };
     float mpeMasterPitchBendRange_ { 2.0f };
     float mpePerNotePitchBendRange_ { 48.0f };
+
+    // MPE auto-config (RPN 6 + RPN 0). The engine listens for the MPE
+    // Configuration Message and Pitch Bend Sensitivity sequences per
+    // MPE 1.0 §2 and updates mpeEnabled_ / the bend-range fields
+    // without host intervention. The bend-range updates are gated by the
+    // two flags below so UIs can opt out per direction; MCM enable/disable
+    // always drives mpeEnabled_ because that is the spec contract.
+    bool mpeMasterBendAutoConfigEnabled_ { true };
+    bool mpePerNoteBendAutoConfigEnabled_ { true };
+
+    // Per-channel RPN parser state. RPN selection is per-channel per the
+    // MIDI spec, so 16 instances. selectedRpn is a 14-bit value composed
+    // of CC 101 (MSB, bits 7..13) and CC 100 (LSB, bits 0..6); the
+    // initial / null/deselect sentinel is 0x3FFF (both at 127). nrpnMode
+    // tracks whether the last CC 98/99 vs CC 100/101 message set NRPN
+    // vs RPN, so that a CC 6 following an NRPN selection isn't
+    // misinterpreted as RPN data entry.
+    struct RpnParserState {
+        static constexpr uint16_t kNullRpn = 0x3FFF;
+        uint16_t selectedRpn { kNullRpn };
+        bool nrpnMode { false };
+    };
+    std::array<RpnParserState, 16> rpnParsers_;
 };
 
 } // namespace sfz

--- a/src/sfizz/SynthPrivate.h
+++ b/src/sfizz/SynthPrivate.h
@@ -133,16 +133,19 @@ struct Synth::Impl final: public Parser::Listener {
      * @param noteNumber
      * @param velocity
      */
-    void noteOnDispatch(int delay, int noteNumber, float velocity) noexcept;
+    void noteOnDispatch(int delay, int channel, int noteNumber, float velocity) noexcept;
 
     /**
      * @brief Check all regions and start voices for note off events
      *
      * @param delay
+     * @param channel  the MIDI channel the note-off arrived on (0..15);
+     *                 propagates into the TriggerEvent so voices spawned
+     *                 by release-trigger regions inherit the channel
      * @param noteNumber
      * @param velocity
      */
-    void noteOffDispatch(int delay, int noteNumber, float velocity) noexcept;
+    void noteOffDispatch(int delay, int channel, int noteNumber, float velocity) noexcept;
 
     /**
      * @brief Check all regions and start voices for cc events
@@ -152,7 +155,7 @@ struct Synth::Impl final: public Parser::Listener {
      * @param value
      * @param extendedArg used for some extendedCC (eg. polyaftertouch note num, etc)
      */
-    void ccDispatch(int delay, int ccNumber, float value, int extendedArg=-1) noexcept;
+    void ccDispatch(int delay, int channel, int ccNumber, float value, int extendedArg=-1) noexcept;
 
     /**
      * @brief Start a voice for a specific region.
@@ -242,7 +245,7 @@ struct Synth::Impl final: public Parser::Listener {
      * @param asMidi     Whether to process as a MIDI event
      * @param extendedArg for some extendedCC (eg. polyaftertouch: note num, etc)
      */
-    void performHdcc(int delay, int ccNumber, float normValue, bool asMidi, int extendedArg=-1) noexcept;
+    void performHdcc(int delay, int channel, int ccNumber, float normValue, bool asMidi, int extendedArg=-1) noexcept;
 
     /**
      * @brief Set the default value for a CC
@@ -388,6 +391,14 @@ struct Synth::Impl final: public Parser::Listener {
     }
 
     bool playheadMoved_ { false };
+
+    // MPE state. Storage only — the Synth dispatch path handles per-channel
+    // event routing whether or not mpeEnabled_ is set; the flag is consumed
+    // by features that need zone awareness (RPN-driven pitch-bend range
+    // application, MPE-aware voice stealing) added in follow-up commits.
+    bool mpeEnabled_ { false };
+    float mpeMasterPitchBendRange_ { 2.0f };
+    float mpePerNotePitchBendRange_ { 48.0f };
 };
 
 } // namespace sfz

--- a/src/sfizz/TriggerEvent.h
+++ b/src/sfizz/TriggerEvent.h
@@ -19,6 +19,14 @@ struct TriggerEvent
     TriggerEventType type;
     int number;
     float value;
+    /**
+     * @brief MIDI channel (0..15) the event was sent on. Defaults to 0
+     * (master), so existing call sites that brace-initialize with
+     * three fields keep their previous behavior. The value flows down
+     * to the triggered Voice so per-voice modulation reads can route
+     * to the correct slot in MidiState's per-channel storage.
+     */
+    int channel { 0 };
 };
 
 }

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -2030,7 +2030,9 @@ void Voice::Impl::pitchEnvelope(absl::Span<float> pitchSpan) noexcept
         //                    + per_note_bend × per_note_range.
         // Read the two channels separately (no fallback) so the master
         // contribution is preserved even after the member channel's events
-        // were populated by an earlier per-note bend.
+        // were populated by an earlier per-note bend. Either vector may be
+        // empty (member channels are populated lazily on first write), so
+        // guard the linearEnvelope calls — it asserts events.size() > 0.
         const float perNoteCents =
             midiState.getMPEBendRangeForChannel(triggerChannel_) * 100.0f;
         const float masterCents =
@@ -2040,28 +2042,35 @@ void Voice::Impl::pitchEnvelope(absl::Span<float> pitchSpan) noexcept
         const EventVector& masterEvents = midiState.getPitchEventsRaw(0);
 
         // Per-note contribution into pitchSpan.
-        const auto perNoteLambda = [perNoteCents](float bend) {
-            return bend * perNoteCents;
-        };
-        if (region_->bendStep > 1.0f)
-            linearEnvelope(perNoteEvents, pitchSpan, perNoteLambda, region_->bendStep);
-        else
-            linearEnvelope(perNoteEvents, pitchSpan, perNoteLambda);
-
-        // Master contribution into a scratch buffer, then summed onto pitchSpan.
-        auto& bufferPool = resources_.getBufferPool();
-        auto scratch = bufferPool.getBuffer(numFrames);
-        if (scratch) {
-            absl::Span<float> masterSpan = *scratch;
-            const auto masterLambda = [masterCents](float bend) {
-                return bend * masterCents;
+        if (!perNoteEvents.empty()) {
+            const auto perNoteLambda = [perNoteCents](float bend) {
+                return bend * perNoteCents;
             };
             if (region_->bendStep > 1.0f)
-                linearEnvelope(masterEvents, masterSpan, masterLambda, region_->bendStep);
+                linearEnvelope(perNoteEvents, pitchSpan, perNoteLambda, region_->bendStep);
             else
-                linearEnvelope(masterEvents, masterSpan, masterLambda);
-            for (size_t i = 0; i < numFrames; ++i)
-                pitchSpan[i] += masterSpan[i];
+                linearEnvelope(perNoteEvents, pitchSpan, perNoteLambda);
+        }
+        else {
+            std::fill(pitchSpan.begin(), pitchSpan.end(), 0.0f);
+        }
+
+        // Master contribution into a scratch buffer, then summed onto pitchSpan.
+        if (!masterEvents.empty()) {
+            auto& bufferPool = resources_.getBufferPool();
+            auto scratch = bufferPool.getBuffer(numFrames);
+            if (scratch) {
+                absl::Span<float> masterSpan = *scratch;
+                const auto masterLambda = [masterCents](float bend) {
+                    return bend * masterCents;
+                };
+                if (region_->bendStep > 1.0f)
+                    linearEnvelope(masterEvents, masterSpan, masterLambda, region_->bendStep);
+                else
+                    linearEnvelope(masterEvents, masterSpan, masterLambda);
+                for (size_t i = 0; i < numFrames; ++i)
+                    pitchSpan[i] += masterSpan[i];
+            }
         }
     }
     bendSmoother_.process(pitchSpan, pitchSpan);

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -630,7 +630,7 @@ void Voice::Impl::off(int delay, bool fast) noexcept
     release(delay);
 }
 
-void Voice::registerNoteOff(int delay, int noteNumber, float velocity) noexcept
+void Voice::registerNoteOff(int delay, int channel, int noteNumber, float velocity) noexcept
 {
     ASSERT(velocity >= 0.0 && velocity <= 1.0);
     UNUSED(velocity);
@@ -642,7 +642,9 @@ void Voice::registerNoteOff(int delay, int noteNumber, float velocity) noexcept
     if (impl.state_ != State::playing)
         return;
 
-    if (impl.triggerEvent_.number == noteNumber && impl.triggerEvent_.type == TriggerEventType::NoteOn) {
+    if (impl.triggerEvent_.number == noteNumber
+        && impl.triggerEvent_.channel == channel
+        && impl.triggerEvent_.type == TriggerEventType::NoteOn) {
         impl.noteIsOff_ = true;
 
         if (impl.region_->loopMode == LoopMode::one_shot)

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -195,6 +195,14 @@ struct Voice::Impl
     bool released() const noexcept;
 
     /**
+     * @brief MPE 1.0 §2.2.6 / §2.2.7 / §2.2.8 released-note expression
+     * filter — see Voice::expressionChannel for semantics. Internal
+     * Voice::Impl mirror so per-block render code can call it without a
+     * round-trip through the public surface.
+     */
+    int expressionChannel() const noexcept;
+
+    /**
      * @brief Release the voice after a given delay
      *
      * @param delay
@@ -897,9 +905,11 @@ void Voice::Impl::applyCrossfades(absl::Span<float> modulationSpan) noexcept
 
     fill<float>(*xfadeSpan, 1.0f);
 
+    const int xfadeChannel = expressionChannel();
+
     bool canShortcut = true;
     for (const auto& mod : region_->crossfadeCCInRange) {
-        const auto& events = midiState.getCCEvents(triggerChannel_, mod.cc);
+        const auto& events = midiState.getCCEvents(xfadeChannel, mod.cc);
         canShortcut &= (events.size() == 1);
         linearEnvelope(events, *tempSpan, [&](float x) {
             return crossfadeIn(mod.data, x, xfCurve);
@@ -908,7 +918,7 @@ void Voice::Impl::applyCrossfades(absl::Span<float> modulationSpan) noexcept
     }
 
     for (const auto& mod : region_->crossfadeCCOutRange) {
-        const auto& events = midiState.getCCEvents(triggerChannel_, mod.cc);
+        const auto& events = midiState.getCCEvents(xfadeChannel, mod.cc);
         canShortcut &= (events.size() == 1);
         linearEnvelope(events, *tempSpan, [&](float x) {
             return crossfadeOut(mod.data, x, xfCurve);
@@ -1693,6 +1703,17 @@ bool Voice::released() const noexcept
     return impl.released();
 }
 
+int Voice::expressionChannel() const noexcept
+{
+    Impl& impl = *impl_;
+    return impl.expressionChannel();
+}
+
+int Voice::Impl::expressionChannel() const noexcept
+{
+    return (released() && triggerChannel_ != 0) ? 0 : triggerChannel_;
+}
+
 bool Voice::Impl::released() const noexcept
 {
     if (!region_ || state_ != State::playing)
@@ -2033,23 +2054,37 @@ void Voice::Impl::pitchEnvelope(absl::Span<float> pitchSpan) noexcept
         // were populated by an earlier per-note bend. Either vector may be
         // empty (member channels are populated lazily on first write), so
         // guard the linearEnvelope calls — it asserts events.size() > 0.
-        const float perNoteCents =
-            midiState.getMPEBendRangeForChannel(triggerChannel_) * 100.0f;
+        //
+        // MPE 1.0 §2.2.6: once released, the voice must stop reacting to
+        // Member-Channel pitch bend (the controller will reuse the channel
+        // for the next finger) but should still honour Manager-Channel
+        // pitch bend. Skip the per-note read entirely when released —
+        // expressionChannel() returns 0 in that state but reading the
+        // master events as "per-note" would double-apply the master bend,
+        // so zero the per-note contribution explicitly.
+        const bool releasedMember = released();
+        const float perNoteCents = releasedMember ? 0.0f
+            : midiState.getMPEBendRangeForChannel(triggerChannel_) * 100.0f;
         const float masterCents =
             midiState.getMPEBendRangeForChannel(0) * 100.0f;
 
-        const EventVector& perNoteEvents = midiState.getPitchEventsRaw(triggerChannel_);
         const EventVector& masterEvents = midiState.getPitchEventsRaw(0);
 
         // Per-note contribution into pitchSpan.
-        if (!perNoteEvents.empty()) {
-            const auto perNoteLambda = [perNoteCents](float bend) {
-                return bend * perNoteCents;
-            };
-            if (region_->bendStep > 1.0f)
-                linearEnvelope(perNoteEvents, pitchSpan, perNoteLambda, region_->bendStep);
-            else
-                linearEnvelope(perNoteEvents, pitchSpan, perNoteLambda);
+        if (!releasedMember) {
+            const EventVector& perNoteEvents = midiState.getPitchEventsRaw(triggerChannel_);
+            if (!perNoteEvents.empty()) {
+                const auto perNoteLambda = [perNoteCents](float bend) {
+                    return bend * perNoteCents;
+                };
+                if (region_->bendStep > 1.0f)
+                    linearEnvelope(perNoteEvents, pitchSpan, perNoteLambda, region_->bendStep);
+                else
+                    linearEnvelope(perNoteEvents, pitchSpan, perNoteLambda);
+            }
+            else {
+                std::fill(pitchSpan.begin(), pitchSpan.end(), 0.0f);
+            }
         }
         else {
             std::fill(pitchSpan.begin(), pitchSpan.end(), 0.0f);

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -529,7 +529,25 @@ bool Voice::startVoice(Layer* layer, int delay, const TriggerEvent& event) noexc
     impl.sampleEnd_ = int(sampleEnd(region, midiState));
     impl.sampleSize_ = impl.sampleEnd_- impl.sourcePosition_ - 1;
     impl.bendSmoother_.setSmoothing(region.bendSmooth, impl.sampleRate_);
-    impl.bendSmoother_.reset(region.getBendInCents(midiState.getPitchBend(impl.triggerChannel_)));
+    {
+        // Same master vs. member channel distinction as in pitchEnvelope:
+        // master uses region bend_up/down. Member channels combine their own
+        // bend (per-note range) with master bend (master range) per MPE 1.0.
+        float initialCents;
+        if (impl.triggerChannel_ == 0) {
+            initialCents = region.getBendInCents(midiState.getPitchBend(0));
+        }
+        else {
+            const float perNoteBend = midiState.getPitchBendRaw(impl.triggerChannel_);
+            const float masterBend = midiState.getPitchBendRaw(0);
+            const float perNoteCents =
+                midiState.getMPEBendRangeForChannel(impl.triggerChannel_) * 100.0f;
+            const float masterCents =
+                midiState.getMPEBendRangeForChannel(0) * 100.0f;
+            initialCents = perNoteBend * perNoteCents + masterBend * masterCents;
+        }
+        impl.bendSmoother_.reset(initialCents);
+    }
 
     ModMatrix& modMatrix = resources.getModMatrix();
     modMatrix.initVoice(impl.id_, region.getId(), impl.initialDelay_);
@@ -1994,15 +2012,58 @@ void Voice::Impl::pitchEnvelope(absl::Span<float> pitchSpan) noexcept
     const size_t numFrames = pitchSpan.size();
 
     const MidiState& midiState = resources_.getMidiState();
-    const EventVector& events = midiState.getPitchEvents(triggerChannel_);
-    const auto bendLambda = [this](float bend) {
-        return region_->getBendInCents(bend);
-    };
+    const bool isMaster = (triggerChannel_ == 0);
 
-    if (region_->bendStep > 1.0f)
-        linearEnvelope(events, pitchSpan, bendLambda, region_->bendStep);
-    else
-        linearEnvelope(events, pitchSpan, bendLambda);
+    if (isMaster) {
+        // Legacy / non-MPE path: single events vector, region bend_up/down.
+        const EventVector& events = midiState.getPitchEvents(triggerChannel_);
+        const auto bendLambda = [this](float bend) {
+            return region_->getBendInCents(bend);
+        };
+        if (region_->bendStep > 1.0f)
+            linearEnvelope(events, pitchSpan, bendLambda, region_->bendStep);
+        else
+            linearEnvelope(events, pitchSpan, bendLambda);
+    }
+    else {
+        // MPE 1.0: total bend = master_bend × master_range
+        //                    + per_note_bend × per_note_range.
+        // Read the two channels separately (no fallback) so the master
+        // contribution is preserved even after the member channel's events
+        // were populated by an earlier per-note bend.
+        const float perNoteCents =
+            midiState.getMPEBendRangeForChannel(triggerChannel_) * 100.0f;
+        const float masterCents =
+            midiState.getMPEBendRangeForChannel(0) * 100.0f;
+
+        const EventVector& perNoteEvents = midiState.getPitchEventsRaw(triggerChannel_);
+        const EventVector& masterEvents = midiState.getPitchEventsRaw(0);
+
+        // Per-note contribution into pitchSpan.
+        const auto perNoteLambda = [perNoteCents](float bend) {
+            return bend * perNoteCents;
+        };
+        if (region_->bendStep > 1.0f)
+            linearEnvelope(perNoteEvents, pitchSpan, perNoteLambda, region_->bendStep);
+        else
+            linearEnvelope(perNoteEvents, pitchSpan, perNoteLambda);
+
+        // Master contribution into a scratch buffer, then summed onto pitchSpan.
+        auto& bufferPool = resources_.getBufferPool();
+        auto scratch = bufferPool.getBuffer(numFrames);
+        if (scratch) {
+            absl::Span<float> masterSpan = *scratch;
+            const auto masterLambda = [masterCents](float bend) {
+                return bend * masterCents;
+            };
+            if (region_->bendStep > 1.0f)
+                linearEnvelope(masterEvents, masterSpan, masterLambda, region_->bendStep);
+            else
+                linearEnvelope(masterEvents, masterSpan, masterLambda);
+            for (size_t i = 0; i < numFrames; ++i)
+                pitchSpan[i] += masterSpan[i];
+        }
+    }
     bendSmoother_.process(pitchSpan, pitchSpan);
 
     ModMatrix& mm = resources_.getModMatrix();

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -428,12 +428,7 @@ bool Voice::startVoice(Layer* layer, int delay, const TriggerEvent& event) noexc
     impl.region_ = &region;
 
     impl.triggerEvent_ = event;
-    // M2: channel field is plumbed but always master until channel-aware
-    // noteOn dispatch is wired (M3). When MPE input lands on member
-    // channels, this should be set from the dispatched channel so the
-    // voice's pitch/CC/aftertouch reads route to the right slot in
-    // MidiState's per-channel state.
-    impl.triggerChannel_ = 0;
+    impl.triggerChannel_ = event.channel;
     if (impl.triggerEvent_.type == TriggerEventType::CC)
         impl.triggerEvent_.number = region.pitchKeycenter;
 

--- a/src/sfizz/Voice.cpp
+++ b/src/sfizz/Voice.cpp
@@ -231,6 +231,15 @@ struct Voice::Impl
     SostenutoState sostenutoState_ { SostenutoState::Up };
 
     TriggerEvent triggerEvent_;
+    /**
+     * @brief MIDI channel (0..15) the voice was triggered on. Used to
+     * route per-voice modulation reads to the correct channel slot in
+     * MidiState. Default 0 (master) until channel-aware noteOn dispatch
+     * is added; populating this will let voices respond independently
+     * to per-note pitch bend / CC / aftertouch when MPE input is split
+     * across member channels.
+     */
+    int triggerChannel_ { 0 };
     absl::optional<int> triggerDelay_;
 
     float speedRatio_ { 1.0 };
@@ -419,6 +428,12 @@ bool Voice::startVoice(Layer* layer, int delay, const TriggerEvent& event) noexc
     impl.region_ = &region;
 
     impl.triggerEvent_ = event;
+    // M2: channel field is plumbed but always master until channel-aware
+    // noteOn dispatch is wired (M3). When MPE input lands on member
+    // channels, this should be set from the dispatched channel so the
+    // voice's pitch/CC/aftertouch reads route to the right slot in
+    // MidiState's per-channel state.
+    impl.triggerChannel_ = 0;
     if (impl.triggerEvent_.type == TriggerEventType::CC)
         impl.triggerEvent_.number = region.pitchKeycenter;
 
@@ -519,7 +534,7 @@ bool Voice::startVoice(Layer* layer, int delay, const TriggerEvent& event) noexc
     impl.sampleEnd_ = int(sampleEnd(region, midiState));
     impl.sampleSize_ = impl.sampleEnd_- impl.sourcePosition_ - 1;
     impl.bendSmoother_.setSmoothing(region.bendSmooth, impl.sampleRate_);
-    impl.bendSmoother_.reset(region.getBendInCents(midiState.getPitchBend()));
+    impl.bendSmoother_.reset(region.getBendInCents(midiState.getPitchBend(impl.triggerChannel_)));
 
     ModMatrix& modMatrix = resources.getModMatrix();
     modMatrix.initVoice(impl.id_, region.getId(), impl.initialDelay_);
@@ -839,12 +854,12 @@ void Voice::Impl::resetCrossfades() noexcept
     MidiState& midiState = resources_.getMidiState();
 
     for (const auto& mod : region_->crossfadeCCInRange) {
-        const auto value = midiState.getCCValue(mod.cc);
+        const auto value = midiState.getCCValue(triggerChannel_, mod.cc);
         xfadeValue *= crossfadeIn(mod.data, value, xfCurve);
     }
 
     for (const auto& mod : region_->crossfadeCCOutRange) {
-        const auto value = midiState.getCCValue(mod.cc);
+        const auto value = midiState.getCCValue(triggerChannel_, mod.cc);
         xfadeValue *= crossfadeOut(mod.data, value, xfCurve);
     }
 
@@ -869,7 +884,7 @@ void Voice::Impl::applyCrossfades(absl::Span<float> modulationSpan) noexcept
 
     bool canShortcut = true;
     for (const auto& mod : region_->crossfadeCCInRange) {
-        const auto& events = midiState.getCCEvents(mod.cc);
+        const auto& events = midiState.getCCEvents(triggerChannel_, mod.cc);
         canShortcut &= (events.size() == 1);
         linearEnvelope(events, *tempSpan, [&](float x) {
             return crossfadeIn(mod.data, x, xfCurve);
@@ -878,7 +893,7 @@ void Voice::Impl::applyCrossfades(absl::Span<float> modulationSpan) noexcept
     }
 
     for (const auto& mod : region_->crossfadeCCOutRange) {
-        const auto& events = midiState.getCCEvents(mod.cc);
+        const auto& events = midiState.getCCEvents(triggerChannel_, mod.cc);
         canShortcut &= (events.size() == 1);
         linearEnvelope(events, *tempSpan, [&](float x) {
             return crossfadeOut(mod.data, x, xfCurve);
@@ -1982,7 +1997,7 @@ void Voice::Impl::pitchEnvelope(absl::Span<float> pitchSpan) noexcept
     const size_t numFrames = pitchSpan.size();
 
     const MidiState& midiState = resources_.getMidiState();
-    const EventVector& events = midiState.getPitchEvents();
+    const EventVector& events = midiState.getPitchEvents(triggerChannel_);
     const auto bendLambda = [this](float bend) {
         return region_->getBendInCents(bend);
     };

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -134,10 +134,15 @@ public:
      * @brief Register a note-off event; this may trigger a release.
      *
      * @param delay
+     * @param channel  MPE / MIDI channel of the note-off (0 for master /
+     *                 legacy single-channel). Only voices that started on the
+     *                 matching channel are released; voices on other channels
+     *                 are unaffected. This is what keeps overlapping notes on
+     *                 different MPE member channels independent.
      * @param noteNumber
      * @param velocity
      */
-    void registerNoteOff(int delay, int noteNumber, float velocity) noexcept;
+    void registerNoteOff(int delay, int channel, int noteNumber, float velocity) noexcept;
     /**
      * @brief Register a CC event; this may trigger a release. If the voice is playing and its
      * region has CC modifiers, it will use this value to compute the CC envelope to apply to the

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -482,6 +482,9 @@ inline bool sisterVoices(const Voice* lhs, const Voice* rhs)
     if (lhsTrigger.type != rhsTrigger.type)
         return false;
 
+    if (lhsTrigger.channel != rhsTrigger.channel)
+        return false;
+
     return true;
 }
 
@@ -501,6 +504,9 @@ inline bool voiceOrdering(const Voice* lhs, const Voice* rhs)
 
     if (lhsTrigger.type != rhsTrigger.type)
         return lhsTrigger.type > rhsTrigger.type;
+
+    if (lhsTrigger.channel != rhsTrigger.channel)
+        return lhsTrigger.channel < rhsTrigger.channel;
 
     return false;
 }

--- a/src/sfizz/Voice.h
+++ b/src/sfizz/Voice.h
@@ -218,6 +218,18 @@ public:
      */
     bool released() const noexcept;
     /**
+     * @brief MPE 1.0 §2.2.6 / §2.2.7 / §2.2.8 released-note expression
+     * filter. Returns 0 (Lower Zone Manager Channel) once the voice is
+     * released if it was triggered on a Member Channel, otherwise the
+     * voice's trigger channel. Per-block expression readers (pitch bend,
+     * channel pressure, CC routes) should consult this rather than the
+     * raw trigger channel so a released voice stops responding to traffic
+     * on its old Member Channel — which the controller has by now
+     * reallocated to a fresh finger — while Manager Channel events still
+     * reach the release tail.
+     */
+    int expressionChannel() const noexcept;
+    /**
      * @brief Can the voice be reused (i.e. is it releasing after being killed or free)
      *
      * @return true

--- a/src/sfizz/VoiceManager.cpp
+++ b/src/sfizz/VoiceManager.cpp
@@ -144,13 +144,13 @@ void VoiceManager::setStealingAlgorithm(StealingAlgorithm algorithm)
     }
 }
 
-void VoiceManager::checkPolyphony(const Region* region, int delay, const TriggerEvent& triggerEvent) noexcept
+void VoiceManager::checkPolyphony(const Region* region, int delay, const TriggerEvent& triggerEvent, int preferredChannel) noexcept
 {
     checkNotePolyphony(region, delay, triggerEvent);
-    checkRegionPolyphony(region, delay);
-    checkGroupPolyphony(region, delay);
-    checkSetPolyphony(region, delay);
-    checkEnginePolyphony(delay);
+    checkRegionPolyphony(region, delay, preferredChannel);
+    checkGroupPolyphony(region, delay, preferredChannel);
+    checkSetPolyphony(region, delay, preferredChannel);
+    checkEnginePolyphony(delay, preferredChannel);
 }
 
 Voice* VoiceManager::findFreeVoice() noexcept
@@ -193,9 +193,9 @@ void VoiceManager::requireNumVoices(int numVoices, Resources& resources)
     }
 }
 
-void VoiceManager::checkRegionPolyphony(const Region* region, int delay) noexcept
+void VoiceManager::checkRegionPolyphony(const Region* region, int delay, int preferredChannel) noexcept
 {
-    Voice* candidate = stealer_->checkRegionPolyphony(region, absl::MakeSpan(activeVoices_));
+    Voice* candidate = stealer_->checkRegionPolyphony(region, absl::MakeSpan(activeVoices_), preferredChannel);
     SisterVoiceRing::offAllSisters(candidate, delay);
 }
 
@@ -254,29 +254,29 @@ bool VoiceManager::withinValidTimerRange(const Region* region, unsigned timestam
     return true;
 }
 
-void VoiceManager::checkGroupPolyphony(const Region* region, int delay) noexcept
+void VoiceManager::checkGroupPolyphony(const Region* region, int delay, int preferredChannel) noexcept
 {
     auto& group = polyphonyGroups_[region->group];
     Voice* candidate = stealer_->checkPolyphony(
-        absl::MakeSpan(group.getActiveVoices()), group.getPolyphonyLimit());
+        absl::MakeSpan(group.getActiveVoices()), group.getPolyphonyLimit(), preferredChannel);
     SisterVoiceRing::offAllSisters(candidate, delay);
 }
 
-void VoiceManager::checkSetPolyphony(const Region* region, int delay) noexcept
+void VoiceManager::checkSetPolyphony(const Region* region, int delay, int preferredChannel) noexcept
 {
     auto parent = region->parent;
     while (parent != nullptr) {
         Voice* candidate = stealer_->checkPolyphony(
-            absl::MakeSpan(parent->getActiveVoices()), parent->getPolyphonyLimit());
+            absl::MakeSpan(parent->getActiveVoices()), parent->getPolyphonyLimit(), preferredChannel);
         SisterVoiceRing::offAllSisters(candidate, delay);
         parent = parent->getParent();
     }
 }
 
-void VoiceManager::checkEnginePolyphony(int delay) noexcept
+void VoiceManager::checkEnginePolyphony(int delay, int preferredChannel) noexcept
 {
     Voice* candidate = stealer_->checkPolyphony(
-        absl::MakeSpan(activeVoices_), numRequiredVoices_);
+        absl::MakeSpan(activeVoices_), numRequiredVoices_, preferredChannel);
     SisterVoiceRing::offAllSisters(candidate, delay, true);
 }
 

--- a/src/sfizz/VoiceManager.h
+++ b/src/sfizz/VoiceManager.h
@@ -107,7 +107,7 @@ struct VoiceManager final : public Voice::StateListener
      * @param delay
      * @param triggerEvent
      */
-    void checkPolyphony(const Region* region, int delay, const TriggerEvent& triggerEvent) noexcept;
+    void checkPolyphony(const Region* region, int delay, const TriggerEvent& triggerEvent, int preferredChannel = -1) noexcept;
 
     /**
      * @brief Get the number of active voices
@@ -164,7 +164,7 @@ private:
      * @param region
      * @param delay
      */
-    void checkRegionPolyphony(const Region* region, int delay) noexcept;
+    void checkRegionPolyphony(const Region* region, int delay, int preferredChannel = -1) noexcept;
 
     /**
      * @brief Check the note polyphony, releasing voices if necessary
@@ -181,7 +181,7 @@ private:
      * @param region
      * @param delay
      */
-    void checkGroupPolyphony(const Region* region, int delay) noexcept;
+    void checkGroupPolyphony(const Region* region, int delay, int preferredChannel = -1) noexcept;
 
     /**
      * @brief Check the region set polyphony at all levels, releasing voices if necessary
@@ -189,14 +189,14 @@ private:
      * @param region
      * @param delay
      */
-    void checkSetPolyphony(const Region* region, int delay) noexcept;
+    void checkSetPolyphony(const Region* region, int delay, int preferredChannel = -1) noexcept;
 
     /**
      * @brief Check the engine polyphony, fast releasing voices if necessary
      *
      * @param delay
      */
-    void checkEnginePolyphony(int delay) noexcept;
+    void checkEnginePolyphony(int delay, int preferredChannel = -1) noexcept;
 
 public:
     // Vector shortcuts

--- a/src/sfizz/VoiceStealing.cpp
+++ b/src/sfizz/VoiceStealing.cpp
@@ -6,30 +6,46 @@ namespace sfz {
 /**
  * @brief Generic polyphony checker
  * A voice is counted as incrementing the voice count and "stealable" if voiceCond(voice) is true.
- * For each stealable voice, the voice becomes the stealing candidate if candidateCont(voice, candidate) is true.
+ * For each stealable voice, the voice becomes the stealing candidate if candidateCond(voice, candidate) is true.
+ *
+ * When preferredChannel >= 0, two candidates are tracked: one across all
+ * stealable voices, and one restricted to voices whose TriggerEvent.channel
+ * matches preferredChannel. If the polyphony cap is exceeded and a
+ * same-channel candidate exists, it is returned in preference to the
+ * cross-channel candidate. preferredChannel = -1 reproduces the original
+ * single-candidate behavior exactly.
  *
  * @tparam F
  * @tparam G
  * @param candidates
+ * @param polyphony
  * @param voiceCond a functor with signature bool(Voice* voice)
  * @param candidateCond a functor with signature bool(Voice* voice, Voice* candidate)
+ * @param preferredChannel see header
  * @return Voice*
  */
 template<class F, class G>
-Voice* genericPolyphonyCheck(absl::Span<Voice*> candidates, unsigned polyphony, F&& voiceCond, G&& candidateCond)
+Voice* genericPolyphonyCheck(absl::Span<Voice*> candidates, unsigned polyphony, F&& voiceCond, G&& candidateCond, int preferredChannel = -1)
 {
     Voice* candidate = nullptr;
+    Voice* sameChannelCandidate = nullptr;
     unsigned numPlaying = 0;
     for (const auto& voice : candidates) {
         if (voiceCond(voice)) {
             if (candidateCond(voice, candidate))
                 candidate = voice;
+            if (preferredChannel >= 0
+                && voice != nullptr
+                && voice->getTriggerEvent().channel == preferredChannel
+                && candidateCond(voice, sameChannelCandidate)) {
+                sameChannelCandidate = voice;
+            }
             numPlaying += 1;
         }
     }
 
     if (numPlaying >= polyphony)
-        return candidate;
+        return sameChannelCandidate ? sameChannelCandidate : candidate;
 
     return {};
 }
@@ -45,34 +61,38 @@ constexpr bool ignoreVoice(const Voice* voice)
     return (voice == nullptr || voice->offedOrFree());
 }
 
-Voice* FirstStealer::checkRegionPolyphony(const Region* region, absl::Span<Voice*> candidates)
+Voice* FirstStealer::checkRegionPolyphony(const Region* region, absl::Span<Voice*> candidates, int preferredChannel)
 {
     ASSERT(region);
     return genericPolyphonyCheck(candidates, region->polyphony,
         [=](const Voice* v) { return (!ignoreVoice(v) && v->getRegion() == region); },
-        [=](const Voice*, const Voice* c) { return c == nullptr; });
+        [=](const Voice*, const Voice* c) { return c == nullptr; },
+        preferredChannel);
 }
 
-Voice* FirstStealer::checkPolyphony(absl::Span<Voice*> candidates, unsigned maxPolyphony)
+Voice* FirstStealer::checkPolyphony(absl::Span<Voice*> candidates, unsigned maxPolyphony, int preferredChannel)
 {
     return genericPolyphonyCheck(candidates, maxPolyphony,
         [=](const Voice* v) { return (!ignoreVoice(v)); },
-        [=](const Voice*, const Voice* c) { return c == nullptr; });
+        [=](const Voice*, const Voice* c) { return c == nullptr; },
+        preferredChannel);
 }
 
-Voice* OldestStealer::checkRegionPolyphony(const Region* region, absl::Span<Voice*> candidates)
+Voice* OldestStealer::checkRegionPolyphony(const Region* region, absl::Span<Voice*> candidates, int preferredChannel)
 {
     ASSERT(region);
     return genericPolyphonyCheck(candidates, region->polyphony,
         [=](const Voice* v) { return (!ignoreVoice(v) && v->getRegion() == region); },
-        [=](const Voice* v, const Voice* c) { return (c == nullptr || v->getAge() > c->getAge()); });
+        [=](const Voice* v, const Voice* c) { return (c == nullptr || v->getAge() > c->getAge()); },
+        preferredChannel);
 }
 
-Voice* OldestStealer::checkPolyphony(absl::Span<Voice*> candidates, unsigned maxPolyphony)
+Voice* OldestStealer::checkPolyphony(absl::Span<Voice*> candidates, unsigned maxPolyphony, int preferredChannel)
 {
     return genericPolyphonyCheck(candidates, maxPolyphony,
         [=](const Voice* v) { return (!ignoreVoice(v)); },
-        [=](const Voice* v, const Voice* c) { return (c == nullptr || v->getAge() > c->getAge()); });
+        [=](const Voice* v, const Voice* c) { return (c == nullptr || v->getAge() > c->getAge()); },
+        preferredChannel);
 }
 
 /**
@@ -128,7 +148,28 @@ sfz::Voice* stealEnvelopeAndAge(absl::Span<Voice*> voices) noexcept
     return returnedVoice;
 }
 
-Voice* EnvelopeAndAgeStealer::checkRegionPolyphony(const Region* region, absl::Span<Voice*> candidates)
+/**
+ * @brief Run the envelope-and-age scoring on a candidate set, optionally
+ * preferring same-channel candidates first when preferredChannel >= 0.
+ * Falls back to the full candidate set if the same-channel set is empty.
+ */
+static sfz::Voice* stealEnvelopeAndAgeWithChannelPref(
+    std::vector<Voice*>& temp, int preferredChannel) noexcept
+{
+    if (preferredChannel >= 0) {
+        std::vector<Voice*> sameChannel;
+        sameChannel.reserve(temp.size());
+        for (Voice* v : temp) {
+            if (v != nullptr && v->getTriggerEvent().channel == preferredChannel)
+                sameChannel.push_back(v);
+        }
+        if (!sameChannel.empty())
+            return stealEnvelopeAndAge(absl::MakeSpan(sameChannel));
+    }
+    return stealEnvelopeAndAge(absl::MakeSpan(temp));
+}
+
+Voice* EnvelopeAndAgeStealer::checkRegionPolyphony(const Region* region, absl::Span<Voice*> candidates, int preferredChannel)
 {
     ASSERT(region);
     temp_.clear();
@@ -137,12 +178,12 @@ Voice* EnvelopeAndAgeStealer::checkRegionPolyphony(const Region* region, absl::S
     });
 
     if (temp_.size() >= region->polyphony)
-        return stealEnvelopeAndAge(absl::MakeSpan(temp_));
+        return stealEnvelopeAndAgeWithChannelPref(temp_, preferredChannel);
 
     return {};
 }
 
-Voice* EnvelopeAndAgeStealer::checkPolyphony(absl::Span<Voice*> candidates, unsigned maxPolyphony)
+Voice* EnvelopeAndAgeStealer::checkPolyphony(absl::Span<Voice*> candidates, unsigned maxPolyphony, int preferredChannel)
 {
     temp_.clear();
     absl::c_copy_if(candidates, std::back_inserter(temp_), [=](Voice* v) {
@@ -150,7 +191,7 @@ Voice* EnvelopeAndAgeStealer::checkPolyphony(absl::Span<Voice*> candidates, unsi
     });
 
     if (temp_.size() >= maxPolyphony)
-        return stealEnvelopeAndAge(absl::MakeSpan(temp_));
+        return stealEnvelopeAndAgeWithChannelPref(temp_, preferredChannel);
 
     return {};
 }

--- a/src/sfizz/VoiceStealing.h
+++ b/src/sfizz/VoiceStealing.h
@@ -31,39 +31,45 @@ public:
      *
      * @param region
      * @param candidates
+     * @param preferredChannel  if >= 0, the stealer prefers a victim
+     *        whose triggering MIDI channel matches this value, and only
+     *        falls back to a cross-channel victim if no same-channel
+     *        candidate is suitable. -1 means "no preference" (default —
+     *        preserves pre-MPE-fork stealing behavior).
      * @return Voice* a non-null voice if the region polyphony is not respected
      */
-    virtual Voice* checkRegionPolyphony(const Region* region, absl::Span<Voice*> candidates) = 0;
+    virtual Voice* checkRegionPolyphony(const Region* region, absl::Span<Voice*> candidates, int preferredChannel = -1) = 0;
     /**
-     * @brief Check that then polyphony is respected.
+     * @brief Check that the polyphony is respected.
      *
-     * @param region
      * @param candidates
-     * @return Voice* a non-null voice if the region polyphony is not respected
+     * @param maxPolyphony
+     * @param preferredChannel  see checkRegionPolyphony.
+     * @return Voice* a non-null voice if the polyphony is not respected
      */
-    virtual Voice* checkPolyphony(absl::Span<Voice*> candidates, unsigned maxPolyphony) = 0;
+    virtual Voice* checkPolyphony(absl::Span<Voice*> candidates, unsigned maxPolyphony, int preferredChannel = -1) = 0;
 };
 
 class FirstStealer final : public VoiceStealer
 {
 public:
-    Voice* checkRegionPolyphony(const Region* region, absl::Span<Voice*> candidates) final;
-    Voice* checkPolyphony(absl::Span<Voice*> candidates, unsigned maxPolyphony) final;
+    Voice* checkRegionPolyphony(const Region* region, absl::Span<Voice*> candidates, int preferredChannel = -1) final;
+    Voice* checkPolyphony(absl::Span<Voice*> candidates, unsigned maxPolyphony, int preferredChannel = -1) final;
 };
 
 class OldestStealer final : public VoiceStealer
 {
 public:
-    Voice* checkRegionPolyphony(const Region* region, absl::Span<Voice*> candidates) final;
-    Voice* checkPolyphony(absl::Span<Voice*> candidates, unsigned maxPolyphony) final;
+    Voice* checkRegionPolyphony(const Region* region, absl::Span<Voice*> candidates, int preferredChannel = -1) final;
+    Voice* checkPolyphony(absl::Span<Voice*> candidates, unsigned maxPolyphony, int preferredChannel = -1) final;
 };
 
 class EnvelopeAndAgeStealer final : public VoiceStealer
 {
 public:
     EnvelopeAndAgeStealer();
-    Voice* checkRegionPolyphony(const Region* region, absl::Span<Voice*> candidates) final;
-    Voice* checkPolyphony(absl::Span<Voice*> candidates, unsigned maxPolyphony) final;
+    Voice* checkRegionPolyphony(const Region* region, absl::Span<Voice*> candidates, int preferredChannel = -1) final;
+    Voice* checkPolyphony(absl::Span<Voice*> candidates, unsigned maxPolyphony, int preferredChannel = -1) final;
 private:
     std::vector<Voice*> temp_;
 };

--- a/src/sfizz/modulations/sources/ChannelAftertouch.cpp
+++ b/src/sfizz/modulations/sources/ChannelAftertouch.cpp
@@ -26,7 +26,10 @@ void ChannelAftertouchSource::generate(const ModKey& sourceKey, NumericId<Voice>
 {
     UNUSED(sourceKey);
     Voice* voice = manager_.getVoiceById(voiceId);
-    const int channel = voice ? voice->getTriggerEvent().channel : 0;
+    // MPE 1.0 §2.2.7: once released, the voice stops responding to
+    // Channel Pressure on its Member Channel; Manager-Channel CP still
+    // affects the release tail.
+    const int channel = voice ? voice->expressionChannel() : 0;
     const EventVector& events = midiState_.getChannelAftertouchEvents(channel);
     linearEnvelope(events, buffer, [](float x) { return x; });
 }

--- a/src/sfizz/modulations/sources/ChannelAftertouch.cpp
+++ b/src/sfizz/modulations/sources/ChannelAftertouch.cpp
@@ -11,9 +11,8 @@
 namespace sfz {
 
 ChannelAftertouchSource::ChannelAftertouchSource(VoiceManager& manager, MidiState& state)
-    : midiState_(state)
+    : midiState_(state), manager_(manager)
 {
-    (void)manager;
 }
 
 void ChannelAftertouchSource::init(const ModKey& sourceKey, NumericId<Voice> voiceId, unsigned delay)
@@ -26,8 +25,9 @@ void ChannelAftertouchSource::init(const ModKey& sourceKey, NumericId<Voice> voi
 void ChannelAftertouchSource::generate(const ModKey& sourceKey, NumericId<Voice> voiceId, absl::Span<float> buffer)
 {
     UNUSED(sourceKey);
-    UNUSED(voiceId);
-    const EventVector& events = midiState_.getChannelAftertouchEvents();
+    Voice* voice = manager_.getVoiceById(voiceId);
+    const int channel = voice ? voice->getTriggerEvent().channel : 0;
+    const EventVector& events = midiState_.getChannelAftertouchEvents(channel);
     linearEnvelope(events, buffer, [](float x) { return x; });
 }
 

--- a/src/sfizz/modulations/sources/ChannelAftertouch.h
+++ b/src/sfizz/modulations/sources/ChannelAftertouch.h
@@ -20,6 +20,7 @@ public:
 
 private:
     MidiState& midiState_;
+    VoiceManager& manager_;
 };
 
 } // namespace sfz

--- a/src/sfizz/modulations/sources/Controller.cpp
+++ b/src/sfizz/modulations/sources/Controller.cpp
@@ -186,13 +186,17 @@ void ControllerSource::generate(const ModKey& sourceKey, NumericId<Voice> voiceI
         }
     case ExtendedCCs::pitchBend: // fallthrough
     case ExtendedCCs::channelAftertouch: {
-            const EventVector& events = ms.getCCEvents(p.cc);
+            const auto voice = impl_->voiceManager_->getVoiceById(voiceId);
+            const int channel = voice ? voice->getTriggerEvent().channel : 0;
+            const EventVector& events = ms.getCCEvents(channel, p.cc);
             linearEnvelope(events, buffer, [](float x) { return x; }, p.step);
             canShortcut = events.size() == 1;
             break;
         }
     default: {
-            const EventVector& events = ms.getCCEvents(p.cc);
+            const auto voice = impl_->voiceManager_->getVoiceById(voiceId);
+            const int channel = voice ? voice->getTriggerEvent().channel : 0;
+            const EventVector& events = ms.getCCEvents(channel, p.cc);
             linearEnvelope(events, buffer, transformValue, p.step);
             canShortcut = events.size() == 1;
         }

--- a/src/sfizz/modulations/sources/Controller.cpp
+++ b/src/sfizz/modulations/sources/Controller.cpp
@@ -187,7 +187,11 @@ void ControllerSource::generate(const ModKey& sourceKey, NumericId<Voice> voiceI
     case ExtendedCCs::pitchBend: // fallthrough
     case ExtendedCCs::channelAftertouch: {
             const auto voice = impl_->voiceManager_->getVoiceById(voiceId);
-            const int channel = voice ? voice->getTriggerEvent().channel : 0;
+            // MPE 1.0 §2.2.6 / §2.2.7: a released note must stop reacting
+            // to Member-Channel pitch bend / channel pressure (the
+            // controller reallocates the channel to the next finger);
+            // Manager-Channel traffic continues to reach the release tail.
+            const int channel = voice ? voice->expressionChannel() : 0;
             const EventVector& events = ms.getCCEvents(channel, p.cc);
             linearEnvelope(events, buffer, [](float x) { return x; }, p.step);
             canShortcut = events.size() == 1;
@@ -195,7 +199,14 @@ void ControllerSource::generate(const ModKey& sourceKey, NumericId<Voice> voiceI
         }
     default: {
             const auto voice = impl_->voiceManager_->getVoiceById(voiceId);
-            const int channel = voice ? voice->getTriggerEvent().channel : 0;
+            // MPE 1.0 §2.2.8 (and the same channel-reuse argument that
+            // applies to PB / CP): a released note must stop reacting to
+            // Member-Channel CC traffic — CC#74 in particular, but the
+            // engine doesn't know a priori which CCs a patch uses for
+            // per-note expression, so all CCs are gated uniformly. The
+            // Manager-only filter from MPE 1.0 §2.3 (in Synth) already
+            // drops pedal / mode / Bank Select before they reach here.
+            const int channel = voice ? voice->expressionChannel() : 0;
             const EventVector& events = ms.getCCEvents(channel, p.cc);
             linearEnvelope(events, buffer, transformValue, p.step);
             canShortcut = events.size() == 1;

--- a/src/sfizz/modulations/sources/PolyAftertouch.cpp
+++ b/src/sfizz/modulations/sources/PolyAftertouch.cpp
@@ -34,7 +34,7 @@ void PolyAftertouchSource::generate(const ModKey& sourceKey, NumericId<Voice> vo
 
     const int noteNumber = voice->getTriggerEvent().number;
     // Defense-in-depth: MPE 1.0 §2.2.7 prohibits Poly Key Pressure on
-    // Member Channels (Synth::hdPolyAftertouchMPE drops it before it
+    // Member Channels (Synth::hdPolyAftertouch drops it before it
     // reaches MidiState), and once released a voice should not be reading
     // its old Member Channel anyway since the controller will have
     // reallocated it. Route through the released-note channel gate so

--- a/src/sfizz/modulations/sources/PolyAftertouch.cpp
+++ b/src/sfizz/modulations/sources/PolyAftertouch.cpp
@@ -33,8 +33,9 @@ void PolyAftertouchSource::generate(const ModKey& sourceKey, NumericId<Voice> vo
     }
 
     const int noteNumber = voice->getTriggerEvent().number;
+    const int channel    = voice->getTriggerEvent().channel;
 
-    const EventVector& events = midiState_.getPolyAftertouchEvents(noteNumber);
+    const EventVector& events = midiState_.getPolyAftertouchEvents(channel, noteNumber);
     linearEnvelope(events, buffer, [](float x) { return x; });
 }
 

--- a/src/sfizz/modulations/sources/PolyAftertouch.cpp
+++ b/src/sfizz/modulations/sources/PolyAftertouch.cpp
@@ -33,7 +33,13 @@ void PolyAftertouchSource::generate(const ModKey& sourceKey, NumericId<Voice> vo
     }
 
     const int noteNumber = voice->getTriggerEvent().number;
-    const int channel    = voice->getTriggerEvent().channel;
+    // Defense-in-depth: MPE 1.0 §2.2.7 prohibits Poly Key Pressure on
+    // Member Channels (Synth::hdPolyAftertouchMPE drops it before it
+    // reaches MidiState), and once released a voice should not be reading
+    // its old Member Channel anyway since the controller will have
+    // reallocated it. Route through the released-note channel gate so
+    // both rules hold even if the engine later relaxes one.
+    const int channel = voice->expressionChannel();
 
     const EventVector& events = midiState_.getPolyAftertouchEvents(channel, noteNumber);
     linearEnvelope(events, buffer, [](float x) { return x; });

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -350,6 +350,11 @@ int sfz::Sfizz::getDroppedPolyKpOnMemberCount() const noexcept
     return synth->synth.getDroppedPolyKpOnMemberCount();
 }
 
+int sfz::Sfizz::getDroppedManagerOnlyMessageCount() const noexcept
+{
+    return synth->synth.getDroppedManagerOnlyMessageCount();
+}
+
 void sfz::Sfizz::tempo(int delay, float secondsPerBeat) noexcept
 {
     synth->synth.tempo(delay, secondsPerBeat);

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -345,6 +345,11 @@ bool sfz::Sfizz::getMPEPerNoteBendAutoConfigEnabled() const noexcept
     return synth->synth.getMPEPerNoteBendAutoConfigEnabled();
 }
 
+int sfz::Sfizz::getDroppedPolyKpOnMemberCount() const noexcept
+{
+    return synth->synth.getDroppedPolyKpOnMemberCount();
+}
+
 void sfz::Sfizz::tempo(int delay, float secondsPerBeat) noexcept
 {
     synth->synth.tempo(delay, secondsPerBeat);

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -240,64 +240,64 @@ void sfz::Sfizz::hdPolyAftertouch(int delay, int noteNumber, float aftertouch) n
     synth->synth.hdPolyAftertouch(delay, noteNumber, aftertouch);
 }
 
-void sfz::Sfizz::noteOnMPE(int delay, int channel, int noteNumber, int velocity) noexcept
+void sfz::Sfizz::noteOn(int delay, int channel, int noteNumber, int velocity) noexcept
 {
-    synth->synth.noteOnMPE(delay, channel, noteNumber, velocity);
+    synth->synth.noteOn(delay, channel, noteNumber, velocity);
 }
 
-void sfz::Sfizz::hdNoteOnMPE(int delay, int channel, int noteNumber, float velocity) noexcept
+void sfz::Sfizz::hdNoteOn(int delay, int channel, int noteNumber, float velocity) noexcept
 {
-    synth->synth.hdNoteOnMPE(delay, channel, noteNumber, velocity);
+    synth->synth.hdNoteOn(delay, channel, noteNumber, velocity);
 }
 
-void sfz::Sfizz::noteOffMPE(int delay, int channel, int noteNumber, int velocity) noexcept
+void sfz::Sfizz::noteOff(int delay, int channel, int noteNumber, int velocity) noexcept
 {
-    synth->synth.noteOffMPE(delay, channel, noteNumber, velocity);
+    synth->synth.noteOff(delay, channel, noteNumber, velocity);
 }
 
-void sfz::Sfizz::hdNoteOffMPE(int delay, int channel, int noteNumber, float velocity) noexcept
+void sfz::Sfizz::hdNoteOff(int delay, int channel, int noteNumber, float velocity) noexcept
 {
-    synth->synth.hdNoteOffMPE(delay, channel, noteNumber, velocity);
+    synth->synth.hdNoteOff(delay, channel, noteNumber, velocity);
 }
 
-void sfz::Sfizz::ccMPE(int delay, int channel, int ccNumber, int ccValue) noexcept
+void sfz::Sfizz::cc(int delay, int channel, int ccNumber, int ccValue) noexcept
 {
-    synth->synth.ccMPE(delay, channel, ccNumber, ccValue);
+    synth->synth.cc(delay, channel, ccNumber, ccValue);
 }
 
-void sfz::Sfizz::hdccMPE(int delay, int channel, int ccNumber, float normValue) noexcept
+void sfz::Sfizz::hdcc(int delay, int channel, int ccNumber, float normValue) noexcept
 {
-    synth->synth.hdccMPE(delay, channel, ccNumber, normValue);
+    synth->synth.hdcc(delay, channel, ccNumber, normValue);
 }
 
-void sfz::Sfizz::pitchWheelMPE(int delay, int channel, int pitch) noexcept
+void sfz::Sfizz::pitchWheel(int delay, int channel, int pitch) noexcept
 {
-    synth->synth.pitchWheelMPE(delay, channel, pitch);
+    synth->synth.pitchWheel(delay, channel, pitch);
 }
 
-void sfz::Sfizz::hdPitchWheelMPE(int delay, int channel, float pitch) noexcept
+void sfz::Sfizz::hdPitchWheel(int delay, int channel, float pitch) noexcept
 {
-    synth->synth.hdPitchWheelMPE(delay, channel, pitch);
+    synth->synth.hdPitchWheel(delay, channel, pitch);
 }
 
-void sfz::Sfizz::channelAftertouchMPE(int delay, int channel, int aftertouch) noexcept
+void sfz::Sfizz::channelAftertouch(int delay, int channel, int aftertouch) noexcept
 {
-    synth->synth.channelAftertouchMPE(delay, channel, aftertouch);
+    synth->synth.channelAftertouch(delay, channel, aftertouch);
 }
 
-void sfz::Sfizz::hdChannelAftertouchMPE(int delay, int channel, float normAftertouch) noexcept
+void sfz::Sfizz::hdChannelAftertouch(int delay, int channel, float normAftertouch) noexcept
 {
-    synth->synth.hdChannelAftertouchMPE(delay, channel, normAftertouch);
+    synth->synth.hdChannelAftertouch(delay, channel, normAftertouch);
 }
 
-void sfz::Sfizz::polyAftertouchMPE(int delay, int channel, int noteNumber, int aftertouch) noexcept
+void sfz::Sfizz::polyAftertouch(int delay, int channel, int noteNumber, int aftertouch) noexcept
 {
-    synth->synth.polyAftertouchMPE(delay, channel, noteNumber, aftertouch);
+    synth->synth.polyAftertouch(delay, channel, noteNumber, aftertouch);
 }
 
-void sfz::Sfizz::hdPolyAftertouchMPE(int delay, int channel, int noteNumber, float normAftertouch) noexcept
+void sfz::Sfizz::hdPolyAftertouch(int delay, int channel, int noteNumber, float normAftertouch) noexcept
 {
-    synth->synth.hdPolyAftertouchMPE(delay, channel, noteNumber, normAftertouch);
+    synth->synth.hdPolyAftertouch(delay, channel, noteNumber, normAftertouch);
 }
 
 void sfz::Sfizz::setMPEEnabled(bool enabled) noexcept

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -240,6 +240,91 @@ void sfz::Sfizz::hdPolyAftertouch(int delay, int noteNumber, float aftertouch) n
     synth->synth.hdPolyAftertouch(delay, noteNumber, aftertouch);
 }
 
+void sfz::Sfizz::noteOnMPE(int delay, int channel, int noteNumber, int velocity) noexcept
+{
+    synth->synth.noteOnMPE(delay, channel, noteNumber, velocity);
+}
+
+void sfz::Sfizz::hdNoteOnMPE(int delay, int channel, int noteNumber, float velocity) noexcept
+{
+    synth->synth.hdNoteOnMPE(delay, channel, noteNumber, velocity);
+}
+
+void sfz::Sfizz::noteOffMPE(int delay, int channel, int noteNumber, int velocity) noexcept
+{
+    synth->synth.noteOffMPE(delay, channel, noteNumber, velocity);
+}
+
+void sfz::Sfizz::hdNoteOffMPE(int delay, int channel, int noteNumber, float velocity) noexcept
+{
+    synth->synth.hdNoteOffMPE(delay, channel, noteNumber, velocity);
+}
+
+void sfz::Sfizz::ccMPE(int delay, int channel, int ccNumber, int ccValue) noexcept
+{
+    synth->synth.ccMPE(delay, channel, ccNumber, ccValue);
+}
+
+void sfz::Sfizz::hdccMPE(int delay, int channel, int ccNumber, float normValue) noexcept
+{
+    synth->synth.hdccMPE(delay, channel, ccNumber, normValue);
+}
+
+void sfz::Sfizz::pitchWheelMPE(int delay, int channel, int pitch) noexcept
+{
+    synth->synth.pitchWheelMPE(delay, channel, pitch);
+}
+
+void sfz::Sfizz::hdPitchWheelMPE(int delay, int channel, float pitch) noexcept
+{
+    synth->synth.hdPitchWheelMPE(delay, channel, pitch);
+}
+
+void sfz::Sfizz::channelAftertouchMPE(int delay, int channel, int aftertouch) noexcept
+{
+    synth->synth.channelAftertouchMPE(delay, channel, aftertouch);
+}
+
+void sfz::Sfizz::hdChannelAftertouchMPE(int delay, int channel, float normAftertouch) noexcept
+{
+    synth->synth.hdChannelAftertouchMPE(delay, channel, normAftertouch);
+}
+
+void sfz::Sfizz::polyAftertouchMPE(int delay, int channel, int noteNumber, int aftertouch) noexcept
+{
+    synth->synth.polyAftertouchMPE(delay, channel, noteNumber, aftertouch);
+}
+
+void sfz::Sfizz::hdPolyAftertouchMPE(int delay, int channel, int noteNumber, float normAftertouch) noexcept
+{
+    synth->synth.hdPolyAftertouchMPE(delay, channel, noteNumber, normAftertouch);
+}
+
+void sfz::Sfizz::setMPEEnabled(bool enabled) noexcept
+{
+    synth->synth.setMPEEnabled(enabled);
+}
+
+bool sfz::Sfizz::getMPEEnabled() const noexcept
+{
+    return synth->synth.getMPEEnabled();
+}
+
+void sfz::Sfizz::setMPEPitchBendRange(float masterSemitones, float perNoteSemitones) noexcept
+{
+    synth->synth.setMPEPitchBendRange(masterSemitones, perNoteSemitones);
+}
+
+float sfz::Sfizz::getMPEMasterPitchBendRange() const noexcept
+{
+    return synth->synth.getMPEMasterPitchBendRange();
+}
+
+float sfz::Sfizz::getMPEPerNotePitchBendRange() const noexcept
+{
+    return synth->synth.getMPEPerNotePitchBendRange();
+}
+
 void sfz::Sfizz::tempo(int delay, float secondsPerBeat) noexcept
 {
     synth->synth.tempo(delay, secondsPerBeat);

--- a/src/sfizz/sfizz.cpp
+++ b/src/sfizz/sfizz.cpp
@@ -325,6 +325,26 @@ float sfz::Sfizz::getMPEPerNotePitchBendRange() const noexcept
     return synth->synth.getMPEPerNotePitchBendRange();
 }
 
+void sfz::Sfizz::setMPEMasterBendAutoConfigEnabled(bool enabled) noexcept
+{
+    synth->synth.setMPEMasterBendAutoConfigEnabled(enabled);
+}
+
+bool sfz::Sfizz::getMPEMasterBendAutoConfigEnabled() const noexcept
+{
+    return synth->synth.getMPEMasterBendAutoConfigEnabled();
+}
+
+void sfz::Sfizz::setMPEPerNoteBendAutoConfigEnabled(bool enabled) noexcept
+{
+    synth->synth.setMPEPerNoteBendAutoConfigEnabled(enabled);
+}
+
+bool sfz::Sfizz::getMPEPerNoteBendAutoConfigEnabled() const noexcept
+{
+    return synth->synth.getMPEPerNoteBendAutoConfigEnabled();
+}
+
 void sfz::Sfizz::tempo(int delay, float secondsPerBeat) noexcept
 {
     synth->synth.tempo(delay, secondsPerBeat);

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -242,6 +242,22 @@ float sfizz_get_mpe_per_note_pitch_bend_range(sfizz_synth_t* synth)
 {
     return synth->synth.getMPEPerNotePitchBendRange();
 }
+void sfizz_set_mpe_master_bend_auto_config_enabled(sfizz_synth_t* synth, bool enabled)
+{
+    synth->synth.setMPEMasterBendAutoConfigEnabled(enabled);
+}
+bool sfizz_get_mpe_master_bend_auto_config_enabled(sfizz_synth_t* synth)
+{
+    return synth->synth.getMPEMasterBendAutoConfigEnabled();
+}
+void sfizz_set_mpe_per_note_bend_auto_config_enabled(sfizz_synth_t* synth, bool enabled)
+{
+    synth->synth.setMPEPerNoteBendAutoConfigEnabled(enabled);
+}
+bool sfizz_get_mpe_per_note_bend_auto_config_enabled(sfizz_synth_t* synth)
+{
+    return synth->synth.getMPEPerNoteBendAutoConfigEnabled();
+}
 void sfizz_send_tempo(sfizz_synth_t* synth, int delay, float seconds_per_quarter)
 {
     synth->synth.tempo(delay, seconds_per_quarter);

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -258,6 +258,10 @@ bool sfizz_get_mpe_per_note_bend_auto_config_enabled(sfizz_synth_t* synth)
 {
     return synth->synth.getMPEPerNoteBendAutoConfigEnabled();
 }
+int sfizz_get_dropped_poly_kp_on_member_count(sfizz_synth_t* synth)
+{
+    return synth->synth.getDroppedPolyKpOnMemberCount();
+}
 void sfizz_send_tempo(sfizz_synth_t* synth, int delay, float seconds_per_quarter)
 {
     synth->synth.tempo(delay, seconds_per_quarter);

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -174,53 +174,53 @@ void sfizz_send_hd_poly_aftertouch(sfizz_synth_t* synth, int delay, int note_num
 {
     synth->synth.hdPolyAftertouch(delay, note_number, aftertouch);
 }
-void sfizz_send_note_on_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, int velocity)
+void sfizz_send_note_on_channel(sfizz_synth_t* synth, int delay, int channel, int note_number, int velocity)
 {
-    synth->synth.noteOnMPE(delay, channel, note_number, velocity);
+    synth->synth.noteOn(delay, channel, note_number, velocity);
 }
-void sfizz_send_hd_note_on_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, float velocity)
+void sfizz_send_hd_note_on_channel(sfizz_synth_t* synth, int delay, int channel, int note_number, float velocity)
 {
-    synth->synth.hdNoteOnMPE(delay, channel, note_number, velocity);
+    synth->synth.hdNoteOn(delay, channel, note_number, velocity);
 }
-void sfizz_send_note_off_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, int velocity)
+void sfizz_send_note_off_channel(sfizz_synth_t* synth, int delay, int channel, int note_number, int velocity)
 {
-    synth->synth.noteOffMPE(delay, channel, note_number, velocity);
+    synth->synth.noteOff(delay, channel, note_number, velocity);
 }
-void sfizz_send_hd_note_off_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, float velocity)
+void sfizz_send_hd_note_off_channel(sfizz_synth_t* synth, int delay, int channel, int note_number, float velocity)
 {
-    synth->synth.hdNoteOffMPE(delay, channel, note_number, velocity);
+    synth->synth.hdNoteOff(delay, channel, note_number, velocity);
 }
-void sfizz_send_cc_mpe(sfizz_synth_t* synth, int delay, int channel, int cc_number, int cc_value)
+void sfizz_send_cc_channel(sfizz_synth_t* synth, int delay, int channel, int cc_number, int cc_value)
 {
-    synth->synth.ccMPE(delay, channel, cc_number, cc_value);
+    synth->synth.cc(delay, channel, cc_number, cc_value);
 }
-void sfizz_send_hdcc_mpe(sfizz_synth_t* synth, int delay, int channel, int cc_number, float norm_value)
+void sfizz_send_hdcc_channel(sfizz_synth_t* synth, int delay, int channel, int cc_number, float norm_value)
 {
-    synth->synth.hdccMPE(delay, channel, cc_number, norm_value);
+    synth->synth.hdcc(delay, channel, cc_number, norm_value);
 }
-void sfizz_send_pitch_wheel_mpe(sfizz_synth_t* synth, int delay, int channel, int pitch)
+void sfizz_send_pitch_wheel_channel(sfizz_synth_t* synth, int delay, int channel, int pitch)
 {
-    synth->synth.pitchWheelMPE(delay, channel, pitch);
+    synth->synth.pitchWheel(delay, channel, pitch);
 }
-void sfizz_send_hd_pitch_wheel_mpe(sfizz_synth_t* synth, int delay, int channel, float pitch)
+void sfizz_send_hd_pitch_wheel_channel(sfizz_synth_t* synth, int delay, int channel, float pitch)
 {
-    synth->synth.hdPitchWheelMPE(delay, channel, pitch);
+    synth->synth.hdPitchWheel(delay, channel, pitch);
 }
-void sfizz_send_channel_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, int aftertouch)
+void sfizz_send_channel_aftertouch_channel(sfizz_synth_t* synth, int delay, int channel, int aftertouch)
 {
-    synth->synth.channelAftertouchMPE(delay, channel, aftertouch);
+    synth->synth.channelAftertouch(delay, channel, aftertouch);
 }
-void sfizz_send_hd_channel_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, float aftertouch)
+void sfizz_send_hd_channel_aftertouch_channel(sfizz_synth_t* synth, int delay, int channel, float aftertouch)
 {
-    synth->synth.hdChannelAftertouchMPE(delay, channel, aftertouch);
+    synth->synth.hdChannelAftertouch(delay, channel, aftertouch);
 }
-void sfizz_send_poly_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, int aftertouch)
+void sfizz_send_poly_aftertouch_channel(sfizz_synth_t* synth, int delay, int channel, int note_number, int aftertouch)
 {
-    synth->synth.polyAftertouchMPE(delay, channel, note_number, aftertouch);
+    synth->synth.polyAftertouch(delay, channel, note_number, aftertouch);
 }
-void sfizz_send_hd_poly_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, float aftertouch)
+void sfizz_send_hd_poly_aftertouch_channel(sfizz_synth_t* synth, int delay, int channel, int note_number, float aftertouch)
 {
-    synth->synth.hdPolyAftertouchMPE(delay, channel, note_number, aftertouch);
+    synth->synth.hdPolyAftertouch(delay, channel, note_number, aftertouch);
 }
 void sfizz_set_mpe_enabled(sfizz_synth_t* synth, bool enabled)
 {

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -174,6 +174,74 @@ void sfizz_send_hd_poly_aftertouch(sfizz_synth_t* synth, int delay, int note_num
 {
     synth->synth.hdPolyAftertouch(delay, note_number, aftertouch);
 }
+void sfizz_send_note_on_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, int velocity)
+{
+    synth->synth.noteOnMPE(delay, channel, note_number, velocity);
+}
+void sfizz_send_hd_note_on_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, float velocity)
+{
+    synth->synth.hdNoteOnMPE(delay, channel, note_number, velocity);
+}
+void sfizz_send_note_off_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, int velocity)
+{
+    synth->synth.noteOffMPE(delay, channel, note_number, velocity);
+}
+void sfizz_send_hd_note_off_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, float velocity)
+{
+    synth->synth.hdNoteOffMPE(delay, channel, note_number, velocity);
+}
+void sfizz_send_cc_mpe(sfizz_synth_t* synth, int delay, int channel, int cc_number, int cc_value)
+{
+    synth->synth.ccMPE(delay, channel, cc_number, cc_value);
+}
+void sfizz_send_hdcc_mpe(sfizz_synth_t* synth, int delay, int channel, int cc_number, float norm_value)
+{
+    synth->synth.hdccMPE(delay, channel, cc_number, norm_value);
+}
+void sfizz_send_pitch_wheel_mpe(sfizz_synth_t* synth, int delay, int channel, int pitch)
+{
+    synth->synth.pitchWheelMPE(delay, channel, pitch);
+}
+void sfizz_send_hd_pitch_wheel_mpe(sfizz_synth_t* synth, int delay, int channel, float pitch)
+{
+    synth->synth.hdPitchWheelMPE(delay, channel, pitch);
+}
+void sfizz_send_channel_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, int aftertouch)
+{
+    synth->synth.channelAftertouchMPE(delay, channel, aftertouch);
+}
+void sfizz_send_hd_channel_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, float aftertouch)
+{
+    synth->synth.hdChannelAftertouchMPE(delay, channel, aftertouch);
+}
+void sfizz_send_poly_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, int aftertouch)
+{
+    synth->synth.polyAftertouchMPE(delay, channel, note_number, aftertouch);
+}
+void sfizz_send_hd_poly_aftertouch_mpe(sfizz_synth_t* synth, int delay, int channel, int note_number, float aftertouch)
+{
+    synth->synth.hdPolyAftertouchMPE(delay, channel, note_number, aftertouch);
+}
+void sfizz_set_mpe_enabled(sfizz_synth_t* synth, bool enabled)
+{
+    synth->synth.setMPEEnabled(enabled);
+}
+bool sfizz_get_mpe_enabled(sfizz_synth_t* synth)
+{
+    return synth->synth.getMPEEnabled();
+}
+void sfizz_set_mpe_pitch_bend_range(sfizz_synth_t* synth, float master_semitones, float per_note_semitones)
+{
+    synth->synth.setMPEPitchBendRange(master_semitones, per_note_semitones);
+}
+float sfizz_get_mpe_master_pitch_bend_range(sfizz_synth_t* synth)
+{
+    return synth->synth.getMPEMasterPitchBendRange();
+}
+float sfizz_get_mpe_per_note_pitch_bend_range(sfizz_synth_t* synth)
+{
+    return synth->synth.getMPEPerNotePitchBendRange();
+}
 void sfizz_send_tempo(sfizz_synth_t* synth, int delay, float seconds_per_quarter)
 {
     synth->synth.tempo(delay, seconds_per_quarter);

--- a/src/sfizz/sfizz_wrapper.cpp
+++ b/src/sfizz/sfizz_wrapper.cpp
@@ -262,6 +262,10 @@ int sfizz_get_dropped_poly_kp_on_member_count(sfizz_synth_t* synth)
 {
     return synth->synth.getDroppedPolyKpOnMemberCount();
 }
+int sfizz_get_dropped_manager_only_message_count(sfizz_synth_t* synth)
+{
+    return synth->synth.getDroppedManagerOnlyMessageCount();
+}
 void sfizz_send_tempo(sfizz_synth_t* synth, int delay, float seconds_per_quarter)
 {
     synth->synth.tempo(delay, seconds_per_quarter);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SFIZZ_TEST_SOURCES
     SIMDHelpersT.cpp
     FilesT.cpp
     MidiStateT.cpp
+    MPET.cpp
     InterpolatorsT.cpp
     SmoothersT.cpp
     PolyphonyT.cpp

--- a/tests/MPET.cpp
+++ b/tests/MPET.cpp
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+// This code is part of the sfizz library and is licensed under a BSD 2-clause
+// license. You should have receive a LICENSE.md file along with the code.
+// If not, contact the sfizz maintainers at https://github.com/sfztools/sfizz
+
+/**
+ * @brief MPE (MIDI Polyphonic Expression) regression tests.
+ *
+ * Covers per-channel state isolation in MidiState, channel-aware writes
+ * via the Synth::*MPE public API, propagation of channel into TriggerEvent
+ * and Voice, and same-channel-preference behavior of voice stealing when
+ * MPE is enabled. With MPE disabled (the default) all paths reduce to
+ * master-channel reads and the existing single-channel tests continue to
+ * pass unchanged.
+ */
+
+#include "sfizz/MidiState.h"
+#include "sfizz/Synth.h"
+#include "sfizz/Voice.h"
+#include "sfizz/SfzHelpers.h"
+#include "catch2/catch.hpp"
+using namespace Catch::literals;
+using namespace sfz::literals;
+
+// =============================================================================
+// MidiState: per-channel writes/reads in isolation
+// =============================================================================
+
+TEST_CASE("[MPE] MidiState pitch bend is per-channel")
+{
+    sfz::MidiState state;
+    state.pitchBendEvent(0, /*channel=*/1, 0.3f);
+    state.pitchBendEvent(0, /*channel=*/2, -0.4f);
+    state.pitchBendEvent(0, /*channel=*/3, 0.7f);
+
+    REQUIRE(state.getPitchBend(1) == 0.3f);
+    REQUIRE(state.getPitchBend(2) == -0.4f);
+    REQUIRE(state.getPitchBend(3) == 0.7f);
+    // Master channel was not written, so it should still read 0.
+    REQUIRE(state.getPitchBend(0) == 0.0f);
+    // The single-arg overload defaults to master.
+    REQUIRE(state.getPitchBend() == 0.0f);
+}
+
+TEST_CASE("[MPE] MidiState CC values are per-channel")
+{
+    sfz::MidiState state;
+    state.ccEvent(0, /*channel=*/1, 74, 0.3f);
+    state.ccEvent(0, /*channel=*/2, 74, 0.7f);
+    state.ccEvent(0, /*channel=*/2, 11, 0.5f);
+
+    REQUIRE(state.getCCValue(1, 74) == 0.3f);
+    REQUIRE(state.getCCValue(2, 74) == 0.7f);
+    REQUIRE(state.getCCValue(2, 11) == 0.5f);
+    // Channel 1's CC11 was never written.
+    REQUIRE(state.getCCValue(1, 11) == 0.0f);
+    // Master untouched.
+    REQUIRE(state.getCCValue(0, 74) == 0.0f);
+    REQUIRE(state.getCCValue(74) == 0.0f);
+}
+
+TEST_CASE("[MPE] MidiState channel aftertouch is per-channel")
+{
+    sfz::MidiState state;
+    state.channelAftertouchEvent(0, /*channel=*/1, 0.3f);
+    state.channelAftertouchEvent(0, /*channel=*/2, 0.7f);
+
+    REQUIRE(state.getChannelAftertouch(1) == 0.3f);
+    REQUIRE(state.getChannelAftertouch(2) == 0.7f);
+    REQUIRE(state.getChannelAftertouch(0) == 0.0f);
+    REQUIRE(state.getChannelAftertouch() == 0.0f);
+}
+
+TEST_CASE("[MPE] MidiState polyphonic aftertouch is per-channel")
+{
+    sfz::MidiState state;
+    state.polyAftertouchEvent(0, /*channel=*/1, /*note=*/60, 0.3f);
+    state.polyAftertouchEvent(0, /*channel=*/2, /*note=*/60, 0.7f);
+    state.polyAftertouchEvent(0, /*channel=*/2, /*note=*/64, 0.5f);
+
+    REQUIRE(state.getPolyAftertouch(1, 60) == 0.3f);
+    REQUIRE(state.getPolyAftertouch(2, 60) == 0.7f);
+    REQUIRE(state.getPolyAftertouch(2, 64) == 0.5f);
+    REQUIRE(state.getPolyAftertouch(1, 64) == 0.0f);
+    REQUIRE(state.getPolyAftertouch(0, 60) == 0.0f);
+    REQUIRE(state.getPolyAftertouch(60) == 0.0f);
+}
+
+TEST_CASE("[MPE] MidiState single-arg overloads forward to master")
+{
+    sfz::MidiState state;
+    // Write via master via the single-arg overloads, read both ways.
+    state.pitchBendEvent(0, 0.5f);
+    state.ccEvent(0, 64, 0.6f);
+    state.channelAftertouchEvent(0, 0.7f);
+    state.polyAftertouchEvent(0, 60, 0.8f);
+
+    REQUIRE(state.getPitchBend() == 0.5f);
+    REQUIRE(state.getPitchBend(0) == 0.5f);
+    REQUIRE(state.getCCValue(64) == 0.6f);
+    REQUIRE(state.getCCValue(0, 64) == 0.6f);
+    REQUIRE(state.getChannelAftertouch() == 0.7f);
+    REQUIRE(state.getChannelAftertouch(0) == 0.7f);
+    REQUIRE(state.getPolyAftertouch(60) == 0.8f);
+    REQUIRE(state.getPolyAftertouch(0, 60) == 0.8f);
+}
+
+TEST_CASE("[MPE] MidiState out-of-range channels are no-ops on write and 0 on read")
+{
+    sfz::MidiState state;
+    // These should be silently dropped, not crash, not corrupt master.
+    state.pitchBendEvent(0, /*channel=*/-1, 0.5f);
+    state.pitchBendEvent(0, /*channel=*/16, 0.5f);
+    state.pitchBendEvent(0, /*channel=*/99, 0.5f);
+    state.ccEvent(0, /*channel=*/-1, 64, 0.5f);
+    state.ccEvent(0, /*channel=*/99, 64, 0.5f);
+    state.channelAftertouchEvent(0, /*channel=*/-1, 0.5f);
+    state.polyAftertouchEvent(0, /*channel=*/-1, 60, 0.5f);
+
+    // Master remains untouched.
+    REQUIRE(state.getPitchBend(0) == 0.0f);
+    REQUIRE(state.getCCValue(0, 64) == 0.0f);
+    REQUIRE(state.getChannelAftertouch(0) == 0.0f);
+    REQUIRE(state.getPolyAftertouch(0, 60) == 0.0f);
+
+    // Out-of-range reads return 0.
+    REQUIRE(state.getPitchBend(-1) == 0.0f);
+    REQUIRE(state.getPitchBend(16) == 0.0f);
+    REQUIRE(state.getPitchBend(99) == 0.0f);
+}
+
+// =============================================================================
+// Synth: *MPE public API routes events to the right channel slot
+// =============================================================================
+
+TEST_CASE("[MPE] Synth::pitchWheelMPE lands in the per-channel pitch slot")
+{
+    sfz::Synth synth;
+    synth.pitchWheelMPE(0, 1, 4096);
+    synth.pitchWheelMPE(0, 2, -4096);
+
+    // pitchWheel takes a 14-bit centered-zero value (-8192..+8191 effective)
+    // normalized to roughly -1..+1. The exact divisor differs by sign in
+    // sfizz's normalizeBend, so the values are approximate; a margin of
+    // 0.001 is plenty to catch the per-channel routing while tolerating
+    // the asymmetry.
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getPitchBend(1) == Approx(0.5).margin(0.001));
+    REQUIRE(mid.getPitchBend(2) == Approx(-0.5).margin(0.001));
+    REQUIRE(mid.getPitchBend(0) == Approx(0.0).margin(0.001));
+}
+
+TEST_CASE("[MPE] Synth::ccMPE lands in the per-channel CC slot")
+{
+    sfz::Synth synth;
+    synth.ccMPE(0, 1, 74, 64);
+    synth.ccMPE(0, 2, 74, 127);
+
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getCCValue(1, 74) == 64_norm);
+    REQUIRE(mid.getCCValue(2, 74) == 127_norm);
+    REQUIRE(mid.getCCValue(0, 74) == 0.0_a);
+}
+
+TEST_CASE("[MPE] Synth::channelAftertouchMPE lands in the per-channel slot")
+{
+    sfz::Synth synth;
+    synth.channelAftertouchMPE(0, 1, 64);
+    synth.channelAftertouchMPE(0, 2, 127);
+
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getChannelAftertouch(1) == 64_norm);
+    REQUIRE(mid.getChannelAftertouch(2) == 127_norm);
+    REQUIRE(mid.getChannelAftertouch(0) == 0.0_a);
+}
+
+TEST_CASE("[MPE] Synth::polyAftertouchMPE lands in the per-channel slot")
+{
+    sfz::Synth synth;
+    synth.polyAftertouchMPE(0, 1, 60, 64);
+    synth.polyAftertouchMPE(0, 2, 60, 127);
+
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getPolyAftertouch(1, 60) == 64_norm);
+    REQUIRE(mid.getPolyAftertouch(2, 60) == 127_norm);
+    REQUIRE(mid.getPolyAftertouch(0, 60) == 0.0_a);
+}
+
+TEST_CASE("[MPE] Existing single-channel API forwards to master-channel slot")
+{
+    sfz::Synth synth;
+    // Using the legacy non-MPE API should populate channel 0 (master).
+    synth.pitchWheel(0, 8192); // +1 normalized
+    synth.cc(0, 74, 90);
+    synth.channelAftertouch(0, 100);
+
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getPitchBend(0) == 1.0_a);
+    REQUIRE(mid.getCCValue(0, 74) == 90_norm);
+    REQUIRE(mid.getChannelAftertouch(0) == 100_norm);
+    // Other channels untouched.
+    REQUIRE(mid.getPitchBend(1) == 0.0_a);
+    REQUIRE(mid.getCCValue(1, 74) == 0.0_a);
+    REQUIRE(mid.getChannelAftertouch(1) == 0.0_a);
+}
+
+// =============================================================================
+// Synth: noteOnMPE tags spawned voices with the originating channel
+// =============================================================================
+
+TEST_CASE("[MPE] noteOnMPE tags TriggerEvent with the dispatched channel")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_basic.sfz", R"(
+        <region> sample=*sine
+    )");
+
+    synth.noteOnMPE(0, /*channel=*/1, 60, 100);
+    synth.noteOnMPE(0, /*channel=*/3, 64, 100);
+    synth.renderBlock(buffer);
+
+    auto activeVoices = synth.getActiveVoices();
+    REQUIRE(activeVoices.size() == 2);
+
+    // Each voice's TriggerEvent should carry the channel it was triggered on.
+    int sumChannels = 0;
+    int sumNumbers = 0;
+    for (const sfz::Voice* v : activeVoices) {
+        sumChannels += v->getTriggerEvent().channel;
+        sumNumbers += v->getTriggerEvent().number;
+    }
+    REQUIRE(sumChannels == 1 + 3);
+    REQUIRE(sumNumbers == 60 + 64);
+
+    // And the per-channel pairing must match (the ch=1 voice plays note 60,
+    // ch=3 voice plays note 64).
+    bool foundCh1Note60 = false;
+    bool foundCh3Note64 = false;
+    for (const sfz::Voice* v : activeVoices) {
+        const auto& t = v->getTriggerEvent();
+        if (t.channel == 1 && t.number == 60) foundCh1Note60 = true;
+        if (t.channel == 3 && t.number == 64) foundCh3Note64 = true;
+    }
+    REQUIRE(foundCh1Note60);
+    REQUIRE(foundCh3Note64);
+}
+
+// =============================================================================
+// MPE configuration getters/setters
+// =============================================================================
+
+TEST_CASE("[MPE] setMPEEnabled / getMPEEnabled round-trip")
+{
+    sfz::Synth synth;
+    REQUIRE(synth.getMPEEnabled() == false);
+    synth.setMPEEnabled(true);
+    REQUIRE(synth.getMPEEnabled() == true);
+    synth.setMPEEnabled(false);
+    REQUIRE(synth.getMPEEnabled() == false);
+}
+
+TEST_CASE("[MPE] setMPEPitchBendRange / getters round-trip")
+{
+    sfz::Synth synth;
+    // MPE 1.0 default conventions.
+    REQUIRE(synth.getMPEMasterPitchBendRange() == 2.0_a);
+    REQUIRE(synth.getMPEPerNotePitchBendRange() == 48.0_a);
+
+    synth.setMPEPitchBendRange(7.0f, 24.0f);
+    REQUIRE(synth.getMPEMasterPitchBendRange() == 7.0_a);
+    REQUIRE(synth.getMPEPerNotePitchBendRange() == 24.0_a);
+}
+
+// =============================================================================
+// Voice stealing: same-channel preference under MPE
+// =============================================================================
+
+TEST_CASE("[MPE] Voice stealing prefers same-channel candidates when MPE enabled")
+{
+    // Setup: polyphony cap = 4, three voices on channel 2 plus one voice on
+    // channel 1. Trigger a fifth note on channel 1 — with MPE enabled, the
+    // stealer must pick the existing ch1 voice as the victim because it is
+    // the only same-channel candidate. After the steal, all three channel-2
+    // voices must still be alive.
+
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
+    synth.setNumVoices(4);
+    synth.setMPEEnabled(true);
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_stealing.sfz", R"(
+        <region> sample=*sine
+    )");
+
+    synth.noteOnMPE(0, 2, 60, 100); synth.renderBlock(buffer);
+    synth.noteOnMPE(0, 2, 62, 100); synth.renderBlock(buffer);
+    synth.noteOnMPE(0, 2, 64, 100); synth.renderBlock(buffer);
+    synth.noteOnMPE(0, 1, 67, 100); synth.renderBlock(buffer);
+    REQUIRE(synth.getNumActiveVoices() == 4);
+
+    synth.noteOnMPE(0, 1, 69, 100);
+    synth.renderBlock(buffer);
+
+    int channel2Count = 0;
+    for (const sfz::Voice* v : synth.getActiveVoices())
+        if (v->getTriggerEvent().channel == 2)
+            channel2Count++;
+    REQUIRE(channel2Count == 3);
+}

--- a/tests/MPET.cpp
+++ b/tests/MPET.cpp
@@ -368,3 +368,165 @@ TEST_CASE("[MPE] Voice stealing prefers same-channel candidates when MPE enabled
             channel2Count++;
     REQUIRE(channel2Count == 3);
 }
+
+// =============================================================================
+// MPE auto-config: RPN 6 (MCM) + RPN 0 (Pitch Bend Sensitivity) parsing
+// =============================================================================
+//
+// MPE 1.0 §2 lets controllers self-announce their zone (RPN 6) and bend
+// ranges (RPN 0). The engine parses these RPN sequences inside performHdcc
+// and reacts automatically. The CCs themselves still propagate to MidiState
+// so SFZ *_oncc bindings on CC 6/100/101/etc. remain functional.
+//
+// Lower-Zone master in sfizz's 0-indexed channel convention is channel 0
+// (MIDI channel 1 on the wire); members are channels 1..15.
+
+namespace {
+
+void sendMCM(sfz::Synth& synth, int channel, int memberCount)
+{
+    synth.ccMPE(0, channel, 101, 0);          // RPN MSB
+    synth.ccMPE(0, channel, 100, 6);          // RPN LSB → RPN 6
+    synth.ccMPE(0, channel, 6,   memberCount); // Data Entry MSB
+    synth.ccMPE(0, channel, 101, 127);        // Null RPN MSB
+    synth.ccMPE(0, channel, 100, 127);        // Null RPN LSB
+}
+
+void sendPitchBendSensitivity(sfz::Synth& synth, int channel, int semitones)
+{
+    synth.ccMPE(0, channel, 101, 0);          // RPN MSB
+    synth.ccMPE(0, channel, 100, 0);          // RPN LSB → RPN 0
+    synth.ccMPE(0, channel, 6,   semitones);  // Data Entry MSB
+    synth.ccMPE(0, channel, 101, 127);        // Null RPN MSB
+    synth.ccMPE(0, channel, 100, 127);        // Null RPN LSB
+}
+
+} // namespace
+
+TEST_CASE("[MPE] RPN 6 (MCM) on master channel enables MPE")
+{
+    sfz::Synth synth;
+    REQUIRE(synth.getMPEEnabled() == false);
+    sendMCM(synth, /*channel=*/0, /*memberCount=*/8);
+    REQUIRE(synth.getMPEEnabled() == true);
+}
+
+TEST_CASE("[MPE] RPN 6 (MCM) with N=0 disables MPE")
+{
+    sfz::Synth synth;
+    synth.setMPEEnabled(true);
+    sendMCM(synth, /*channel=*/0, /*memberCount=*/0);
+    REQUIRE(synth.getMPEEnabled() == false);
+}
+
+TEST_CASE("[MPE] RPN 6 (MCM) on non-master channel is rejected")
+{
+    sfz::Synth synth;
+    REQUIRE(synth.getMPEEnabled() == false);
+    sendMCM(synth, /*channel=*/5, /*memberCount=*/8);
+    REQUIRE(synth.getMPEEnabled() == false);
+}
+
+TEST_CASE("[MPE] RPN 0 on master channel updates master bend range")
+{
+    sfz::Synth synth;
+    REQUIRE(synth.getMPEMasterPitchBendRange() == 2.0_a);
+    sendPitchBendSensitivity(synth, /*channel=*/0, /*semitones=*/12);
+    REQUIRE(synth.getMPEMasterPitchBendRange() == 12.0_a);
+    // Per-note range untouched.
+    REQUIRE(synth.getMPEPerNotePitchBendRange() == 48.0_a);
+}
+
+TEST_CASE("[MPE] RPN 0 on member channel updates per-note bend range")
+{
+    sfz::Synth synth;
+    REQUIRE(synth.getMPEPerNotePitchBendRange() == 48.0_a);
+    sendPitchBendSensitivity(synth, /*channel=*/2, /*semitones=*/24);
+    REQUIRE(synth.getMPEPerNotePitchBendRange() == 24.0_a);
+    // Master range untouched.
+    REQUIRE(synth.getMPEMasterPitchBendRange() == 2.0_a);
+}
+
+TEST_CASE("[MPE] Null RPN followed by CC 6 does not trigger MPE handlers")
+{
+    sfz::Synth synth;
+    // Deselect any pending RPN first.
+    synth.ccMPE(0, 0, 101, 127);
+    synth.ccMPE(0, 0, 100, 127);
+    // A bare Data Entry with no RPN selected must not flip MPE state.
+    synth.ccMPE(0, 0, 6, 8);
+    REQUIRE(synth.getMPEEnabled() == false);
+}
+
+TEST_CASE("[MPE] NRPN sequence followed by CC 6 does not trigger MPE handlers")
+{
+    sfz::Synth synth;
+    // Select NRPN (0, 6) on the master channel — same data values as RPN 6
+    // but via CC 99 / CC 98 instead of CC 101 / CC 100. The parser must not
+    // mistake this for an MCM.
+    synth.ccMPE(0, 0, 99, 0);
+    synth.ccMPE(0, 0, 98, 6);
+    synth.ccMPE(0, 0, 6, 8);
+    REQUIRE(synth.getMPEEnabled() == false);
+}
+
+TEST_CASE("[MPE] Opt-out: master-bend auto-config disabled blocks RPN 0 on master")
+{
+    sfz::Synth synth;
+    synth.setMPEMasterBendAutoConfigEnabled(false);
+    sendPitchBendSensitivity(synth, /*channel=*/0, /*semitones=*/12);
+    REQUIRE(synth.getMPEMasterPitchBendRange() == 2.0_a);
+    // The per-note opt-out is still on, so a member-channel RPN still lands.
+    sendPitchBendSensitivity(synth, /*channel=*/2, /*semitones=*/24);
+    REQUIRE(synth.getMPEPerNotePitchBendRange() == 24.0_a);
+}
+
+TEST_CASE("[MPE] Opt-out: per-note-bend auto-config disabled blocks RPN 0 on members")
+{
+    sfz::Synth synth;
+    synth.setMPEPerNoteBendAutoConfigEnabled(false);
+    sendPitchBendSensitivity(synth, /*channel=*/2, /*semitones=*/24);
+    REQUIRE(synth.getMPEPerNotePitchBendRange() == 48.0_a);
+    // The master opt-out is still on, so a master-channel RPN still lands.
+    sendPitchBendSensitivity(synth, /*channel=*/0, /*semitones=*/12);
+    REQUIRE(synth.getMPEMasterPitchBendRange() == 12.0_a);
+}
+
+TEST_CASE("[MPE] MCM enable is unconditional (not gated by the bend-range opt-outs)")
+{
+    sfz::Synth synth;
+    synth.setMPEMasterBendAutoConfigEnabled(false);
+    synth.setMPEPerNoteBendAutoConfigEnabled(false);
+    sendMCM(synth, /*channel=*/0, /*memberCount=*/8);
+    // MCM enable is part of the MPE 1.0 spec contract — UIs gate only the
+    // bend-range updates, not the MPE-enable flag.
+    REQUIRE(synth.getMPEEnabled() == true);
+}
+
+TEST_CASE("[MPE] RPN control CCs still propagate to MidiState (parser is a tap)")
+{
+    sfz::Synth synth;
+    synth.ccMPE(0, 0, 101, 0);
+    synth.ccMPE(0, 0, 100, 6);
+    synth.ccMPE(0, 0, 6,   8);
+
+    auto& mid = synth.getResources().getMidiState();
+    // The parser must not swallow the CCs — SFZ instruments can bind
+    // *_oncc6 / *_oncc100 / *_oncc101 and those bindings rely on the
+    // MidiState slot being updated.
+    REQUIRE(mid.getCCValue(0, 101) == 0.0_a);
+    REQUIRE(mid.getCCValue(0, 100) == 6_norm);
+    REQUIRE(mid.getCCValue(0, 6)   == 8_norm);
+}
+
+TEST_CASE("[MPE] Opt-out flag round-trip getters")
+{
+    sfz::Synth synth;
+    REQUIRE(synth.getMPEMasterBendAutoConfigEnabled() == true);
+    REQUIRE(synth.getMPEPerNoteBendAutoConfigEnabled() == true);
+    synth.setMPEMasterBendAutoConfigEnabled(false);
+    REQUIRE(synth.getMPEMasterBendAutoConfigEnabled() == false);
+    REQUIRE(synth.getMPEPerNoteBendAutoConfigEnabled() == true);
+    synth.setMPEPerNoteBendAutoConfigEnabled(false);
+    REQUIRE(synth.getMPEPerNoteBendAutoConfigEnabled() == false);
+}

--- a/tests/MPET.cpp
+++ b/tests/MPET.cpp
@@ -194,6 +194,7 @@ TEST_CASE("[MPE] First member-channel event at delay>0 keeps the delay-0 sentine
 TEST_CASE("[MPE] Synth::pitchWheelMPE lands in the per-channel pitch slot")
 {
     sfz::Synth synth;
+    synth.setMPEEnabled(true); // *MPE methods honor the channel arg only when MPE is on
     synth.pitchWheelMPE(0, 1, 4096);
     synth.pitchWheelMPE(0, 2, -4096);
 
@@ -211,6 +212,7 @@ TEST_CASE("[MPE] Synth::pitchWheelMPE lands in the per-channel pitch slot")
 TEST_CASE("[MPE] Synth::ccMPE lands in the per-channel CC slot")
 {
     sfz::Synth synth;
+    synth.setMPEEnabled(true);
     synth.ccMPE(0, 1, 74, 64);
     synth.ccMPE(0, 2, 74, 127);
 
@@ -223,6 +225,7 @@ TEST_CASE("[MPE] Synth::ccMPE lands in the per-channel CC slot")
 TEST_CASE("[MPE] Synth::channelAftertouchMPE lands in the per-channel slot")
 {
     sfz::Synth synth;
+    synth.setMPEEnabled(true);
     synth.channelAftertouchMPE(0, 1, 64);
     synth.channelAftertouchMPE(0, 2, 127);
 
@@ -232,16 +235,20 @@ TEST_CASE("[MPE] Synth::channelAftertouchMPE lands in the per-channel slot")
     REQUIRE(mid.getChannelAftertouch(0) == 0.0_a);
 }
 
-TEST_CASE("[MPE] Synth::polyAftertouchMPE lands in the per-channel slot")
+TEST_CASE("[MPE] Synth::polyAftertouchMPE on Manager Channel lands in the per-channel slot")
 {
+    // Member-channel Poly KP is dropped by the MPE 1.0 §2.2.7 filter, so the
+    // per-channel storage path is only exercisable through the Manager
+    // Channel (channel 0) under MPE on. The MidiState-direct test above
+    // covers raw per-channel writes for channels 1..15.
     sfz::Synth synth;
-    synth.polyAftertouchMPE(0, 1, 60, 64);
-    synth.polyAftertouchMPE(0, 2, 60, 127);
+    synth.setMPEEnabled(true);
+    synth.polyAftertouchMPE(0, 0, 60, 64);
+    synth.polyAftertouchMPE(0, 0, 64, 127);
 
     auto& mid = synth.getResources().getMidiState();
-    REQUIRE(mid.getPolyAftertouch(1, 60) == 64_norm);
-    REQUIRE(mid.getPolyAftertouch(2, 60) == 127_norm);
-    REQUIRE(mid.getPolyAftertouch(0, 60) == 0.0_a);
+    REQUIRE(mid.getPolyAftertouch(0, 60) == 64_norm);
+    REQUIRE(mid.getPolyAftertouch(0, 64) == 127_norm);
 }
 
 TEST_CASE("[MPE] Existing single-channel API forwards to master-channel slot")
@@ -265,50 +272,75 @@ TEST_CASE("[MPE] Existing single-channel API forwards to master-channel slot")
     REQUIRE(mid.getChannelAftertouch(1) == 100_norm);
 }
 
-TEST_CASE("[MPE] Voices triggered via the legacy API are isolated from MPE per-channel writes")
+TEST_CASE("[MPE] When MPE is disabled, *MPE methods collapse channel to 0 (single-channel contract)")
 {
-    // Defensive regression for the MPE-off compatibility contract: in a
-    // mixed-API session, a voice triggered through the channel-less legacy
-    // API gets triggerChannel_=0 and must read modulation from the master
-    // channel only — non-master channel writes via the *MPE API must not
-    // affect it. This is the property hosts rely on when they call the
-    // legacy API to opt out of MPE routing (the wrapper-side behaviour
-    // shipped for the sfizz-ui MPE-off toggle).
+    // With MPE off, the *MPE API surface and the legacy channel-less API
+    // are equivalent: both land in channel-0 storage and both trigger
+    // voices with triggerChannel_=0. Consumers (sfizz-ui's VST3 wrapper,
+    // sample-machine's PlayerEngine) can therefore call *MPE unconditionally
+    // without an MPE-off vs MPE-on dispatch branch, and the engine takes
+    // sole responsibility for what "MPE off" means.
     sfz::Synth synth;
+    REQUIRE(synth.getMPEEnabled() == false);
     sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
-    synth.loadSfzString(fs::current_path() / "tests/MPE_legacy_isolation.sfz", R"(
+    synth.loadSfzString(fs::current_path() / "tests/MPE_off_normalization.sfz", R"(
         <region> sample=*sine
     )");
 
-    // Trigger via the legacy API — voice gets triggerChannel_=0.
-    synth.noteOn(0, 60, 100);
+    // *MPE noteOn on a non-zero channel — voice should still get
+    // triggerChannel_=0 because MPE is off.
+    synth.noteOnMPE(0, /*channel=*/5, 60, 100);
     synth.renderBlock(buffer);
 
     auto activeVoices = synth.getActiveVoices();
     REQUIRE(activeVoices.size() == 1);
     REQUIRE(activeVoices[0]->getTriggerEvent().channel == 0);
 
-    // Per-channel writes via the *MPE API on non-master channels must NOT
-    // touch the master channel that the legacy-triggered voice reads from.
+    // *MPE modulation writes on non-zero channels also land in channel 0.
     synth.pitchWheelMPE(0, /*channel=*/5, 4096);
     synth.ccMPE(0, /*channel=*/5, 74, 90);
     synth.channelAftertouchMPE(0, /*channel=*/5, 100);
     synth.renderBlock(buffer);
 
     auto& mid = synth.getResources().getMidiState();
-    REQUIRE(mid.getPitchBendRaw(0) == 0.0_a);            // master untouched
-    REQUIRE(mid.getCCValue(0, 74) == 0_norm);            // master CC slot untouched
-    REQUIRE(mid.getChannelAftertouch(0) == 0_norm);      // master pressure untouched
-    // Channel 5 has the writes; the voice doesn't read from there.
-    REQUIRE(mid.getPitchBendRaw(5) == Approx(0.5).margin(0.001));
+    REQUIRE(mid.getPitchBendRaw(0) == Approx(0.5).margin(0.001));
+    REQUIRE(mid.getCCValue(0, 74) == 90_norm);
+    REQUIRE(mid.getChannelAftertouch(0) == 100_norm);
+    // Channel 5 should NOT have any of these writes — they were normalized.
+    REQUIRE(mid.getPitchBendRaw(5) == 0.0_a);
 
-    // A legacy note-off (channel-less → forwards to channel 0) must release
-    // the voice. registerNoteOff matches on channel; triggerChannel_=0 and
-    // channel-0 noteOff match → voice releases. This is the path the sfizz-ui
-    // wrapper uses when the MPE toggle is off.
-    synth.noteOff(0, 60, 0);
+    // *MPE noteOff on a non-zero channel also collapses to channel 0 and
+    // matches the voice (which has triggerChannel_=0).
+    synth.noteOffMPE(0, /*channel=*/5, 60, 0);
     synth.renderBlock(buffer);
     REQUIRE((activeVoices[0]->released() || activeVoices[0]->isFree()));
+}
+
+TEST_CASE("[MPE] setMPEEnabled(false) flushes active voices triggered while MPE was on")
+{
+    // On→off transition has to clear voices that carry triggerChannel_>0,
+    // otherwise their channel-aware modulation reads stay pinned to the
+    // member channel that no longer receives input under the new contract
+    // (everything collapses to channel 0 after the flip).
+    sfz::Synth synth;
+    synth.setMPEEnabled(true);
+    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
+    synth.loadSfzString(fs::current_path() / "tests/MPE_off_transition.sfz", R"(
+        <region> sample=*sine
+    )");
+
+    synth.noteOnMPE(0, /*channel=*/3, 60, 100);
+    synth.noteOnMPE(0, /*channel=*/4, 64, 100);
+    synth.renderBlock(buffer);
+    REQUIRE(synth.getActiveVoices().size() == 2);
+
+    synth.setMPEEnabled(false);
+    synth.renderBlock(buffer);
+
+    // All voices should have been released by allSoundOff() in setMPEEnabled.
+    for (const sfz::Voice* v : synth.getActiveVoices()) {
+        REQUIRE(v->isFree());
+    }
 }
 
 // =============================================================================
@@ -318,6 +350,7 @@ TEST_CASE("[MPE] Voices triggered via the legacy API are isolated from MPE per-c
 TEST_CASE("[MPE] noteOnMPE tags TriggerEvent with the dispatched channel")
 {
     sfz::Synth synth;
+    synth.setMPEEnabled(true);
     sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_basic.sfz", R"(
         <region> sample=*sine

--- a/tests/MPET.cpp
+++ b/tests/MPET.cpp
@@ -256,10 +256,13 @@ TEST_CASE("[MPE] Existing single-channel API forwards to master-channel slot")
     REQUIRE(mid.getPitchBend(0) == 1.0_a);
     REQUIRE(mid.getCCValue(0, 74) == 90_norm);
     REQUIRE(mid.getChannelAftertouch(0) == 100_norm);
-    // Other channels untouched.
-    REQUIRE(mid.getPitchBend(1) == 0.0_a);
-    REQUIRE(mid.getCCValue(1, 74) == 0.0_a);
-    REQUIRE(mid.getChannelAftertouch(1) == 0.0_a);
+    // Member channels with no events of their own inherit master state
+    // via the MidiState fallback (b117153f) — voices triggered on a member
+    // channel before that channel sees any per-note modulation read the
+    // master scalars so global bend / pressure / CC values still apply.
+    REQUIRE(mid.getPitchBend(1) == 1.0_a);
+    REQUIRE(mid.getCCValue(1, 74) == 90_norm);
+    REQUIRE(mid.getChannelAftertouch(1) == 100_norm);
 }
 
 // =============================================================================

--- a/tests/MPET.cpp
+++ b/tests/MPET.cpp
@@ -530,3 +530,54 @@ TEST_CASE("[MPE] Opt-out flag round-trip getters")
     synth.setMPEPerNoteBendAutoConfigEnabled(false);
     REQUIRE(synth.getMPEPerNoteBendAutoConfigEnabled() == false);
 }
+
+// =============================================================================
+// Polyphonic Key Pressure asymmetry (MPE 1.0 §2.2.7 / Appendix E Table 5)
+// =============================================================================
+//
+// Poly KP is prohibited on Member Channels under MPE — per-note pressure
+// flows through Channel Pressure, and Poly KP on a Member Channel would
+// compound the response. The engine drops such events at hdPolyAftertouchMPE
+// and reports the drop via getDroppedPolyKpOnMemberCount. Manager-Channel
+// Poly KP remains permitted (spec leaves this to the implementer for
+// compatibility with non-MPE-aware devices) and still routes to MidiState.
+
+TEST_CASE("[MPE] Poly KP on a Member Channel is dropped when MPE is enabled")
+{
+    sfz::Synth synth;
+    synth.setMPEEnabled(true);
+    REQUIRE(synth.getDroppedPolyKpOnMemberCount() == 0);
+
+    synth.polyAftertouchMPE(0, /*channel=*/2, /*note=*/60, 100);
+
+    REQUIRE(synth.getDroppedPolyKpOnMemberCount() == 1);
+    // The dropped event must not reach MidiState — the slot stays at the
+    // default 0 / master-fallback value.
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getPolyAftertouch(/*channel=*/2, /*note=*/60) == 0.0_a);
+}
+
+TEST_CASE("[MPE] Poly KP on the Manager Channel still routes through when MPE is enabled")
+{
+    sfz::Synth synth;
+    synth.setMPEEnabled(true);
+    REQUIRE(synth.getDroppedPolyKpOnMemberCount() == 0);
+
+    synth.polyAftertouchMPE(0, /*channel=*/0, /*note=*/60, 127);
+
+    REQUIRE(synth.getDroppedPolyKpOnMemberCount() == 0);
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getPolyAftertouch(/*channel=*/0, /*note=*/60) == 127_norm);
+}
+
+TEST_CASE("[MPE] Poly KP on any channel is accepted when MPE is disabled")
+{
+    sfz::Synth synth;
+    REQUIRE(synth.getMPEEnabled() == false);
+
+    synth.polyAftertouchMPE(0, /*channel=*/5, /*note=*/72, 80);
+
+    REQUIRE(synth.getDroppedPolyKpOnMemberCount() == 0);
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getPolyAftertouch(/*channel=*/5, /*note=*/72) == 80_norm);
+}

--- a/tests/MPET.cpp
+++ b/tests/MPET.cpp
@@ -130,6 +130,63 @@ TEST_CASE("[MPE] MidiState out-of-range channels are no-ops on write and 0 on re
     REQUIRE(state.getPitchBend(99) == 0.0f);
 }
 
+TEST_CASE("[MPE] Empty member channels inherit master CC / pitch / aftertouch state")
+{
+    // Regression: hit during Osmose hand-test. sfizz seeds default values
+    // for CC7 (Volume@~0.79), CC10 (Pan@0.5), CC11 (Expression@1.0) into
+    // the master channel only. Without inheritance, voices on member
+    // channels saw CC7=0 / CC11=0 and rendered near-silent — the user
+    // perceived "first note plays at low volume, then mutes".
+    sfz::MidiState state;
+    state.ccEvent(0, /*channel=*/0, 7, 0.79f);
+    state.ccEvent(0, /*channel=*/0, 11, 1.0f);
+    state.pitchBendEvent(0, /*channel=*/0, 0.25f);
+    state.channelAftertouchEvent(0, /*channel=*/0, 0.6f);
+    state.polyAftertouchEvent(0, /*channel=*/0, 60, 0.4f);
+
+    // Member channel 5 has never received its own values.
+    REQUIRE(state.getCCEvents(5, 7).back().value == 0.79f);
+    REQUIRE(state.getCCEvents(5, 11).back().value == 1.0f);
+    REQUIRE(state.getPitchEvents(5).back().value == 0.25f);
+    REQUIRE(state.getChannelAftertouchEvents(5).back().value == 0.6f);
+    REQUIRE(state.getPolyAftertouchEvents(5, 60).back().value == 0.4f);
+
+    // Once the member channel writes its own value, it overrides master.
+    state.ccEvent(0, /*channel=*/5, 7, 0.3f);
+    REQUIRE(state.getCCEvents(5, 7).back().value == 0.3f);
+    // Master is unchanged.
+    REQUIRE(state.getCCEvents(0, 7).back().value == 0.79f);
+}
+
+TEST_CASE("[MPE] First member-channel event at delay>0 keeps the delay-0 sentinel")
+{
+    // Regression: hit during Osmose hand-test. linearEnvelope ASSERTs the
+    // event vector starts at delay 0; member channels are populated lazily
+    // so before this fix a first write at delay>0 produced a vector whose
+    // first entry was {delay, value}, tripping the ASSERT and SIGTRAP'ing
+    // the audio thread on the very first MPE pitch-bend / CC event.
+    sfz::MidiState state;
+
+    state.pitchBendEvent(/*delay=*/42, /*channel=*/3, 0.5f);
+    state.ccEvent(/*delay=*/17, /*channel=*/4, 74, 0.7f);
+    state.channelAftertouchEvent(/*delay=*/9, /*channel=*/5, 0.4f);
+    state.polyAftertouchEvent(/*delay=*/3, /*channel=*/6, 60, 0.6f);
+
+    auto firstDelayIsZero = [] (const sfz::EventVector& v) {
+        return ! v.empty() && v.front().delay == 0;
+    };
+
+    REQUIRE(firstDelayIsZero(state.getPitchEvents(3)));
+    REQUIRE(firstDelayIsZero(state.getCCEvents(4, 74)));
+    REQUIRE(firstDelayIsZero(state.getChannelAftertouchEvents(5)));
+    REQUIRE(firstDelayIsZero(state.getPolyAftertouchEvents(6, 60)));
+
+    // The original event is still there, just preceded by the sentinel.
+    REQUIRE(state.getPitchEvents(3).size() == 2);
+    REQUIRE(state.getPitchEvents(3).back().delay == 42);
+    REQUIRE(state.getPitchEvents(3).back().value == 0.5f);
+}
+
 // =============================================================================
 // Synth: *MPE public API routes events to the right channel slot
 // =============================================================================

--- a/tests/MPET.cpp
+++ b/tests/MPET.cpp
@@ -191,12 +191,12 @@ TEST_CASE("[MPE] First member-channel event at delay>0 keeps the delay-0 sentine
 // Synth: *MPE public API routes events to the right channel slot
 // =============================================================================
 
-TEST_CASE("[MPE] Synth::pitchWheelMPE lands in the per-channel pitch slot")
+TEST_CASE("[MPE] Synth::pitchWheel lands in the per-channel pitch slot")
 {
     sfz::Synth synth;
     synth.setMPEEnabled(true); // *MPE methods honor the channel arg only when MPE is on
-    synth.pitchWheelMPE(0, 1, 4096);
-    synth.pitchWheelMPE(0, 2, -4096);
+    synth.pitchWheel(0, 1, 4096);
+    synth.pitchWheel(0, 2, -4096);
 
     // pitchWheel takes a 14-bit centered-zero value (-8192..+8191 effective)
     // normalized to roughly -1..+1. The exact divisor differs by sign in
@@ -209,12 +209,12 @@ TEST_CASE("[MPE] Synth::pitchWheelMPE lands in the per-channel pitch slot")
     REQUIRE(mid.getPitchBend(0) == Approx(0.0).margin(0.001));
 }
 
-TEST_CASE("[MPE] Synth::ccMPE lands in the per-channel CC slot")
+TEST_CASE("[MPE] Synth::cc lands in the per-channel CC slot")
 {
     sfz::Synth synth;
     synth.setMPEEnabled(true);
-    synth.ccMPE(0, 1, 74, 64);
-    synth.ccMPE(0, 2, 74, 127);
+    synth.cc(0, 1, 74, 64);
+    synth.cc(0, 2, 74, 127);
 
     auto& mid = synth.getResources().getMidiState();
     REQUIRE(mid.getCCValue(1, 74) == 64_norm);
@@ -222,12 +222,12 @@ TEST_CASE("[MPE] Synth::ccMPE lands in the per-channel CC slot")
     REQUIRE(mid.getCCValue(0, 74) == 0.0_a);
 }
 
-TEST_CASE("[MPE] Synth::channelAftertouchMPE lands in the per-channel slot")
+TEST_CASE("[MPE] Synth::channelAftertouch lands in the per-channel slot")
 {
     sfz::Synth synth;
     synth.setMPEEnabled(true);
-    synth.channelAftertouchMPE(0, 1, 64);
-    synth.channelAftertouchMPE(0, 2, 127);
+    synth.channelAftertouch(0, 1, 64);
+    synth.channelAftertouch(0, 2, 127);
 
     auto& mid = synth.getResources().getMidiState();
     REQUIRE(mid.getChannelAftertouch(1) == 64_norm);
@@ -235,7 +235,7 @@ TEST_CASE("[MPE] Synth::channelAftertouchMPE lands in the per-channel slot")
     REQUIRE(mid.getChannelAftertouch(0) == 0.0_a);
 }
 
-TEST_CASE("[MPE] Synth::polyAftertouchMPE on Manager Channel lands in the per-channel slot")
+TEST_CASE("[MPE] Synth::polyAftertouch on Manager Channel lands in the per-channel slot")
 {
     // Member-channel Poly KP is dropped by the MPE 1.0 §2.2.7 filter, so the
     // per-channel storage path is only exercisable through the Manager
@@ -243,8 +243,8 @@ TEST_CASE("[MPE] Synth::polyAftertouchMPE on Manager Channel lands in the per-ch
     // covers raw per-channel writes for channels 1..15.
     sfz::Synth synth;
     synth.setMPEEnabled(true);
-    synth.polyAftertouchMPE(0, 0, 60, 64);
-    synth.polyAftertouchMPE(0, 0, 64, 127);
+    synth.polyAftertouch(0, 0, 60, 64);
+    synth.polyAftertouch(0, 0, 64, 127);
 
     auto& mid = synth.getResources().getMidiState();
     REQUIRE(mid.getPolyAftertouch(0, 60) == 64_norm);
@@ -289,7 +289,7 @@ TEST_CASE("[MPE] When MPE is disabled, *MPE methods collapse channel to 0 (singl
 
     // *MPE noteOn on a non-zero channel — voice should still get
     // triggerChannel_=0 because MPE is off.
-    synth.noteOnMPE(0, /*channel=*/5, 60, 100);
+    synth.noteOn(0, /*channel=*/5, 60, 100);
     synth.renderBlock(buffer);
 
     auto activeVoices = synth.getActiveVoices();
@@ -297,9 +297,9 @@ TEST_CASE("[MPE] When MPE is disabled, *MPE methods collapse channel to 0 (singl
     REQUIRE(activeVoices[0]->getTriggerEvent().channel == 0);
 
     // *MPE modulation writes on non-zero channels also land in channel 0.
-    synth.pitchWheelMPE(0, /*channel=*/5, 4096);
-    synth.ccMPE(0, /*channel=*/5, 74, 90);
-    synth.channelAftertouchMPE(0, /*channel=*/5, 100);
+    synth.pitchWheel(0, /*channel=*/5, 4096);
+    synth.cc(0, /*channel=*/5, 74, 90);
+    synth.channelAftertouch(0, /*channel=*/5, 100);
     synth.renderBlock(buffer);
 
     auto& mid = synth.getResources().getMidiState();
@@ -311,7 +311,7 @@ TEST_CASE("[MPE] When MPE is disabled, *MPE methods collapse channel to 0 (singl
 
     // *MPE noteOff on a non-zero channel also collapses to channel 0 and
     // matches the voice (which has triggerChannel_=0).
-    synth.noteOffMPE(0, /*channel=*/5, 60, 0);
+    synth.noteOff(0, /*channel=*/5, 60, 0);
     synth.renderBlock(buffer);
     REQUIRE((activeVoices[0]->released() || activeVoices[0]->isFree()));
 }
@@ -329,8 +329,8 @@ TEST_CASE("[MPE] setMPEEnabled(false) flushes active voices triggered while MPE 
         <region> sample=*sine
     )");
 
-    synth.noteOnMPE(0, /*channel=*/3, 60, 100);
-    synth.noteOnMPE(0, /*channel=*/4, 64, 100);
+    synth.noteOn(0, /*channel=*/3, 60, 100);
+    synth.noteOn(0, /*channel=*/4, 64, 100);
     synth.renderBlock(buffer);
     REQUIRE(synth.getActiveVoices().size() == 2);
 
@@ -344,10 +344,10 @@ TEST_CASE("[MPE] setMPEEnabled(false) flushes active voices triggered while MPE 
 }
 
 // =============================================================================
-// Synth: noteOnMPE tags spawned voices with the originating channel
+// Synth: noteOn tags spawned voices with the originating channel
 // =============================================================================
 
-TEST_CASE("[MPE] noteOnMPE tags TriggerEvent with the dispatched channel")
+TEST_CASE("[MPE] noteOn tags TriggerEvent with the dispatched channel")
 {
     sfz::Synth synth;
     synth.setMPEEnabled(true);
@@ -356,8 +356,8 @@ TEST_CASE("[MPE] noteOnMPE tags TriggerEvent with the dispatched channel")
         <region> sample=*sine
     )");
 
-    synth.noteOnMPE(0, /*channel=*/1, 60, 100);
-    synth.noteOnMPE(0, /*channel=*/3, 64, 100);
+    synth.noteOn(0, /*channel=*/1, 60, 100);
+    synth.noteOn(0, /*channel=*/3, 64, 100);
     synth.renderBlock(buffer);
 
     auto activeVoices = synth.getActiveVoices();
@@ -432,13 +432,13 @@ TEST_CASE("[MPE] Voice stealing prefers same-channel candidates when MPE enabled
         <region> sample=*sine
     )");
 
-    synth.noteOnMPE(0, 2, 60, 100); synth.renderBlock(buffer);
-    synth.noteOnMPE(0, 2, 62, 100); synth.renderBlock(buffer);
-    synth.noteOnMPE(0, 2, 64, 100); synth.renderBlock(buffer);
-    synth.noteOnMPE(0, 1, 67, 100); synth.renderBlock(buffer);
+    synth.noteOn(0, 2, 60, 100); synth.renderBlock(buffer);
+    synth.noteOn(0, 2, 62, 100); synth.renderBlock(buffer);
+    synth.noteOn(0, 2, 64, 100); synth.renderBlock(buffer);
+    synth.noteOn(0, 1, 67, 100); synth.renderBlock(buffer);
     REQUIRE(synth.getNumActiveVoices() == 4);
 
-    synth.noteOnMPE(0, 1, 69, 100);
+    synth.noteOn(0, 1, 69, 100);
     synth.renderBlock(buffer);
 
     int channel2Count = 0;
@@ -464,20 +464,20 @@ namespace {
 
 void sendMCM(sfz::Synth& synth, int channel, int memberCount)
 {
-    synth.ccMPE(0, channel, 101, 0);          // RPN MSB
-    synth.ccMPE(0, channel, 100, 6);          // RPN LSB → RPN 6
-    synth.ccMPE(0, channel, 6,   memberCount); // Data Entry MSB
-    synth.ccMPE(0, channel, 101, 127);        // Null RPN MSB
-    synth.ccMPE(0, channel, 100, 127);        // Null RPN LSB
+    synth.cc(0, channel, 101, 0);          // RPN MSB
+    synth.cc(0, channel, 100, 6);          // RPN LSB → RPN 6
+    synth.cc(0, channel, 6,   memberCount); // Data Entry MSB
+    synth.cc(0, channel, 101, 127);        // Null RPN MSB
+    synth.cc(0, channel, 100, 127);        // Null RPN LSB
 }
 
 void sendPitchBendSensitivity(sfz::Synth& synth, int channel, int semitones)
 {
-    synth.ccMPE(0, channel, 101, 0);          // RPN MSB
-    synth.ccMPE(0, channel, 100, 0);          // RPN LSB → RPN 0
-    synth.ccMPE(0, channel, 6,   semitones);  // Data Entry MSB
-    synth.ccMPE(0, channel, 101, 127);        // Null RPN MSB
-    synth.ccMPE(0, channel, 100, 127);        // Null RPN LSB
+    synth.cc(0, channel, 101, 0);          // RPN MSB
+    synth.cc(0, channel, 100, 0);          // RPN LSB → RPN 0
+    synth.cc(0, channel, 6,   semitones);  // Data Entry MSB
+    synth.cc(0, channel, 101, 127);        // Null RPN MSB
+    synth.cc(0, channel, 100, 127);        // Null RPN LSB
 }
 
 } // namespace
@@ -530,10 +530,10 @@ TEST_CASE("[MPE] Null RPN followed by CC 6 does not trigger MPE handlers")
 {
     sfz::Synth synth;
     // Deselect any pending RPN first.
-    synth.ccMPE(0, 0, 101, 127);
-    synth.ccMPE(0, 0, 100, 127);
+    synth.cc(0, 0, 101, 127);
+    synth.cc(0, 0, 100, 127);
     // A bare Data Entry with no RPN selected must not flip MPE state.
-    synth.ccMPE(0, 0, 6, 8);
+    synth.cc(0, 0, 6, 8);
     REQUIRE(synth.getMPEEnabled() == false);
 }
 
@@ -543,9 +543,9 @@ TEST_CASE("[MPE] NRPN sequence followed by CC 6 does not trigger MPE handlers")
     // Select NRPN (0, 6) on the master channel — same data values as RPN 6
     // but via CC 99 / CC 98 instead of CC 101 / CC 100. The parser must not
     // mistake this for an MCM.
-    synth.ccMPE(0, 0, 99, 0);
-    synth.ccMPE(0, 0, 98, 6);
-    synth.ccMPE(0, 0, 6, 8);
+    synth.cc(0, 0, 99, 0);
+    synth.cc(0, 0, 98, 6);
+    synth.cc(0, 0, 6, 8);
     REQUIRE(synth.getMPEEnabled() == false);
 }
 
@@ -585,9 +585,9 @@ TEST_CASE("[MPE] MCM enable is unconditional (not gated by the bend-range opt-ou
 TEST_CASE("[MPE] RPN control CCs still propagate to MidiState (parser is a tap)")
 {
     sfz::Synth synth;
-    synth.ccMPE(0, 0, 101, 0);
-    synth.ccMPE(0, 0, 100, 6);
-    synth.ccMPE(0, 0, 6,   8);
+    synth.cc(0, 0, 101, 0);
+    synth.cc(0, 0, 100, 6);
+    synth.cc(0, 0, 6,   8);
 
     auto& mid = synth.getResources().getMidiState();
     // The parser must not swallow the CCs — SFZ instruments can bind
@@ -616,7 +616,7 @@ TEST_CASE("[MPE] Opt-out flag round-trip getters")
 //
 // Poly KP is prohibited on Member Channels under MPE — per-note pressure
 // flows through Channel Pressure, and Poly KP on a Member Channel would
-// compound the response. The engine drops such events at hdPolyAftertouchMPE
+// compound the response. The engine drops such events at hdPolyAftertouch
 // and reports the drop via getDroppedPolyKpOnMemberCount. Manager-Channel
 // Poly KP remains permitted (spec leaves this to the implementer for
 // compatibility with non-MPE-aware devices) and still routes to MidiState.
@@ -627,7 +627,7 @@ TEST_CASE("[MPE] Poly KP on a Member Channel is dropped when MPE is enabled")
     synth.setMPEEnabled(true);
     REQUIRE(synth.getDroppedPolyKpOnMemberCount() == 0);
 
-    synth.polyAftertouchMPE(0, /*channel=*/2, /*note=*/60, 100);
+    synth.polyAftertouch(0, /*channel=*/2, /*note=*/60, 100);
 
     REQUIRE(synth.getDroppedPolyKpOnMemberCount() == 1);
     // The dropped event must not reach MidiState — the slot stays at the
@@ -642,7 +642,7 @@ TEST_CASE("[MPE] Poly KP on the Manager Channel still routes through when MPE is
     synth.setMPEEnabled(true);
     REQUIRE(synth.getDroppedPolyKpOnMemberCount() == 0);
 
-    synth.polyAftertouchMPE(0, /*channel=*/0, /*note=*/60, 127);
+    synth.polyAftertouch(0, /*channel=*/0, /*note=*/60, 127);
 
     REQUIRE(synth.getDroppedPolyKpOnMemberCount() == 0);
     auto& mid = synth.getResources().getMidiState();
@@ -654,7 +654,7 @@ TEST_CASE("[MPE] Poly KP on any channel is accepted when MPE is disabled")
     sfz::Synth synth;
     REQUIRE(synth.getMPEEnabled() == false);
 
-    synth.polyAftertouchMPE(0, /*channel=*/5, /*note=*/72, 80);
+    synth.polyAftertouch(0, /*channel=*/5, /*note=*/72, 80);
 
     REQUIRE(synth.getDroppedPolyKpOnMemberCount() == 0);
     auto& mid = synth.getResources().getMidiState();
@@ -677,7 +677,7 @@ TEST_CASE("[MPE] Damper on the Manager Channel is registered when MPE is enabled
 {
     sfz::Synth synth;
     synth.setMPEEnabled(true);
-    synth.ccMPE(0, /*channel=*/0, /*ccNumber=*/64, 127);
+    synth.cc(0, /*channel=*/0, /*ccNumber=*/64, 127);
     REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 0);
     auto& mid = synth.getResources().getMidiState();
     REQUIRE(mid.getCCValue(/*channel=*/0, 64) == 127_norm);
@@ -687,7 +687,7 @@ TEST_CASE("[MPE] Damper on a Member Channel is dropped when MPE is enabled")
 {
     sfz::Synth synth;
     synth.setMPEEnabled(true);
-    synth.ccMPE(0, /*channel=*/2, /*ccNumber=*/64, 127);
+    synth.cc(0, /*channel=*/2, /*ccNumber=*/64, 127);
     REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 1);
     auto& mid = synth.getResources().getMidiState();
     REQUIRE(mid.getCCValue(/*channel=*/2, 64) == 0.0_a);
@@ -698,7 +698,7 @@ TEST_CASE("[MPE] All pedal CCs 64-69 drop on Member Channels under MPE")
     sfz::Synth synth;
     synth.setMPEEnabled(true);
     for (int cc : {64, 65, 66, 67, 68, 69})
-        synth.ccMPE(0, /*channel=*/3, cc, 127);
+        synth.cc(0, /*channel=*/3, cc, 127);
     REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 6);
 }
 
@@ -706,7 +706,7 @@ TEST_CASE("[MPE] All Notes Off on a Member Channel is dropped when MPE is enable
 {
     sfz::Synth synth;
     synth.setMPEEnabled(true);
-    synth.ccMPE(0, /*channel=*/2, /*ccNumber=*/123, 0);
+    synth.cc(0, /*channel=*/2, /*ccNumber=*/123, 0);
     REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 1);
     // The CC must not reach MidiState even though All-Notes-Off normally
     // hits a global early-return path in performHdcc.
@@ -718,7 +718,7 @@ TEST_CASE("[MPE] Reset All Controllers on a Member Channel is dropped when MPE i
 {
     sfz::Synth synth;
     synth.setMPEEnabled(true);
-    synth.ccMPE(0, /*channel=*/4, /*ccNumber=*/121, 0);
+    synth.cc(0, /*channel=*/4, /*ccNumber=*/121, 0);
     REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 1);
 }
 
@@ -726,8 +726,8 @@ TEST_CASE("[MPE] Bank Select MSB/LSB on a Member Channel is dropped when MPE is 
 {
     sfz::Synth synth;
     synth.setMPEEnabled(true);
-    synth.ccMPE(0, /*channel=*/2, /*ccNumber=*/0, 5);   // Bank MSB
-    synth.ccMPE(0, /*channel=*/2, /*ccNumber=*/32, 3);  // Bank LSB
+    synth.cc(0, /*channel=*/2, /*ccNumber=*/0, 5);   // Bank MSB
+    synth.cc(0, /*channel=*/2, /*ccNumber=*/32, 3);  // Bank LSB
     REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 2);
 }
 
@@ -735,7 +735,7 @@ TEST_CASE("[MPE] Manager-only filter is inert when MPE is disabled")
 {
     sfz::Synth synth;
     REQUIRE(synth.getMPEEnabled() == false);
-    synth.ccMPE(0, /*channel=*/2, /*ccNumber=*/64, 127);
+    synth.cc(0, /*channel=*/2, /*ccNumber=*/64, 127);
     REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 0);
     auto& mid = synth.getResources().getMidiState();
     REQUIRE(mid.getCCValue(/*channel=*/2, 64) == 127_norm);
@@ -779,7 +779,7 @@ TEST_CASE("[MPE] expressionChannel: active voice on Member Channel uses its trig
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_released.sfz", R"(
         <region> sample=*sine ampeg_release=1
     )");
-    synth.noteOnMPE(0, /*channel=*/2, /*note=*/60, 100);
+    synth.noteOn(0, /*channel=*/2, /*note=*/60, 100);
     synth.renderBlock(buffer);
 
     auto active = synth.getActiveVoices();
@@ -796,9 +796,9 @@ TEST_CASE("[MPE] expressionChannel: released voice on Member Channel redirects t
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_released.sfz", R"(
         <region> sample=*sine ampeg_release=1
     )");
-    synth.noteOnMPE(0, /*channel=*/2, /*note=*/60, 100);
+    synth.noteOn(0, /*channel=*/2, /*note=*/60, 100);
     synth.renderBlock(buffer);
-    synth.noteOffMPE(0, /*channel=*/2, /*note=*/60, 0);
+    synth.noteOff(0, /*channel=*/2, /*note=*/60, 0);
     synth.renderBlock(buffer);
 
     auto active = synth.getActiveVoices();
@@ -818,14 +818,14 @@ TEST_CASE("[MPE] expressionChannel: voice on Manager Channel always reads Manage
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_released.sfz", R"(
         <region> sample=*sine ampeg_release=1
     )");
-    synth.noteOnMPE(0, /*channel=*/0, /*note=*/60, 100);
+    synth.noteOn(0, /*channel=*/0, /*note=*/60, 100);
     synth.renderBlock(buffer);
 
     auto active = synth.getActiveVoices();
     REQUIRE(active.size() == 1);
     REQUIRE(active[0]->expressionChannel() == 0);
 
-    synth.noteOffMPE(0, /*channel=*/0, /*note=*/60, 0);
+    synth.noteOff(0, /*channel=*/0, /*note=*/60, 0);
     synth.renderBlock(buffer);
     REQUIRE(active[0]->released() == true);
     REQUIRE(active[0]->expressionChannel() == 0);
@@ -842,16 +842,16 @@ TEST_CASE("[MPE] Pitch Bend on released Member Channel doesn't reach the voice's
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_released.sfz", R"(
         <region> sample=*sine ampeg_release=1
     )");
-    synth.noteOnMPE(0, /*channel=*/2, /*note=*/60, 100);
+    synth.noteOn(0, /*channel=*/2, /*note=*/60, 100);
     synth.renderBlock(buffer);
-    synth.noteOffMPE(0, /*channel=*/2, /*note=*/60, 0);
+    synth.noteOff(0, /*channel=*/2, /*note=*/60, 0);
     synth.renderBlock(buffer);
 
     auto active = synth.getActiveVoices();
     REQUIRE(active.size() == 1);
     REQUIRE(active[0]->expressionChannel() == 0);
 
-    synth.hdPitchWheelMPE(0, /*channel=*/2, 0.5f);
+    synth.hdPitchWheel(0, /*channel=*/2, 0.5f);
     auto& mid = synth.getResources().getMidiState();
     // PB lands in MidiState ch 2 ...
     REQUIRE(mid.getPitchBendRaw(2) == 0.5f);
@@ -868,16 +868,16 @@ TEST_CASE("[MPE] Channel Pressure on released Member Channel doesn't reach the v
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_released.sfz", R"(
         <region> sample=*sine ampeg_release=1
     )");
-    synth.noteOnMPE(0, /*channel=*/2, /*note=*/60, 100);
+    synth.noteOn(0, /*channel=*/2, /*note=*/60, 100);
     synth.renderBlock(buffer);
-    synth.noteOffMPE(0, /*channel=*/2, /*note=*/60, 0);
+    synth.noteOff(0, /*channel=*/2, /*note=*/60, 0);
     synth.renderBlock(buffer);
 
     auto active = synth.getActiveVoices();
     REQUIRE(active.size() == 1);
     REQUIRE(active[0]->expressionChannel() == 0);
 
-    synth.channelAftertouchMPE(0, /*channel=*/2, 100);
+    synth.channelAftertouch(0, /*channel=*/2, 100);
     auto& mid = synth.getResources().getMidiState();
     REQUIRE(mid.getChannelAftertouch(/*channel=*/2) == 100_norm);
     REQUIRE(mid.getChannelAftertouch(/*channel=*/0) == 0.0_a);
@@ -892,16 +892,16 @@ TEST_CASE("[MPE] CC74 on released Member Channel doesn't reach the voice's expre
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_released.sfz", R"(
         <region> sample=*sine ampeg_release=1
     )");
-    synth.noteOnMPE(0, /*channel=*/2, /*note=*/60, 100);
+    synth.noteOn(0, /*channel=*/2, /*note=*/60, 100);
     synth.renderBlock(buffer);
-    synth.noteOffMPE(0, /*channel=*/2, /*note=*/60, 0);
+    synth.noteOff(0, /*channel=*/2, /*note=*/60, 0);
     synth.renderBlock(buffer);
 
     auto active = synth.getActiveVoices();
     REQUIRE(active.size() == 1);
     REQUIRE(active[0]->expressionChannel() == 0);
 
-    synth.ccMPE(0, /*channel=*/2, /*ccNumber=*/74, 90);
+    synth.cc(0, /*channel=*/2, /*ccNumber=*/74, 90);
     auto& mid = synth.getResources().getMidiState();
     REQUIRE(mid.getCCValue(/*channel=*/2, 74) == 90_norm);
     REQUIRE(mid.getCCValue(/*channel=*/0, 74) == 0.0_a);
@@ -920,7 +920,7 @@ TEST_CASE("[MPE] Active voice on Member Channel still responds to per-finger exp
     synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_released.sfz", R"(
         <region> sample=*sine ampeg_release=1
     )");
-    synth.noteOnMPE(0, /*channel=*/2, /*note=*/60, 100);
+    synth.noteOn(0, /*channel=*/2, /*note=*/60, 100);
     synth.renderBlock(buffer);
 
     auto active = synth.getActiveVoices();
@@ -928,9 +928,9 @@ TEST_CASE("[MPE] Active voice on Member Channel still responds to per-finger exp
     REQUIRE(active[0]->released() == false);
     REQUIRE(active[0]->expressionChannel() == 2);
 
-    synth.hdPitchWheelMPE(0, /*channel=*/2, 0.25f);
-    synth.channelAftertouchMPE(0, /*channel=*/2, 80);
-    synth.ccMPE(0, /*channel=*/2, 74, 70);
+    synth.hdPitchWheel(0, /*channel=*/2, 0.25f);
+    synth.channelAftertouch(0, /*channel=*/2, 80);
+    synth.cc(0, /*channel=*/2, 74, 70);
     auto& mid = synth.getResources().getMidiState();
     REQUIRE(mid.getPitchBendRaw(2) == 0.25f);
     REQUIRE(mid.getChannelAftertouch(2) == 80_norm);

--- a/tests/MPET.cpp
+++ b/tests/MPET.cpp
@@ -581,3 +581,97 @@ TEST_CASE("[MPE] Poly KP on any channel is accepted when MPE is disabled")
     auto& mid = synth.getResources().getMidiState();
     REQUIRE(mid.getPolyAftertouch(/*channel=*/5, /*note=*/72) == 80_norm);
 }
+
+// =============================================================================
+// Manager-only message filtering (MPE 1.0 §2.3.1 / §2.3.3 / Appendix E Table 5)
+// =============================================================================
+//
+// Pedal CCs (64-69), mode/reset CCs (120-125 excluding 122) and Bank Select
+// (CC 0 / CC 32) are zone-wide and must be honoured only on the Manager
+// Channel when MPE is enabled. The engine drops such events at the top of
+// performHdcc and reports the drop via getDroppedManagerOnlyMessageCount.
+// RPN data CCs (6/38/98/99/100/101) are NOT zone-wide — they are per-channel
+// state machines — and must continue to flow on Member Channels so the
+// SMPL-46 RPN auto-config keeps working.
+
+TEST_CASE("[MPE] Damper on the Manager Channel is registered when MPE is enabled")
+{
+    sfz::Synth synth;
+    synth.setMPEEnabled(true);
+    synth.ccMPE(0, /*channel=*/0, /*ccNumber=*/64, 127);
+    REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 0);
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getCCValue(/*channel=*/0, 64) == 127_norm);
+}
+
+TEST_CASE("[MPE] Damper on a Member Channel is dropped when MPE is enabled")
+{
+    sfz::Synth synth;
+    synth.setMPEEnabled(true);
+    synth.ccMPE(0, /*channel=*/2, /*ccNumber=*/64, 127);
+    REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 1);
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getCCValue(/*channel=*/2, 64) == 0.0_a);
+}
+
+TEST_CASE("[MPE] All pedal CCs 64-69 drop on Member Channels under MPE")
+{
+    sfz::Synth synth;
+    synth.setMPEEnabled(true);
+    for (int cc : {64, 65, 66, 67, 68, 69})
+        synth.ccMPE(0, /*channel=*/3, cc, 127);
+    REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 6);
+}
+
+TEST_CASE("[MPE] All Notes Off on a Member Channel is dropped when MPE is enabled")
+{
+    sfz::Synth synth;
+    synth.setMPEEnabled(true);
+    synth.ccMPE(0, /*channel=*/2, /*ccNumber=*/123, 0);
+    REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 1);
+    // The CC must not reach MidiState even though All-Notes-Off normally
+    // hits a global early-return path in performHdcc.
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getCCValue(/*channel=*/2, 123) == 0.0_a);
+}
+
+TEST_CASE("[MPE] Reset All Controllers on a Member Channel is dropped when MPE is enabled")
+{
+    sfz::Synth synth;
+    synth.setMPEEnabled(true);
+    synth.ccMPE(0, /*channel=*/4, /*ccNumber=*/121, 0);
+    REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 1);
+}
+
+TEST_CASE("[MPE] Bank Select MSB/LSB on a Member Channel is dropped when MPE is enabled")
+{
+    sfz::Synth synth;
+    synth.setMPEEnabled(true);
+    synth.ccMPE(0, /*channel=*/2, /*ccNumber=*/0, 5);   // Bank MSB
+    synth.ccMPE(0, /*channel=*/2, /*ccNumber=*/32, 3);  // Bank LSB
+    REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 2);
+}
+
+TEST_CASE("[MPE] Manager-only filter is inert when MPE is disabled")
+{
+    sfz::Synth synth;
+    REQUIRE(synth.getMPEEnabled() == false);
+    synth.ccMPE(0, /*channel=*/2, /*ccNumber=*/64, 127);
+    REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 0);
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getCCValue(/*channel=*/2, 64) == 127_norm);
+}
+
+TEST_CASE("[MPE] Manager-only filter does not touch RPN data CCs on Member Channels")
+{
+    // Regression for SMPL-46: the per-note bend range auto-config must
+    // keep working when MPE is enabled and the RPN sequence arrives on a
+    // Member Channel. CCs 6 / 38 / 98 / 99 / 100 / 101 must remain off
+    // the Manager-only list.
+    sfz::Synth synth;
+    synth.setMPEEnabled(true);
+    REQUIRE(synth.getMPEPerNotePitchBendRange() == 48.0_a);
+    sendPitchBendSensitivity(synth, /*channel=*/2, /*semitones=*/24);
+    REQUIRE(synth.getMPEPerNotePitchBendRange() == 24.0_a);
+    REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 0);
+}

--- a/tests/MPET.cpp
+++ b/tests/MPET.cpp
@@ -276,10 +276,10 @@ TEST_CASE("[MPE] When MPE is disabled, *MPE methods collapse channel to 0 (singl
 {
     // With MPE off, the *MPE API surface and the legacy channel-less API
     // are equivalent: both land in channel-0 storage and both trigger
-    // voices with triggerChannel_=0. Consumers (sfizz-ui's VST3 wrapper,
-    // sample-machine's PlayerEngine) can therefore call *MPE unconditionally
-    // without an MPE-off vs MPE-on dispatch branch, and the engine takes
-    // sole responsibility for what "MPE off" means.
+    // voices with triggerChannel_=0. Consumers (the VST3 / LV2 wrappers
+    // in sfizz-ui, or any downstream embedder) can therefore call *MPE
+    // unconditionally without an MPE-off vs MPE-on dispatch branch, and
+    // the engine takes sole responsibility for what "MPE off" means.
     sfz::Synth synth;
     REQUIRE(synth.getMPEEnabled() == false);
     sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
@@ -671,7 +671,7 @@ TEST_CASE("[MPE] Poly KP on any channel is accepted when MPE is disabled")
 // performHdcc and reports the drop via getDroppedManagerOnlyMessageCount.
 // RPN data CCs (6/38/98/99/100/101) are NOT zone-wide — they are per-channel
 // state machines — and must continue to flow on Member Channels so the
-// SMPL-46 RPN auto-config keeps working.
+// RPN 0 (Pitch Bend Sensitivity) auto-config keeps working.
 
 TEST_CASE("[MPE] Damper on the Manager Channel is registered when MPE is enabled")
 {

--- a/tests/MPET.cpp
+++ b/tests/MPET.cpp
@@ -265,6 +265,52 @@ TEST_CASE("[MPE] Existing single-channel API forwards to master-channel slot")
     REQUIRE(mid.getChannelAftertouch(1) == 100_norm);
 }
 
+TEST_CASE("[MPE] Voices triggered via the legacy API are isolated from MPE per-channel writes")
+{
+    // Defensive regression for the MPE-off compatibility contract: in a
+    // mixed-API session, a voice triggered through the channel-less legacy
+    // API gets triggerChannel_=0 and must read modulation from the master
+    // channel only — non-master channel writes via the *MPE API must not
+    // affect it. This is the property hosts rely on when they call the
+    // legacy API to opt out of MPE routing (the wrapper-side behaviour
+    // shipped for the sfizz-ui MPE-off toggle).
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
+    synth.loadSfzString(fs::current_path() / "tests/MPE_legacy_isolation.sfz", R"(
+        <region> sample=*sine
+    )");
+
+    // Trigger via the legacy API — voice gets triggerChannel_=0.
+    synth.noteOn(0, 60, 100);
+    synth.renderBlock(buffer);
+
+    auto activeVoices = synth.getActiveVoices();
+    REQUIRE(activeVoices.size() == 1);
+    REQUIRE(activeVoices[0]->getTriggerEvent().channel == 0);
+
+    // Per-channel writes via the *MPE API on non-master channels must NOT
+    // touch the master channel that the legacy-triggered voice reads from.
+    synth.pitchWheelMPE(0, /*channel=*/5, 4096);
+    synth.ccMPE(0, /*channel=*/5, 74, 90);
+    synth.channelAftertouchMPE(0, /*channel=*/5, 100);
+    synth.renderBlock(buffer);
+
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getPitchBendRaw(0) == 0.0_a);            // master untouched
+    REQUIRE(mid.getCCValue(0, 74) == 0_norm);            // master CC slot untouched
+    REQUIRE(mid.getChannelAftertouch(0) == 0_norm);      // master pressure untouched
+    // Channel 5 has the writes; the voice doesn't read from there.
+    REQUIRE(mid.getPitchBendRaw(5) == Approx(0.5).margin(0.001));
+
+    // A legacy note-off (channel-less → forwards to channel 0) must release
+    // the voice. registerNoteOff matches on channel; triggerChannel_=0 and
+    // channel-0 noteOff match → voice releases. This is the path the sfizz-ui
+    // wrapper uses when the MPE toggle is off.
+    synth.noteOff(0, 60, 0);
+    synth.renderBlock(buffer);
+    REQUIRE((activeVoices[0]->released() || activeVoices[0]->isFree()));
+}
+
 // =============================================================================
 // Synth: noteOnMPE tags spawned voices with the originating channel
 // =============================================================================

--- a/tests/MPET.cpp
+++ b/tests/MPET.cpp
@@ -664,14 +664,197 @@ TEST_CASE("[MPE] Manager-only filter is inert when MPE is disabled")
 
 TEST_CASE("[MPE] Manager-only filter does not touch RPN data CCs on Member Channels")
 {
-    // Regression for SMPL-46: the per-note bend range auto-config must
-    // keep working when MPE is enabled and the RPN sequence arrives on a
-    // Member Channel. CCs 6 / 38 / 98 / 99 / 100 / 101 must remain off
-    // the Manager-only list.
+    // Regression for the RPN parser tap: the per-note bend range
+    // auto-config must keep working when MPE is enabled and the RPN
+    // sequence arrives on a Member Channel. CCs 6 / 38 / 98 / 99 / 100 /
+    // 101 must remain off the Manager-only list.
     sfz::Synth synth;
     synth.setMPEEnabled(true);
     REQUIRE(synth.getMPEPerNotePitchBendRange() == 48.0_a);
     sendPitchBendSensitivity(synth, /*channel=*/2, /*semitones=*/24);
     REQUIRE(synth.getMPEPerNotePitchBendRange() == 24.0_a);
     REQUIRE(synth.getDroppedManagerOnlyMessageCount() == 0);
+}
+
+// =============================================================================
+// Released-note expression filter (MPE 1.0 §2.2.6 / §2.2.7 / §2.2.8)
+// =============================================================================
+//
+// Per the spec, a Released Note stops reacting to per-finger Pitch Bend,
+// Channel Pressure and CC#74 on its Member Channel after the Note Off
+// message occurs — because the controller will recycle that Member Channel
+// for the next finger. Manager-Channel traffic still reaches the release
+// tail (§A.4.1). Voice::expressionChannel() returns the channel that
+// expression reads should consult: the trigger channel for active voices
+// (and for any voice triggered on the Manager Channel), and channel 0
+// (Lower Zone Manager) for released voices that were triggered on a
+// Member Channel. Every per-block read site (pitch envelope, the CC /
+// Channel Pressure / Poly Aftertouch mod sources, and region crossfades)
+// routes through this helper so the redirect applies uniformly.
+
+TEST_CASE("[MPE] expressionChannel: active voice on Member Channel uses its trigger channel")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
+    synth.setMPEEnabled(true);
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_released.sfz", R"(
+        <region> sample=*sine ampeg_release=1
+    )");
+    synth.noteOnMPE(0, /*channel=*/2, /*note=*/60, 100);
+    synth.renderBlock(buffer);
+
+    auto active = synth.getActiveVoices();
+    REQUIRE(active.size() == 1);
+    REQUIRE(active[0]->released() == false);
+    REQUIRE(active[0]->expressionChannel() == 2);
+}
+
+TEST_CASE("[MPE] expressionChannel: released voice on Member Channel redirects to Manager")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
+    synth.setMPEEnabled(true);
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_released.sfz", R"(
+        <region> sample=*sine ampeg_release=1
+    )");
+    synth.noteOnMPE(0, /*channel=*/2, /*note=*/60, 100);
+    synth.renderBlock(buffer);
+    synth.noteOffMPE(0, /*channel=*/2, /*note=*/60, 0);
+    synth.renderBlock(buffer);
+
+    auto active = synth.getActiveVoices();
+    REQUIRE(active.size() == 1);
+    REQUIRE(active[0]->released() == true);
+    REQUIRE(active[0]->expressionChannel() == 0);
+    // The trigger channel itself is unchanged — only the expression read
+    // channel redirects. Useful invariant for voice stealing / debugging.
+    REQUIRE(active[0]->getTriggerEvent().channel == 2);
+}
+
+TEST_CASE("[MPE] expressionChannel: voice on Manager Channel always reads Manager")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
+    synth.setMPEEnabled(true);
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_released.sfz", R"(
+        <region> sample=*sine ampeg_release=1
+    )");
+    synth.noteOnMPE(0, /*channel=*/0, /*note=*/60, 100);
+    synth.renderBlock(buffer);
+
+    auto active = synth.getActiveVoices();
+    REQUIRE(active.size() == 1);
+    REQUIRE(active[0]->expressionChannel() == 0);
+
+    synth.noteOffMPE(0, /*channel=*/0, /*note=*/60, 0);
+    synth.renderBlock(buffer);
+    REQUIRE(active[0]->released() == true);
+    REQUIRE(active[0]->expressionChannel() == 0);
+}
+
+TEST_CASE("[MPE] Pitch Bend on released Member Channel doesn't reach the voice's expression read")
+{
+    // The released voice's expression reads route through Manager (ch 0),
+    // so a per-finger Pitch Bend that lands in MidiState's ch 2 slot
+    // doesn't influence the released voice. Manager-Channel PB still does.
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
+    synth.setMPEEnabled(true);
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_released.sfz", R"(
+        <region> sample=*sine ampeg_release=1
+    )");
+    synth.noteOnMPE(0, /*channel=*/2, /*note=*/60, 100);
+    synth.renderBlock(buffer);
+    synth.noteOffMPE(0, /*channel=*/2, /*note=*/60, 0);
+    synth.renderBlock(buffer);
+
+    auto active = synth.getActiveVoices();
+    REQUIRE(active.size() == 1);
+    REQUIRE(active[0]->expressionChannel() == 0);
+
+    synth.hdPitchWheelMPE(0, /*channel=*/2, 0.5f);
+    auto& mid = synth.getResources().getMidiState();
+    // PB lands in MidiState ch 2 ...
+    REQUIRE(mid.getPitchBendRaw(2) == 0.5f);
+    // ... but the voice now reads from ch 0 (master), where no PB lives.
+    REQUIRE(mid.getPitchBendRaw(0) == 0.0f);
+    REQUIRE(active[0]->expressionChannel() == 0);
+}
+
+TEST_CASE("[MPE] Channel Pressure on released Member Channel doesn't reach the voice's expression read")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
+    synth.setMPEEnabled(true);
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_released.sfz", R"(
+        <region> sample=*sine ampeg_release=1
+    )");
+    synth.noteOnMPE(0, /*channel=*/2, /*note=*/60, 100);
+    synth.renderBlock(buffer);
+    synth.noteOffMPE(0, /*channel=*/2, /*note=*/60, 0);
+    synth.renderBlock(buffer);
+
+    auto active = synth.getActiveVoices();
+    REQUIRE(active.size() == 1);
+    REQUIRE(active[0]->expressionChannel() == 0);
+
+    synth.channelAftertouchMPE(0, /*channel=*/2, 100);
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getChannelAftertouch(/*channel=*/2) == 100_norm);
+    REQUIRE(mid.getChannelAftertouch(/*channel=*/0) == 0.0_a);
+    REQUIRE(active[0]->expressionChannel() == 0);
+}
+
+TEST_CASE("[MPE] CC74 on released Member Channel doesn't reach the voice's expression read")
+{
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
+    synth.setMPEEnabled(true);
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_released.sfz", R"(
+        <region> sample=*sine ampeg_release=1
+    )");
+    synth.noteOnMPE(0, /*channel=*/2, /*note=*/60, 100);
+    synth.renderBlock(buffer);
+    synth.noteOffMPE(0, /*channel=*/2, /*note=*/60, 0);
+    synth.renderBlock(buffer);
+
+    auto active = synth.getActiveVoices();
+    REQUIRE(active.size() == 1);
+    REQUIRE(active[0]->expressionChannel() == 0);
+
+    synth.ccMPE(0, /*channel=*/2, /*ccNumber=*/74, 90);
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getCCValue(/*channel=*/2, 74) == 90_norm);
+    REQUIRE(mid.getCCValue(/*channel=*/0, 74) == 0.0_a);
+    REQUIRE(active[0]->expressionChannel() == 0);
+}
+
+TEST_CASE("[MPE] Active voice on Member Channel still responds to per-finger expression")
+{
+    // Regression: the released-note gate must not bleed into active
+    // voices. The expression channel of an active member-channel voice
+    // is its trigger channel; PB / CP / CC74 sent on that channel reach
+    // the voice as today.
+    sfz::Synth synth;
+    sfz::AudioBuffer<float> buffer { 2, static_cast<unsigned>(synth.getSamplesPerBlock()) };
+    synth.setMPEEnabled(true);
+    synth.loadSfzString(fs::current_path() / "tests/TestFiles/mpe_released.sfz", R"(
+        <region> sample=*sine ampeg_release=1
+    )");
+    synth.noteOnMPE(0, /*channel=*/2, /*note=*/60, 100);
+    synth.renderBlock(buffer);
+
+    auto active = synth.getActiveVoices();
+    REQUIRE(active.size() == 1);
+    REQUIRE(active[0]->released() == false);
+    REQUIRE(active[0]->expressionChannel() == 2);
+
+    synth.hdPitchWheelMPE(0, /*channel=*/2, 0.25f);
+    synth.channelAftertouchMPE(0, /*channel=*/2, 80);
+    synth.ccMPE(0, /*channel=*/2, 74, 70);
+    auto& mid = synth.getResources().getMidiState();
+    REQUIRE(mid.getPitchBendRaw(2) == 0.25f);
+    REQUIRE(mid.getChannelAftertouch(2) == 80_norm);
+    REQUIRE(mid.getCCValue(2, 74) == 70_norm);
+    REQUIRE(active[0]->expressionChannel() == 2);
 }


### PR DESCRIPTION
This PR addresses the MPE feature request in #1313 — adding full per-note pitch bend, per-note CC modulation, and per-note channel aftertouch routing through sfizz so a polyphonic chord on an MPE controller (Osmose, Seaboard, LinnStrument, Push 3) renders with each finger's modulation applied to its own voice instead of collapsing globally.

**Status:** draft, inviting design review. Hand-tested against an Expressive E Osmose in Logic Pro and an Ableton Push 3 in Live 12. Full sfizz suite green (526 cases / 52374 assertions) including a new `tests/MPET.cpp` covering per-channel state isolation, voice-stealing biasing, MCM / RPN 0 auto-configuration, MPE 1.0 spec-compliance filters, and the MPE-off compatibility contract.

## What's in the PR

Logically organised; each commit is independently buildable.

**Core engine plumbing**
- `36a6e09a` — `MidiState`: per-channel `ChannelState` struct (storage refactor; behaviour unchanged with master-only access)
- `a8b28743` — `MidiState` / `Voice`: per-voice `triggerChannel_` plumbing for modulation reads
- `3db6b80a` — `Synth`: channel-aware public API + per-channel dispatch
- `e4812d8b` — `VoiceStealing`: bias victim selection to a preferred MIDI channel
- `5ad530a9` — `MidiState`: lazy member-channel events + regression suite
- `cb3ba1dd` + `002f1395` / `b117153f` / `b9449173` / `c2f81dc7` / `51e0e3a1` — hand-test fixes (channel-aware `Voice::registerNoteOff`, master→member fallback for scalar getters, summed master+member pitch envelope, empty-events guard)

**Public C++ + C API**
- `cd7d7df1` — `sfz::Sfizz` C++ wrapper exposes the new methods
- `2977b355` — parallel C API (`sfizz_send_*_channel`, `sfizz_set_mpe_enabled`, bend-range getters/setters)

**MPE 1.0 spec compliance**
- `2b408275` — MCM (RPN 6) + Pitch Bend Sensitivity (RPN 0) auto-configuration with per-axis opt-outs
- `0a443c14` — drop Poly KP on Member Channels (§2.2.7 / Appendix E Table 5)
- `528a4b9d` — drop Manager-only CCs (pedals, mode/reset, Bank Select) on Member Channels (§2.3.1 / §2.3.3)
- `efaf7c2a` — released-voice expression reads route through the Manager Channel (§2.2.6 / §2.2.7 / §2.2.8 / §A.4.1)

**MPE-off compatibility**
- `36c92314` — regression test asserting legacy-API voices isolate from `*MPE` per-channel writes
- `db9717aa` — engine collapses channel argument to 0 in all channel-aware entry points when MPE is disabled, so legacy and channel-aware paths behave identically. `setMPEEnabled(false)` flushes active voices.

**API hygiene**
- `13337446` — dropped the `*MPE` suffix from channel-aware methods now that they handle both modes; C++ becomes overloads of the legacy names, C API uses `_channel` suffix. MPE config surface (`setMPEEnabled`, bend-range getters/setters, drop counters) unchanged.
- `9eaef3fc` — header doc refresh describing the new contract.

## Design notes

- **MPE config surface**: minimal — `setMPEEnabled(bool)` + `setMPEPitchBendRange(masterSemitones, perNoteSemitones)` + the two RPN opt-out flags. Happy to grow this if you'd prefer an explicit `setMPEZone(masterChannel, memberCount)` shape.
- **CC inheritance**: channel-aware getters fall back to master for empty member-channel vectors. Once a member channel writes a CC, it owns its state.
- **Master CCs (sustain pedal, modwheel, …)** apply globally because they're sent on the master channel; member voices read their own channel's vector, find it empty, fall back to master.
- **No SFZ opcode changes**: existing `*_oncc<N>` opcodes "just work" via per-channel CC banks.
- **Lower Zone only**: Upper Zone (master = channel 16) is deferred — no consumer in scope.

## Why a fork

Issue #1313 had been open since April 2025 with no maintainer engagement, and an MPE-capable engine was needed for a personal project. Rather than block, hard-forked at `f5c6e29f` and have been iterating on the fork since. This PR exists to invite review and find a maintainer-preferred shape so the patch series doesn't have to live in a fork indefinitely.

cc @paulfd, @jpcima, @jamshark70.